### PR TITLE
Removing set/get value functions and fixing duration in json

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/RemoteDependencyData.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/RemoteDependencyData.java
@@ -63,11 +63,6 @@ public class RemoteDependencyData extends Domain {
     private DataPointType kind = DataPointType.Measurement;
 
     /**
-     * Backing field for property Value.
-     */
-    private double value;
-
-    /**
      * Backing field for property Count.
      */
     private Integer count;
@@ -147,14 +142,6 @@ public class RemoteDependencyData extends Domain {
 
     public void setKind(DataPointType value) {
         this.kind = value;
-    }
-
-    public double getValue() {
-        return this.value;
-    }
-
-    public void setValue(double value) {
-        this.value = value;
     }
 
     public Integer getCount() {
@@ -252,7 +239,7 @@ public class RemoteDependencyData extends Domain {
         writer.write("name", name);
         writer.write("commandName", commandName);
         writer.write("kind", kind.getValue());
-        writer.write("value", value);
+        writer.write("value", duration.getTotalMilliseconds());
         writer.write("count", count);
         writer.write("min", min);
         writer.write("max", max);
@@ -262,7 +249,6 @@ public class RemoteDependencyData extends Domain {
         writer.write("async", async);
         writer.write("dependencySource", dependencySource.getValue());
         writer.write("properties", properties);
-        writer.write("duration", duration.toString());
     }
 
     public String getEnvelopName() {

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/Duration.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/Duration.java
@@ -122,6 +122,17 @@ public final class Duration {
         return milliseconds;
     }
 
+    /**
+     * Gets the total milliseconds of the duration.
+     * @return The total milliseconds of the duration.
+     */
+    public long getTotalMilliseconds() {
+        return (days * SECONDS_IN_ONE_DAY * 1000) +
+                (hours * SECONDS_IN_ONE_HOUR * 1000) +
+                (minutes * SECONDS_IN_ONE_MINUTE * 1000) +
+                (seconds * 1000) + milliseconds;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/Duration.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/Duration.java
@@ -127,7 +127,7 @@ public final class Duration {
      * @return The total milliseconds of the duration.
      */
     public long getTotalMilliseconds() {
-        return (days * SECONDS_IN_ONE_DAY * 1000) +
+        return  (days * SECONDS_IN_ONE_DAY * 1000) +
                 (hours * SECONDS_IN_ONE_HOUR * 1000) +
                 (minutes * SECONDS_IN_ONE_MINUTE * 1000) +
                 (seconds * 1000) + milliseconds;

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/RemoteDependencyTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/RemoteDependencyTelemetry.java
@@ -100,22 +100,6 @@ public final class RemoteDependencyTelemetry extends BaseTelemetry<RemoteDepende
     public void setCommandName(String commandName) { this.data.setCommandName(commandName); }
 
     /**
-     * Gets the Value property.
-     * @return Value property.
-     */
-    public double getValue() {
-        return data.getValue();
-    }
-
-    /**
-     * Sets the Value property.
-     * @param value Value property.
-     */
-    public void setValue(double value) {
-        data.setValue(value);
-    }
-
-    /**
      * Gets the Count property.
      * @return Count property.
      */
@@ -252,7 +236,7 @@ public final class RemoteDependencyTelemetry extends BaseTelemetry<RemoteDepende
     }
 
     /**
-     * Sets the durations.
+     * Sets the duration.
      * @param duration The duration.
      */
     public void setDuration(Duration duration) {

--- a/core/src/test/java/com/microsoft/applicationinsights/telemetry/DurationTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/telemetry/DurationTest.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.telemetry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -213,6 +214,14 @@ public final class DurationTest {
         Duration duration = new Duration(0, 3, 0, 0, 0);
 
         verify(duration, 0, 3, 0, 0, 0, "03:00:00");
+    }
+
+    @Test
+    public void testTotalMilliseconds() {
+        Duration duration = new Duration(1, 1, 1, 1, 1);
+
+        // 90061001 ms is 1 day, 1 hour, 1 minute, 1 sec and 1 milliseconds.
+        Assert.assertEquals(duration.getTotalMilliseconds(), 90061001);
     }
 
     @Test

--- a/core/src/test/java/com/microsoft/applicationinsights/telemetry/RemoteDependencyTelemetryTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/telemetry/RemoteDependencyTelemetryTest.java
@@ -36,7 +36,6 @@ public final class RemoteDependencyTelemetryTest {
         RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry();
 
         assertNull(telemetry.getName());
-        assertEquals(telemetry.getValue(), 0.0, 0);
         assertNull(telemetry.getCount());
         assertNull(telemetry.getMin());
         assertNull(telemetry.getMax());
@@ -51,7 +50,6 @@ public final class RemoteDependencyTelemetryTest {
         RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry("MockName");
 
         assertEquals(telemetry.getName(), "MockName");
-        assertEquals(telemetry.getValue(), 0.0, 0);
         assertNull(telemetry.getCount());
         assertNull(telemetry.getMin());
         assertNull(telemetry.getMax());
@@ -75,7 +73,6 @@ public final class RemoteDependencyTelemetryTest {
         assertEquals(duration, telemetry.getDuration());
         assertEquals(success, telemetry.getSuccess());
 
-        assertEquals(telemetry.getValue(), 0.0, 0);
         assertNull(telemetry.getCount());
         assertNull(telemetry.getMin());
         assertNull(telemetry.getMax());
@@ -94,7 +91,7 @@ public final class RemoteDependencyTelemetryTest {
     }
 
     @Test
-    public void testDurationName() {
+    public void testDuration() {
         Duration duration = new Duration(1234);
         RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry();
         telemetry.setDuration(duration);
@@ -117,14 +114,6 @@ public final class RemoteDependencyTelemetryTest {
 
         telemetry.setName("MockName1");
         assertEquals(telemetry.getName(), "MockName1");
-    }
-
-    @Test
-    public void testSetValue() {
-        RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry("MockName");
-
-        telemetry.setValue(120.1);
-        assertEquals(telemetry.getValue(), 120.1, 0);
     }
 
     @Test

--- a/samples/src/main/java/com/microsoft/applicationinsights/sample/AiCore.java
+++ b/samples/src/main/java/com/microsoft/applicationinsights/sample/AiCore.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.jar.JarFile;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.TelemetryConfiguration;

--- a/samples/src/main/java/com/microsoft/applicationinsights/sample/AiCore.java
+++ b/samples/src/main/java/com/microsoft/applicationinsights/sample/AiCore.java
@@ -25,9 +25,12 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.jar.JarFile;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 
@@ -41,12 +44,13 @@ public class AiCore {
         if (args.length > 0) {
             appInsights.getContext().setInstrumentationKey(args[0]);
         }
+
         String iKey = appInsights.getContext().getInstrumentationKey();
-        if (iKey == null)
-        {
+        if (iKey == null) {
             System.out.println("Error: no iKey set in ApplicationInsights.xml or as a parameter for this program.");
             return;
         }
+
         System.out.println("Application iKey set to " + appInsights.getContext().getInstrumentationKey());
         TelemetryConfiguration.getActive().getChannel().setDeveloperMode(true);
 
@@ -90,6 +94,12 @@ public class AiCore {
             appInsights.trackException(exc);
             System.out.println("[6] Exception             -- message=\"This is only a test!\"");
         }
+
+        // Track Remote Dependency
+        RemoteDependencyTelemetry remoteDependencyTelemetry = new RemoteDependencyTelemetry(
+                "DependencyName", "commandName", new Duration(0, 0, 1, 1, 1), true);
+        appInsights.trackDependency(remoteDependencyTelemetry);
+        System.out.println("[7] Remote Dependency       -- DependencyName, commandName, 61001 ms, success = true.");
 
         System.out.println();
         System.out.println("Press any key to exit");


### PR DESCRIPTION
PR contains the following:
1. Removing set/get value method from dependency telemetry.
2. Used the duration value in the json sent to the BE.