### PR TITLE
Handle all successful status codes

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionNetworkOutput.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionNetworkOutput.java
@@ -177,7 +177,7 @@ public final class TransmissionNetworkOutput implements TransmissionOutput {
     }
 
     private TransmissionSendResult translateResponse(int code, HttpEntity respEntity) {
-        if (code == HttpStatus.SC_OK) {
+        if (code >= 200 && code < 300) {
             return TransmissionSendResult.SENT_SUCCESSFULLY;
         }
 

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -117,7 +117,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
 
             ApplicationInsightsHttpResponseWrapper response = ((ApplicationInsightsHttpResponseWrapper)res);
             if (response != null) {
-                telemetry.setSuccess(HttpStatus.SC_OK == response.getStatus());
+                telemetry.setSuccess(response.getStatus() >= 200 && response.getStatus() < 300);
                 telemetry.setResponseCode(Integer.toString(response.getStatus()));
             } else {
                 InternalLogger.INSTANCE.error("Failed to get response status for request ID: %s", telemetry.getId());


### PR DESCRIPTION
I have an API which a returns `201` successful status code when an entity is created. Insights is currently incorrectly logging these requests as unsuccessful:

![unsuccessful request](https://cloud.githubusercontent.com/assets/69390/9763004/0a018dfc-56ff-11e5-8861-50028ace20f7.png)
