### PR TITLE
Try to use a per-user temporary directory

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionFileSystemOutput.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionFileSystemOutput.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.microsoft.applicationinsights.internal.channel.TransmissionOutput;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 
+import com.microsoft.applicationinsights.internal.util.FileSystemUtils;
 import com.microsoft.applicationinsights.internal.util.LimitsEnforcer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -100,7 +101,7 @@ public final class TransmissionFileSystemOutput implements TransmissionOutput {
 
     public TransmissionFileSystemOutput(String folderPath, String maxTransmissionStorageCapacity) {
         if (folderPath == null) {
-            folderPath = new File(System.getProperty("java.io.tmpdir"), TRANSMISSION_DEFAULT_FOLDER).getPath();
+            folderPath = new File(FileSystemUtils.getTempDir(), TRANSMISSION_DEFAULT_FOLDER).getPath();
         }
 
         capacityEnforcer = LimitsEnforcer.createWithClosestLimitOnError(MIN_CAPACITY_MEGABYTES,

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/logger/FileLoggerOutput.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/logger/FileLoggerOutput.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 
+import com.microsoft.applicationinsights.internal.util.FileSystemUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.FileUtils;
 
@@ -137,7 +138,7 @@ public final class FileLoggerOutput implements LoggerOutput {
         }
         this.maxSizePerFileInMB = tempSizePerFileInMB;
 
-        baseFolder = new File(System.getProperty("java.io.tmpdir"), baseFolderName);
+        baseFolder = new File(FileSystemUtils.getTempDir(), baseFolderName);
         if (!baseFolder.exists()) {
             baseFolder.mkdirs();
         } else {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
@@ -26,6 +26,7 @@ import com.microsoft.applicationinsights.internal.system.SystemInformation;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.microsoft.applicationinsights.internal.util.FileSystemUtils;
 import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -213,7 +214,7 @@ public final class JniPCConnector {
             throw new RuntimeException("Failed to find SDK version.");
         }
 
-        File dllPath = new File(System.getProperty("java.io.tmpdir"));
+        File dllPath = FileSystemUtils.getTempDir();
         dllPath = new File(dllPath.toString(), AI_BASE_FOLDER);
         dllPath = new File(dllPath.toString(), AI_NATIVE_FOLDER);
         dllPath = new File(dllPath.toString(), version);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/FileSystemUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/FileSystemUtils.java
@@ -21,9 +21,23 @@
 
 package com.microsoft.applicationinsights.internal.util;
 
+import java.io.File;
+
 /**
  * Helper methods for dealing with files and folders.
  */
 public class FileSystemUtils {
 
+    /**
+     * Finds a suitable folder to use for temporary files
+     *
+     * @return a {@link File} representing a folder in which temporary files will be stored
+     *
+     */
+    public static File getTempDir() {
+        final String tempDirectory = System.getProperty("java.io.tmpdir");
+
+        final File result = new File(tempDirectory);
+        return result;
+    }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/FileSystemUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/FileSystemUtils.java
@@ -1,0 +1,29 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.internal.util;
+
+/**
+ * Helper methods for dealing with files and folders.
+ */
+public class FileSystemUtils {
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/FileSystemUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/FileSystemUtils.java
@@ -37,7 +37,11 @@ public class FileSystemUtils {
     public static File getTempDir() {
         final String tempDirectory = System.getProperty("java.io.tmpdir");
 
-        final File result = new File(tempDirectory);
+        final File result = getTempDir(tempDirectory);
         return result;
+    }
+
+    static File getTempDir(final String initialValue) {
+        return new File(initialValue);
     }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/logger/FileLoggerOutputTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/logger/FileLoggerOutputTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.LinkedList;
 import java.util.HashMap;
 
+import com.microsoft.applicationinsights.internal.util.FileSystemUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -50,7 +51,7 @@ public final class FileLoggerOutputTest {
     private final String workingFolder;
 
     public FileLoggerOutputTest() {
-        workingFolder = System.getProperty("java.io.tmpdir") + File.separator + TEMP_LOG_TEST_FOLDER;
+        workingFolder = new File(FileSystemUtils.getTempDir(), TEMP_LOG_TEST_FOLDER).getAbsolutePath();
     }
 
     @Test

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
@@ -24,6 +24,31 @@ package com.microsoft.applicationinsights.internal.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
+
 public class FileSystemUtilsTest {
 
+    /*
+    NOTE: it doesn't matter that Windows paths are converted to *nix paths and vice-versa.
+     */
+
+    @Test
+    public void getTempDir_WindowsForUser() {
+        final String input = "C:\\Users\\olivida\\AppData\\Local\\Temp";
+
+        final File actual = FileSystemUtils.getTempDir(input);
+
+        final File expected = new File(input);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getTempDir_MacForUser() {
+        final String input = "/var/folders/8b/n6pydwyj1cg9yb7822n277xc0000gs/T/";
+
+        final File actual = FileSystemUtils.getTempDir(input);
+
+        final File expected = new File(input);
+        Assert.assertEquals(expected, actual);
+    }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
@@ -61,4 +61,24 @@ public class FileSystemUtilsTest {
         final File expected = new File(input, "olivida").getAbsoluteFile();
         Assert.assertEquals(expected, actual);
     }
+
+    @Test
+    public void getTempDir_PerUser() {
+        final String input = "/tmp/olivida";
+
+        final File actual = FileSystemUtils.getTempDir(input, "olivida");
+
+        final File expected = new File(input);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getTempDir_InsideUserHome() {
+        final String input = "/home/olivida/tmp";
+
+        final File actual = FileSystemUtils.getTempDir(input, "olivida");
+
+        final File expected = new File(input);
+        Assert.assertEquals(expected, actual);
+    }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
@@ -36,7 +36,7 @@ public class FileSystemUtilsTest {
     public void getTempDir_WindowsForUser() {
         final String input = "C:\\Users\\olivida\\AppData\\Local\\Temp";
 
-        final File actual = FileSystemUtils.getTempDir(input);
+        final File actual = FileSystemUtils.getTempDir(input, null);
 
         final File expected = new File(input);
         Assert.assertEquals(expected, actual);
@@ -46,9 +46,19 @@ public class FileSystemUtilsTest {
     public void getTempDir_MacForUser() {
         final String input = "/var/folders/8b/n6pydwyj1cg9yb7822n277xc0000gs/T/";
 
-        final File actual = FileSystemUtils.getTempDir(input);
+        final File actual = FileSystemUtils.getTempDir(input, null);
 
         final File expected = new File(input);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getTempDir_Linux() {
+        final String input = "/tmp";
+
+        final File actual = FileSystemUtils.getTempDir(input, "olivida");
+
+        final File expected = new File(input, "olivida").getAbsoluteFile();
         Assert.assertEquals(expected, actual);
     }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/util/FileSystemUtilsTest.java
@@ -1,0 +1,29 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.internal.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileSystemUtilsTest {
+
+}


### PR DESCRIPTION
# Motivation
Our team uses ApplicationInsights-Java in a few of our products and reports have started coming in from customers trying to use our products under Linux and finding themselves unable to do so when more than one user is involved.  The best, most comprehensive example is in the thread [TFS Command Line Client crashes in Linux](https://social.msdn.microsoft.com/Forums/vstudio/en-US/37561345-25d0-4bd9-8d3d-40531c7c117a/tfs-command-line-client-crashes-in-linux?forum=tee).

The cause seems to be that on GNU/Linux (among others), the temporary directory is **shared** and ApplicationInsights-Java wasn't designed to accommodate that situation.  See the third paragraph of [Separate /tmp directories for each user] (http://www.chiark.greenend.org.uk/~peterb/uxsup/project/tmp-per-user/) for a much more eloquent description of the problem.  On Windows and Mac OS X, it appears [interactive?] users already get their own temporary directory, which is why I suspect it took so long to find this issue.

I haven't dug deeply into the `TransmissionFileSystemOutput` class' use of the `transmissions` temporary folder to see if it's sufficient to have it be per-user (as opposed to per-user, per-process), but this is at least a start.

## Potential alternative implementation
I'm new to this project, so pardon my ignorance.  While investigating the issue, it occurred to me that it's possible `TransmissionFileSystemOutput` may have been written with the expectation that the contents of its `transmissions` temporary folder would stick around between runs of the program emitting telemetry and, should such a program be updated with the next release of ApplicationInsights-Java that contains this fix, any files in the `/tmp/transmissions` folder used by previous releases of this library will be abandoned.

If this is a terrible situation, we could overcome it by having the `TransmissionsFileSystemOutput` be more aware of the temporary folders and have it move the contents of the old one to the new one whenever it starts up.  A lot more work for potentially very few telemetry files, so I'm not sure if it's worth it.

## The "hacky" alternative implementation I don't really want to talk about
Lastly, and I'm afraid to bring this one up, but it's technically the least disruptive option of the bunch: the workaround discovered by our users was to increase the permissions on the temporary folders such that multiple users could run programs that emit telemetry files to the same folder.  In other words, adding something like:

```java
folder.setWritable(true, false);
```
...right after creating the folder.

The thing is, although that might appear to fix the problem, the `TransmissionsFileSystemOutput` may be thread-safe but I'm not sure if it's process-safe, such that two processes (whether from the same user or from separate users) emitting and attempting to transmit telemetry files wouldn't end up in a race condition in cleaning up the folder, with the loser of the race throwing an `IOException` because a file stopped existing in the middle of processing.

# Manual testing
I ran `gradlew test` on the following platforms:
* Oracle Java 1.8.0_71-b15 (64-bit) on Windows 10 (10.0.10586)
* Oracle Java 1.7.0_71-b14 (64-bit) on Mac OS X (Yosemite 10.10.5)
* OpenJDK 1.8.0_71-b15 (64-bit) on Fedora 22
    * This is the only one where an unrelated test is failing. I've opened Issue #278 to track that.