### PR TITLE
Adding commons-logging configuration file to turn

### DIFF
--- a/Core/src/main/resources/commons-logging.properties
+++ b/Core/src/main/resources/commons-logging.properties
@@ -1,0 +1,2 @@
+org.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog
+org.apache.commons.logging.simplelog.log.org.apache.http=OFF


### PR DESCRIPTION
Adding configuration file to turn off Apache components logging.
