### PR TITLE
Fixing URL generation from file path.

### DIFF
--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/AgentImplementation.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/AgentImplementation.java
@@ -64,7 +64,7 @@ public final class AgentImplementation {
     }
 
     private static void appendJarsToBootstrapClassLoader(Instrumentation inst) throws Throwable {
-        String agentJarPath = agentJarLocation.startsWith("file:/") ? agentJarLocation : "file:/" + agentJarLocation;
+        String agentJarPath = agentJarLocation.startsWith("file:/") ? agentJarLocation : new File(agentJarLocation).toURI().toString();
 
         String agentJarName = null;
         File agentFolder = new File(agentJarLocation);


### PR DESCRIPTION
Appending 'file:/' at the start of a file path works only under windows, where paths start with the drive letter (-> file:/c:/...).
On Unix, paths start with /, resulting in a URL like file://var/lib/... - this is then interpreted as a file on the host 'var', in directory 'lib/...'

This fix utilizes Java to source the URL for a file, instead of crafting it manually.