### PR TITLE
Support for exception tracking of exceptions handled by Spring

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/SpringMvcRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/SpringMvcRequestTrackingTelemetryModule.java
@@ -1,0 +1,74 @@
+package com.microsoft.applicationinsights.web.extensibility.modules;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.extensibility.TelemetryModule;
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.servlet.DispatcherServlet;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class SpringMvcRequestTrackingTelemetryModule implements WebTelemetryModule, TelemetryModule {
+
+    private TelemetryClient telemetryClient;
+    private List<String> exceptionAttributesList = asList(DispatcherServlet.class.getName() + ".EXCEPTION");
+    private String exceptionAttributes;
+
+    @Override
+    public void initialize(TelemetryConfiguration configuration) {
+        telemetryClient = new TelemetryClient(configuration);
+    }
+
+    @Override
+    public void onBeginRequest(ServletRequest req, ServletResponse res) {
+
+    }
+
+    @Override
+    public void onEndRequest(ServletRequest req, ServletResponse res) {
+        for (String exceptionAttribute : exceptionAttributesList) {
+            Exception exception = (Exception) req.getAttribute(exceptionAttribute);
+            if (exception != null) {
+                telemetryClient.trackException(exception);
+            }
+        }
+    }
+
+    public TelemetryClient getTelemetryClient() {
+        return telemetryClient;
+    }
+
+    public void setTelemetryClient(TelemetryClient telemetryClient) {
+        this.telemetryClient = telemetryClient;
+    }
+
+    public String getExceptionAttributes() {
+        return exceptionAttributes;
+    }
+
+    public void setExceptionAttributes(String exceptionAttributes) {
+        try {
+            if (StringUtils.isBlank(exceptionAttributes)) {
+                return;
+            }
+            String[] attributes = exceptionAttributes.split(",");
+            exceptionAttributesList = new ArrayList<>(attributes.length);
+            for (String attribute : attributes) {
+                if (!StringUtils.isBlank(exceptionAttributes)) {
+                    exceptionAttributesList.add(attribute);
+                }
+            }
+            InternalLogger.INSTANCE.trace(String.format("SpringMvcRequestTrackingTelemetryModule: set ExceptionAttributes: %s", exceptionAttributes));
+        } catch (Throwable t) {
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, String.format("SpringMvcRequestTrackingTelemetryModule: failed to parse ExceptionAttributes: %s", exceptionAttributes));
+            throw t;
+        }
+
+    }
+}


### PR DESCRIPTION
The current implementation of `WebRequestTrackingFilter` requires exceptions to propagate to the filter in order for them to be reported. That does not happen if the exception is handled by the underlying MVC or Webservice framework.

In the case of Spring MVC, an attribute with the exception is added to the request. Note that the attribute name in this PR is only used by Spring 4 (but there are not Spring 4 dependencies). I'll investigate how Spring 3 behaves, I can't find the same attribute there. The attribute names are configurable, I'm pretty sure that CXF and Jersey behaves the same way, so the module _should_ be usable for those frameworks as well.

I have some tests that verifies this module, they depend on `MockMvc` from Spring 4 in order to call webservices (see [this link](https://spring.io/guides/tutorials/bookmarks/) for an introduction). I have frankly no idea how to test webservices in Spring 3, so as for now the PR is without tests.
