### PR TITLE
HTTP response code is not always set properly

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsHttpResponseWrapper.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsHttpResponseWrapper.java
@@ -46,6 +46,13 @@ public class ApplicationInsightsHttpResponseWrapper extends HttpServletResponseW
     }
 
     @Override
+    public void setStatus(int sc, String sm) {
+        super.setStatus(sc, sm);
+
+        this.httpStatusCode = sc;
+    }
+
+    @Override
     public void sendError(int sc) throws IOException {
         super.sendError(sc);
 


### PR DESCRIPTION
ApplicationInsightsHttpResponseWrapper does not always set HTTP status code properly resulting in displaying code '200' in Azure portal even for failed requests.
The reason is the missing override for setStatus(int sc, String sm) method.