### PR TITLE
Added VS2013 Redist Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To build Application Insights CollectD writer plugin, please do the following:
 ### Notes
 
 * To create a Java 6 compatible build you need to either have JAVA_HOME point to "Java 6 SDK" path or set JAVA_JRE_6 environment variable to point to [JRE 6 JRE installation directory]
+* To enable Windows Performance Counters you need to install the [Visual Studio 2013 C++ Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=40784) (or higher)
 
 
 


### PR DESCRIPTION
In some cases you can see the error below when starting a JVM with Application. This error is because you need the VC2013 redistributable pacakge which is not always installed on non-developer machines.

```
INFO   | jvm 1    | 2016/12/22 17:36:42.556 | AI: ERROR 22-12-2016 17:36, 1: Failed to load native dll, Windows performance counters will not be used. Please make sure that Visual C++ Redistributable is properly installed: Expecting an absolute path of the library: ..\temp\AISDK\native\1.0.6\applicationinsights-core-native-win64.dll.
INFO   | jvm 1    | 2016/12/22 17:36:42.556 | AI: ERROR 22-12-2016 17:36, 1: Failed to initialize JNI connection.
```
