### PR TITLE
Disabling user/session cookies generation

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
@@ -58,7 +58,7 @@ public class WebSessionTrackingTelemetryModule implements WebTelemetryModule, Te
     // region Members
 
     private Integer sessionTimeoutInMinutes;
-    private boolean generateNewSessions = true;
+    private boolean generateNewSessions = false;
     private TelemetryClient telemetryClient;
     private boolean isInitialized = false;
     private boolean isUserModuleEnabled = false;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebUserTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebUserTrackingTelemetryModule.java
@@ -49,7 +49,7 @@ public class WebUserTrackingTelemetryModule implements WebTelemetryModule, Telem
 
     // region Members
 
-    private boolean generateNewUsers = true;
+    private boolean generateNewUsers = false;
 
     // endregion Members
 

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModuleTests.java
@@ -89,7 +89,6 @@ public class WebSessionTrackingTelemetryModuleTests {
 
     // region Tests
 
-    @Ignore
     @Test
     public void testNewSessionIsCreatedWhenCookieNotExist() throws Exception {
         CookiesContainer cookiesContainer = HttpHelper.sendRequestAndGetResponseCookie();
@@ -123,7 +122,6 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testNewSessionIsCreatedWhenCookieSessionExpired() throws Exception {
         sessionCookieFormatted = HttpHelper.getFormattedSessionCookieHeader(true);
 
@@ -135,7 +133,6 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testNewSessionIsCreatedWhenCookieCorrupted() throws Exception {
         CookiesContainer cookiesContainer = HttpHelper.sendRequestAndGetResponseCookie("corrupted;session;cookie");
 
@@ -153,7 +150,6 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testWhenNewSessionStartedSessionStateStartTracked() throws Exception {
         HttpHelper.sendRequestAndGetResponseCookie();
 
@@ -169,7 +165,6 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testSessionStateTelemetryContainsSessionIdOnStartState() throws Exception {
         HttpHelper.sendRequestAndGetResponseCookie();
 
@@ -179,7 +174,6 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testWhenCookieNotUpToDateUpdatedCookieReturned() throws Exception {
         sessionCookieFormatted = HttpHelper.getFormattedSessionCookieWithOldTime(6);
         String originalSessionId = HttpHelper.getSessionIdFromCookie(sessionCookieFormatted);
@@ -189,8 +183,8 @@ public class WebSessionTrackingTelemetryModuleTests {
         Assert.assertEquals("Session ID shouldn't be generated.", originalSessionId, returnedSessionId);
     }
 
-    @Ignore
     @Test
+    @Ignore
     public void testSessionStateTelemetryContainsSessionIdOnEndState() throws Exception {
         sessionCookieFormatted = HttpHelper.getFormattedSessionCookieHeader(true);
 
@@ -201,8 +195,8 @@ public class WebSessionTrackingTelemetryModuleTests {
         Assert.assertNotNull("Session ID shouldn't be null", telemetry.getContext().getSession().getId());
     }
 
-    @Ignore
     @Test
+    @Ignore
     public void testSessionStateTelemetryEndStateContainsExpiredSessionId() throws Exception {
         sessionCookieFormatted = HttpHelper.getFormattedSessionCookieHeader(true);
 
@@ -248,11 +242,13 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testWhenSessionTimeoutParameterUsedThenCookieCreatedWithCorrectAge() {
         int sessionTimeoutInMinutes = 12;
-        WebSessionTrackingTelemetryModule module = createModuleWithParam(
-                WebSessionTrackingTelemetryModule.SESSION_TIMEOUT_PARAM_KEY, String.valueOf(sessionTimeoutInMinutes));
+        Map<String, String> moduleParameters = new HashMap<String, String>();
+        moduleParameters.put(WebSessionTrackingTelemetryModule.GENERATE_NEW_SESSIONS_PARAM_KEY, String.valueOf(true));
+        moduleParameters.put(WebSessionTrackingTelemetryModule.SESSION_TIMEOUT_PARAM_KEY, String.valueOf(sessionTimeoutInMinutes));
+
+        WebSessionTrackingTelemetryModule module = createModuleWithParam(moduleParameters);
 
         Cookie cookie = callOnBeginRequestAndGetCookieResult(module);
 
@@ -288,6 +284,10 @@ public class WebSessionTrackingTelemetryModuleTests {
         Map<String, String> map = new HashMap<String, String>();
         map.put(paramName, paramValue);
 
+        return createModuleWithParam(map);
+    }
+
+    private WebSessionTrackingTelemetryModule createModuleWithParam(Map<String, String> map) {
         return new WebSessionTrackingTelemetryModule(map);
     }
 

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModuleTests.java
@@ -89,6 +89,7 @@ public class WebSessionTrackingTelemetryModuleTests {
 
     // region Tests
 
+    @Ignore
     @Test
     public void testNewSessionIsCreatedWhenCookieNotExist() throws Exception {
         CookiesContainer cookiesContainer = HttpHelper.sendRequestAndGetResponseCookie();
@@ -106,6 +107,15 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
+    public void testWhenCookieExistCorrectSessionIdAttachedToSentTelemetry() throws Exception {
+        HttpHelper.sendRequestAndGetResponseCookie(sessionCookieFormatted);
+
+        RequestTelemetry requestTelemetry = channel.getTelemetryItems(RequestTelemetry.class).get(0);
+
+        Assert.assertTrue(sessionCookieFormatted.contains(requestTelemetry.getContext().getSession().getId()));
+    }
+
+    @Test
     public void testNoSessionCreatedWhenValidSessionExists() throws Exception {
         CookiesContainer cookiesContainer = HttpHelper.sendRequestAndGetResponseCookie(sessionCookieFormatted);
 
@@ -113,6 +123,7 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
+    @Ignore
     public void testNewSessionIsCreatedWhenCookieSessionExpired() throws Exception {
         sessionCookieFormatted = HttpHelper.getFormattedSessionCookieHeader(true);
 
@@ -124,6 +135,7 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
+    @Ignore
     public void testNewSessionIsCreatedWhenCookieCorrupted() throws Exception {
         CookiesContainer cookiesContainer = HttpHelper.sendRequestAndGetResponseCookie("corrupted;session;cookie");
 
@@ -141,6 +153,7 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
+    @Ignore
     public void testWhenNewSessionStartedSessionStateStartTracked() throws Exception {
         HttpHelper.sendRequestAndGetResponseCookie();
 
@@ -156,6 +169,7 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
+    @Ignore
     public void testSessionStateTelemetryContainsSessionIdOnStartState() throws Exception {
         HttpHelper.sendRequestAndGetResponseCookie();
 
@@ -165,6 +179,7 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
+    @Ignore
     public void testWhenCookieNotUpToDateUpdatedCookieReturned() throws Exception {
         sessionCookieFormatted = HttpHelper.getFormattedSessionCookieWithOldTime(6);
         String originalSessionId = HttpHelper.getSessionIdFromCookie(sessionCookieFormatted);
@@ -233,6 +248,7 @@ public class WebSessionTrackingTelemetryModuleTests {
     }
 
     @Test
+    @Ignore
     public void testWhenSessionTimeoutParameterUsedThenCookieCreatedWithCorrectAge() {
         int sessionTimeoutInMinutes = 12;
         WebSessionTrackingTelemetryModule module = createModuleWithParam(

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebUserTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebUserTrackingTelemetryModuleTests.java
@@ -32,7 +32,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.Assert;
-import org.junit.Ignore;
 import com.microsoft.applicationinsights.web.utils.CookiesContainer;
 import com.microsoft.applicationinsights.web.utils.HttpHelper;
 import com.microsoft.applicationinsights.web.utils.JettyTestServer;
@@ -98,7 +97,6 @@ public class WebUserTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testNewUserCookieIsCreatedWhenCookieNotExist() throws Exception {
         CookiesContainer cookiesContainer = HttpHelper.sendRequestAndGetResponseCookie();
 
@@ -113,7 +111,6 @@ public class WebUserTrackingTelemetryModuleTests {
     }
 
     @Test
-    @Ignore
     public void testNewUserCookieIsCreatedWhenCookieCorrupted() throws Exception {
         CookiesContainer cookiesContainer = HttpHelper.sendRequestAndGetResponseCookie("corrupted;user;cookie");
 

--- a/web/src/test/java/com/microsoft/applicationinsights/web/utils/HttpHelper.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/utils/HttpHelper.java
@@ -123,6 +123,11 @@ public class HttpHelper {
 
     private static CookiesContainer getCookiesContainer(List<String> responseCookies) throws Exception {
         CookiesContainer cookiesContainer = new CookiesContainer();
+
+        if (responseCookies == null) {
+            return cookiesContainer;
+        }
+
         for (String formattedCookieWithExpiration : responseCookies) {
             if (formattedCookieWithExpiration.startsWith("ai_user")) {
                 String formattedCookie = formattedCookieWithExpiration.split("=")[1].split(";")[0];

--- a/web/src/test/resources/ApplicationInsights.xml
+++ b/web/src/test/resources/ApplicationInsights.xml
@@ -32,8 +32,13 @@
     </TelemetryInitializers>
     <TelemetryModules>
         <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule">
+            <Param name="GenerateNewSessions" value="true" />
+        </Add>
+
+        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule">
+            <Param name="GenerateNewUsers" value="true" />
+        </Add>
     </TelemetryModules>
     <Channel type="com.microsoft.applicationinsights.internal.shared.LogChannelMock">
         <EndpointAddress>


### PR DESCRIPTION
Disabling user/session cookies generation by defaulting the modules to NOT generate cookies. Only if a cookie contains in the request, the module will use it information to update the telemetry sent to AI BE.