### PR TITLE
Adding Maven requirements to jars' pom

### DIFF
--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -25,6 +25,14 @@ uploadArchives {
                 repository(url: mavenRepositoryUrl) {
                     authentication(userName: mavenUsername, password: mavenUserPassword)
                 }
+
+                updatePomWithProjectInformation(pom)
+
+                // Updating Core pom specific values.
+                pom.project {
+                    name = "Microsoft Application Insights Java SDK Core"
+                    description = "This is the core module of Microsoft Application Insights Java SDK"
+                }
             }
         }
     }

--- a/Logging/build.gradle
+++ b/Logging/build.gradle
@@ -17,26 +17,50 @@ uploadArchives {
                 addFilter('LogbackJar') { artifact, file ->
                     artifact.name == "LogbackJar"
                 }
-                pom('LogbackJar').artifactId = 'applicationinsights-logging-logback'
-                pom('LogbackJar').whenConfigured { p -> p.dependencies = p.dependencies.findAll {
-                    dep -> dep.artifactId == 'logback-classic' || dep.artifactId == 'logback-core'
-                }.toList() }
+                pom('LogbackJar') {
+                    artifactId = 'applicationinsights-logging-logback'
+                    whenConfigured { p -> p.dependencies = p.dependencies.findAll {
+                        dep -> dep.artifactId == 'logback-classic' || dep.artifactId == 'logback-core'
+                    }.toList() }
+
+                    project {
+                        name = "Microsoft Application Insights Logback Appender"
+                        description = "This module provides an Application Insights appender implementation for Logback framework"
+                    }
+                }
+                updatePomWithProjectInformation(pom('LogbackJar'))
 
                 addFilter('Log4j1_2Jar') { artifact, file ->
                     artifact.name == "Log4j1_2Jar"
                 }
-                pom('Log4j1_2Jar').artifactId = 'applicationinsights-logging-log4j1_2'
-                pom('Log4j1_2Jar').whenConfigured { p -> p.dependencies = p.dependencies.findAll {
-                    dep -> dep.groupId == 'log4j'
-                }.toList() }
+                pom('Log4j1_2Jar') {
+                    artifactId = 'applicationinsights-logging-log4j1_2'
+                    whenConfigured { p -> p.dependencies = p.dependencies.findAll {
+                        dep -> dep.groupId == 'log4j'
+                    }.toList() }
+
+                    project {
+                        name = "Microsoft Application Insights Log4j 1.2 Appender"
+                        description = "This module provides an Application Insights appender implementation for Log4j 1.2 framework"
+                    }
+                }
+                updatePomWithProjectInformation(pom('Log4j1_2Jar'))
 
                 addFilter('Log4j2Jar') { artifact, file ->
                     artifact.name == "Log4j2Jar"
                 }
-                pom('Log4j2Jar').artifactId = 'applicationinsights-logging-log4j2'
-                pom('Log4j2Jar').whenConfigured { p -> p.dependencies = p.dependencies.findAll {
-                    dep -> dep.artifactId == 'log4j-core' || dep.artifactId == 'log4j-api'
-                }.toList() }
+                pom('Log4j2Jar') {
+                    artifactId = 'applicationinsights-logging-log4j2'
+                    whenConfigured { p -> p.dependencies = p.dependencies.findAll {
+                        dep -> dep.artifactId == 'log4j-core' || dep.artifactId == 'log4j-api'
+                    }.toList() }
+
+                    project {
+                        name = "Microsoft Application Insights Log4j 2 Appender"
+                        description = "This module provides an Application Insights appender implementation for Log4j 2 framework"
+                    }
+                }
+                updatePomWithProjectInformation(pom('Log4j2Jar'))
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,29 @@ allprojects {
     }
 }
 
+// Azure SDK Pom as a reference: https://repo1.maven.org/maven2/com/microsoft/azure/azure-core/0.7.0/azure-core-0.7.0.pom
+def updatePomWithGeneralProjectInformation(pomObject) {
+    pomObject.project {
+        licenses {
+            license {
+                name = "MIT License"
+                url = "http://www.opensource.org/licenses/mit-license.php"
+            }
+        }
+
+        scm {
+            url = "scm:git:https://github.com/Microsoft/AppInsights-Java"
+            connection = "scm:git:git://github.com/Microsoft/AppInsights-Java.git"
+        }
+
+        // This section was taken from Azure SDK core POM.
+        developers {
+            developer {
+                id = "microsoft"
+                name = "Microsoft"
+            }
+        }
+    }
+}
+
 // endregion Shared sub-projects configuration


### PR DESCRIPTION
Adding the POMs information required by Maven central.

please double check that the names, descriptions etc. are were written without errors as those fields will be exposed to customers.
