### PR TITLE
Avoid error message when agent is not loaded

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/agent/AgentConnector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/agent/AgentConnector.java
@@ -35,7 +35,7 @@ public enum AgentConnector {
 
     private String agentKey;
     private boolean registered = false;
-    private CoreAgentNotificationsHandler coreDataAgent;
+    private CoreAgentNotificationsHandler coreDataAgent = null;
 
     public static class RegistrationResult {
         private final String key;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -212,8 +212,7 @@ public final class WebRequestTrackingFilter implements Filter {
             //if agent is not installed (jar not loaded), can skip the entire registration process
             try {
                 AgentConnector test = AgentConnector.INSTANCE;
-            } catch(Throwable t)
-            {
+            } catch(Throwable t) {
                 InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.INFO, "Agent was not found. Skipping the agent registration");
                 return;
             }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -208,6 +208,16 @@ public final class WebRequestTrackingFilter implements Filter {
 
     private synchronized void initialize(FilterConfig filterConfig) {
         try {
+
+            //if agent is not installed (jar not loaded), can skip the entire registration process
+            try {
+                AgentConnector test = AgentConnector.INSTANCE;
+            } catch(Throwable t)
+            {
+                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.INFO, "Agent was not found. Skipping the agent registration");
+                return;
+            }
+
             ServletContext context = filterConfig.getServletContext();
 
             String name = getName(context);


### PR DESCRIPTION
Check that the agent jar is loaded before attempting to register with it. If not loaded, skip registration and avoid scary error message

fix #317 