### PR TITLE
Propagate log context data

### DIFF
--- a/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/internal/ApplicationInsightsLogEvent.java
+++ b/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/internal/ApplicationInsightsLogEvent.java
@@ -84,6 +84,12 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
             addLogEventProperty("LineNumber", String.valueOf(locationInfo.getLineNumber()), metaData);
         }
 
+        for (Object o : loggingEvent.getProperties().entrySet()) {
+            Map.Entry<String, Object> entry = (Map.Entry<String, Object>) o;
+            addLogEventProperty(entry.getKey(), entry.getValue().toString(), metaData);
+        }
+
+
         // TODO: Username, domain and identity should be included as in .NET version.
         // TODO: Should check, seems that it is not included in Log4j2.
 

--- a/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEvent.java
+++ b/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEvent.java
@@ -84,6 +84,10 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
             addLogEventProperty("LineNumber", String.valueOf(stackTraceElement.getLineNumber()), metaData);
         }
 
+        for (Map.Entry<String, String> entry : logEvent.getContextMap().entrySet()) {
+            addLogEventProperty(entry.getKey(), entry.getValue(), metaData);
+        }
+
         // TODO: Username, domain and identity should be included as in .NET version.
         // TODO: Should check, seems that it is not included in Log4j2.
 

--- a/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/internal/ApplicationInsightsLogEvent.java
+++ b/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/internal/ApplicationInsightsLogEvent.java
@@ -71,6 +71,10 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
         addLogEventProperty("ThreadName", loggingEvent.getThreadName(), metaData);
         addLogEventProperty("TimeStamp", getFormattedDate(loggingEvent.getTimeStamp()), metaData);
 
+        for (Map.Entry<String, String> entry : loggingEvent.getMDCPropertyMap().entrySet()) {
+            addLogEventProperty(entry.getKey(), entry.getValue(), metaData);
+        }
+
         // TODO: No location info?
         // TODO: Username, domain and identity should be included as in .NET version.
         // TODO: Should check, seems that it is not included in Log4j2.


### PR DESCRIPTION
Details of the Logging Contexts (MDC, ThreadContext, etc) are not sent to AI - this fix adds them as Custom Properties for each logging framework.