### PR TITLE
Use the non-default JDK when JDKToUse property is defined

### DIFF
--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -21,6 +21,8 @@
 
 // region Shared java configuration
 
+import org.gradle.internal.os.OperatingSystem;
+
 apply plugin: 'java'
 
 def java6JreDir = System.env.'JAVA_JRE_6'
@@ -44,6 +46,36 @@ if (java6JreDir) {
     logger.warn "Environment variable 'JAVA_JRE_6' is not defined - falling back to use machine default Java SDK"
 }
 
+if (hasProperty("JDKToUse")) {
+    logger.info("using $JDKToUse to compile and run tests")
+    def javaExecutablesPath = new File(JDKToUse, 'bin')
+    def javaExecutables = [:].withDefault { execName ->
+        def execNameToUse = execName
+        if (OperatingSystem.current().isWindows()){
+            execNameToUse = execName + ".exe"
+        }
+        def executable = new File(javaExecutablesPath, execNameToUse)
+        assert executable.exists(): "There is no ${execName} executable in ${javaExecutablesPath}"
+        executable
+    }
+    tasks.withType(AbstractCompile) {
+        options.with {
+            fork = true
+            forkOptions.executable = javaExecutables.javac
+        }
+    }
+    tasks.withType(Javadoc) {
+        executable = javaExecutables.javadoc
+    }
+    tasks.withType(Test) {
+        executable = javaExecutables.java
+    }
+    tasks.withType(JavaExec) {
+        executable = javaExecutables.java
+    }
+} else {
+    logger.info("JDKToUse not found. Using default JAVA_HOME")
+}
 updateTestDirectories()
 
 sourceSets {


### PR DESCRIPTION
Gradle3 requires Java 7 and above to run. We support JDK 6 and test it internally by running tests against JDK6.
Add a property  `JDKToUse` and setting it to the location of the JDK using `-P` to instruct gradle to use a different JDK for buildling and testing 
See [here](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_cross_compilation) for more details. 
Added a small tweak for the above to work better on Windows (append .exe to the file names)