### PR TITLE
enable uploading of artifacts to the temporary location

### DIFF
--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -1,13 +1,37 @@
 
 apply plugin: 'java'
+apply plugin: 'maven'
 
 jar {
     version = '1.0'
     baseName = 'appinsights-core'
 }
 
+configurations {
+    deployerJars
+}
+
 repositories {
     mavenCentral()
+}
+
+dependencies { 
+    deployerJars "org.apache.maven.wagon:wagon-ftp:2.8"
+} 
+
+version = "1.0.0-SNAPSHOT"
+group = "com.microsoft.applicationinsights"
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            configuration = configurations.deployerJars
+
+            repository(url: "ftp://waws-prod-dm1-003.ftp.azurewebsites.windows.net/site/wwwroot/repository/") { 
+                authentication(userName: "dotm2\\\$dotm2", password:javamavenuserpassword)
+            }
+         }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Here is what I did:
http://apmtips.com/blog/2014/12/23/use-azure-websites-to-host-custom-maven-repository/

Now you can reference SDK by setting the following in your application so you don't need to copy jars manually:

repositories {
    mavenCentral()

```
maven {
    url 'http://dotm2.azurewebsites.net/repository/'
}
```

}
dependencies {
    testCompile group: 'junit', name: 'junit', version: '4.11'
    compile group: 'com.microsoft.applicationinsights', name:'appinsights-core', version:'1.+'
    runtime('org.apache.httpcomponents:httpclient:4.3.5')
}

I'll send password to upload in e-mail
