### PR TITLE
Fix build problems when using Gradle 2.11+

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -20,7 +20,7 @@
  */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.1'
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"

--- a/collectd/build.gradle
+++ b/collectd/build.gradle
@@ -20,7 +20,7 @@
  */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.1'
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"

--- a/distributions/build.gradle
+++ b/distributions/build.gradle
@@ -20,7 +20,7 @@
  */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.1'
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"


### PR DESCRIPTION
Incremented Gradle Shadow plugin to version 1.2.3 as this version supports Gradle 2.11 and newer

More information:
https://github.com/johnrengelman/shadow/releases/tag/1.2.3