### PR TITLE
Support method names that follow java naming standard

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -459,7 +459,7 @@ public enum TelemetryConfigurationFactory {
 
             initializer = createInstance(className.getType(), clazz);
             for (ParamXmlElement param : className.getAdds()){
-                String methodName = "set" + param.getName();
+                String methodName = "set" + param.getName().substring(0,1).toUpperCase() + param.getName().substring(1);
                 try {
                     if (activateMethod(initializer, methodName, param.getValue(), String.class)) {
                         list.add(initializer);


### PR DESCRIPTION
When configuring processors, it's natural for java developers to follow the naming standard for the rest of the project, that is lower case first character in method names.
