### PR TITLE
Setting default channel when no configuration file found

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -81,6 +81,7 @@ public enum TelemetryConfigurationFactory {
         try {
             String configurationFile = getConfigurationFile();
             if (Strings.isNullOrEmpty(configurationFile)) {
+                configuration.setChannel(new InProcessTelemetryChannel());
                 return;
             }
 


### PR DESCRIPTION
When no configuration file found, we still need to set the default channel, so the user won't need to set it by himself.