### PR TITLE
Refactoring web modules to use tls

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/WebRequestTrackingTelemetryModule.java
@@ -34,6 +34,7 @@ import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.telemetry.Duration;
 import com.microsoft.applicationinsights.telemetry.HttpRequestTelemetry;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import org.apache.http.HttpStatus;
 
 /**
@@ -57,7 +58,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
         }
 
         try {
-            RequestTelemetryContext context = getTelemetryContextFromServletRequest(req);
+            RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
             HttpRequestTelemetry telemetry = context.getHttpRequestTelemetry();
 
             HttpServletRequest request = (HttpServletRequest) req;
@@ -97,7 +98,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
         }
 
         try {
-            RequestTelemetryContext context = getTelemetryContextFromServletRequest(req);
+            RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
             HttpRequestTelemetry telemetry = context.getHttpRequestTelemetry();
 
             long endTime = new Date().getTime();
@@ -128,12 +129,4 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
                     "Failed to initialize telemetry module " + this.getClass().getSimpleName() + ". Exception: %s.", e.getMessage());
         }
     }
-
-    // region Private methods
-
-    private RequestTelemetryContext getTelemetryContextFromServletRequest(ServletRequest request) {
-        return (RequestTelemetryContext)request.getAttribute(RequestTelemetryContext.CONTEXT_ATTR_KEY);
-    }
-
-    // endregion Private methods
 }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/WebSessionTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/WebSessionTrackingTelemetryModule.java
@@ -36,6 +36,7 @@ import com.microsoft.applicationinsights.extensibility.context.SessionContext;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.util.DateTimeUtils;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.cookies.SessionCookie;
 
 /**
@@ -63,7 +64,7 @@ public class WebSessionTrackingTelemetryModule implements WebTelemetryModule, Te
     @Override
     public void onBeginRequest(ServletRequest req, ServletResponse res) {
         HttpServletRequest request = (HttpServletRequest)req;
-        RequestTelemetryContext context = (RequestTelemetryContext)request.getAttribute(RequestTelemetryContext.CONTEXT_ATTR_KEY);
+        RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
 
         SessionCookie sessionCookie =
                 com.microsoft.applicationinsights.web.internal.cookies.Cookie.getCookie(
@@ -97,7 +98,7 @@ public class WebSessionTrackingTelemetryModule implements WebTelemetryModule, Te
     // region Private
 
     private void setSessionCookie(HttpServletRequest req, HttpServletResponse res) {
-        RequestTelemetryContext context = (RequestTelemetryContext)req.getAttribute(RequestTelemetryContext.CONTEXT_ATTR_KEY);
+        RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
         if (isSessionCookieUpToDate(context)) {
             return;
         }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/WebUserTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/WebUserTrackingTelemetryModule.java
@@ -30,6 +30,7 @@ import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.extensibility.context.UserContext;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.cookies.UserCookie;
 
 /**
@@ -57,7 +58,7 @@ public class WebUserTrackingTelemetryModule implements WebTelemetryModule, Telem
     @Override
     public void onBeginRequest(ServletRequest req, ServletResponse res) {
         HttpServletRequest request = (HttpServletRequest)req;
-        RequestTelemetryContext context = (RequestTelemetryContext)request.getAttribute(RequestTelemetryContext.CONTEXT_ATTR_KEY);
+        RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
 
         UserCookie userCookie =
                 com.microsoft.applicationinsights.web.internal.cookies.Cookie.getCookie(

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/RequestTelemetryContext.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/RequestTelemetryContext.java
@@ -34,8 +34,6 @@ public class RequestTelemetryContext {
     private SessionCookie sessionCookie;
     private UserCookie userCookie;
 
-    public static final String CONTEXT_ATTR_KEY = "CONTEXT_ATTR";
-
     /**
      * Constructs new RequestTelemetryContext object.
      * @param ticks The time in ticks

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/ThreadContext.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/ThreadContext.java
@@ -1,0 +1,37 @@
+/*
+ * AppInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.web.internal;
+
+/**
+ * Created by yonisha on 2/16/2015.
+ */
+public class ThreadContext {
+    private static final ThreadLocal<RequestTelemetryContext> threadLocal = new ThreadLocal<RequestTelemetryContext>();
+
+    public static void setRequestTelemetryContext(RequestTelemetryContext telemetryContext) {
+        threadLocal.set(telemetryContext);
+    }
+
+    public static RequestTelemetryContext getRequestTelemetryContext() {
+        return threadLocal.get();
+    }
+}

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -104,7 +104,7 @@ public final class WebRequestTrackingFilter implements Filter {
 
         try {
             RequestTelemetryContext context = new RequestTelemetryContext(new Date().getTime());
-            req.setAttribute(RequestTelemetryContext.CONTEXT_ATTR_KEY, context);
+            ThreadContext.setRequestTelemetryContext(context);
 
             webModulesContainer.invokeOnBeginRequest(req, res);
         } catch (Exception e) {

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
@@ -1,0 +1,59 @@
+/*
+ * AppInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.web.internal;
+
+import org.junit.Test;
+import com.microsoft.applicationinsights.web.utils.ThreadContextValidator;
+
+import java.util.ArrayList;
+
+/**
+ * Created by yonisha on 2/16/2015.
+ */
+public class ThreadContextTests {
+
+    /**
+     * Here we're using a large number of threads in order to increase the probability that threads will interrupt
+     * each other in case of a wrong logic.
+     */
+    private final int NUMBER_OF_VALIDATOR_THREADS = 10000;
+
+    @Test
+    public void testConcurrentThreadsGetTheirOwnContext() throws InterruptedException {
+        ArrayList<ThreadContextValidator> threadContextValidators = new ArrayList<ThreadContextValidator>();
+
+        // Initializing validators.
+        for (int i = 0; i < NUMBER_OF_VALIDATOR_THREADS; i++) {
+            threadContextValidators.add(new ThreadContextValidator());
+        }
+
+        // Executing all validators.
+        for (ThreadContextValidator validator : threadContextValidators) {
+            validator.start();
+        }
+
+        // Wait for all threads to complete.
+        for (ThreadContextValidator validator : threadContextValidators) {
+            validator.join();
+        }
+    }
+}

--- a/web/src/test/java/com/microsoft/applicationinsights/web/utils/ThreadContextValidator.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/utils/ThreadContextValidator.java
@@ -1,0 +1,59 @@
+/*
+ * AppInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.web.utils;
+
+import com.microsoft.applicationinsights.internal.util.DateTimeUtils;
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
+import org.junit.Assert;
+
+/**
+ * Created by yonisha on 2/16/2015.
+ *
+ * This class validates the ThreadContext class.
+ * The idea is simple: store a request telemetry context using TLS and then getting it back
+ * to validate the expected value.
+ * This class should be called concurrently to increase the probability of other threads (validators)
+ * interrupting each other, and therefore identify potential bugs.
+ * Concurrent invocations of this calls basically simulates concurrent http requests on a web server.
+ */
+public class ThreadContextValidator extends Thread {
+    private long startTicks;
+
+    public ThreadContextValidator() {
+        startTicks = DateTimeUtils.getDateTimeNow().getTime();
+    }
+
+    @Override
+    public void run() {
+        RequestTelemetryContext context = new RequestTelemetryContext(startTicks);
+        ThreadContext.setRequestTelemetryContext(context);
+
+        validate();
+    }
+
+    private void validate() {
+        long currentTicks = ThreadContext.getRequestTelemetryContext().getRequestStartTimeTicks();
+
+        Assert.assertEquals("Found a thread with unexpected value.", startTicks, currentTicks);
+    }
+}


### PR DESCRIPTION
Refactoring the web modules to use TLS that is required for the traces correlation modules.

You can read about tls here: http://en.wikipedia.org/wiki/Thread-local_storage.
In short: it is simply memory allocation  - variable, local to a single thread. Each thread can store/retrieved its value without other threads interrupting it.
