### PR TITLE
Extracting required info from build parameters

### DIFF
--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -17,13 +17,13 @@ dependencies {
 // region Publishing tasks
 
 uploadArchives {
-    if (this.hasProperty("mavenuserpassword")) {
+    if (this.hasProperty("mavenUserPassword")) {
         repositories {
             mavenDeployer {
                 configuration = configurations.deployerJars
 
-                repository(url: mavenrepositoryurl) {
-                    authentication(userName: mavenusername, password: mavenuserpassword)
+                repository(url: mavenRepositoryUrl) {
+                    authentication(userName: mavenUsername, password: mavenUserPassword)
                 }
             }
         }

--- a/Logging/build.gradle
+++ b/Logging/build.gradle
@@ -4,13 +4,13 @@ group = "com.microsoft.applicationinsights.logging"
 // region Publishing tasks
 
 uploadArchives {
-    if (this.hasProperty("mavenuserpassword")) {
+    if (this.hasProperty("mavenUserPassword")) {
         repositories {
             mavenDeployer {
                 configuration = configurations.deployerJars
 
-                repository(url: mavenrepositoryurl) {
-                    authentication(userName: mavenusername, password: mavenuserpassword)
+                repository(url: mavenRepositoryUrl) {
+                    authentication(userName: mavenUsername, password: mavenUserPassword)
                 }
 
                 // Updating artifacts IDs and dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -17,18 +17,18 @@ allprojects {
     apply plugin: 'maven'
 
     task checkUploadProperties << {
-        if (!this.hasProperty("mavenuserpassword")) {
-            throw new GroovyRuntimeException("Property mavenuserpassword should be defined for uploadArchives task")
-        } else if (!this.hasProperty("mavenusername")) {
-            throw new GroovyRuntimeException("Property mavenusername should be defined for uploadArchives task")
-        } else if (!this.hasProperty("mavenrepositoryurl")) {
-            throw new GroovyRuntimeException("Property mavenrepositoryurl should be defined for uploadArchives task")
+        if (!this.hasProperty("mavenUserPassword")) {
+            throw new GroovyRuntimeException("Property mavenUserPassword should be defined for uploadArchives task")
+        } else if (!this.hasProperty("mavenUsername")) {
+            throw new GroovyRuntimeException("Property mavenUsername should be defined for uploadArchives task")
+        } else if (!this.hasProperty("mavenRepositoryUrl")) {
+            throw new GroovyRuntimeException("Property mavenRepositoryUrl should be defined for uploadArchives task")
         }
     }
 
     task checkIfReleaseAndUpdateVersion << {
-        if (this.hasProperty("release")) {
-            version = release
+        if (this.hasProperty("releaseVersion")) {
+            version = releaseVersion
         }
     }
 


### PR DESCRIPTION
Currently only the password is passed as parameter.

Changes:
1. Moving repository url and username out of the build script, to be taken from build parameters.
2. Adding support for uploading release versions.

The build switches will be updated from:  "-Pjavamavenuserpassword=NotRealPassword" to "-Pmavenusername=username -Pmavenuserpassword=password -Pmavenrepositoryurl=url".
This, by default, will upload a SNAPSHOT version.

To upload a release version, another switch is required: 'Prelease=<release_version>', for example:
"-Pmavenusername=username -Pmavenuserpassword=password -Pmavenrepositoryurl=url -Prelease=2.1.0
