### PR TITLE
Bugfix/362

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.4'])
     compile ([group: 'commons-io', name: 'commons-io', version: '2.4' ])
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1']) 
-    compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
-    compile ([group: 'com.google.guava', name: 'guava', version: '12.0.1']) { transitive = false }
+    compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.5'])
+    compile ([group: 'com.google.guava', name: 'guava', version: '12.0.1'])
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.8.0'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '1.7.2'
@@ -52,6 +52,7 @@ shadowJar {
     relocate 'eu.infomas.annotation', 'com.microsoft.applicationinsights.core.dependencies.annotation'
     relocate 'org.apache.commons', 'com.microsoft.applicationinsights.core.dependencies.apachecommons'
     relocate 'com.google.common', 'com.microsoft.applicationinsights.core.dependencies.googlecommon'
+    relocate 'javax.annotation', 'com.microsoft.applicationinsights.core.dependencies.javaxannotation'
 }
 
 jar {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,11 +36,11 @@ archivesBaseName = 'applicationinsights-core'
 
 dependencies {
     provided (project(':agent')) { transitive = false }
-    compile group: 'eu.infomas', name: 'annotation-detector', version: '3.0.4'
-    compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.1'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.5'
-    compile group: 'com.google.guava', name: 'guava', version: '12.0.1'
+    compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.4']) { transitive = false }
+    compile ([group: 'commons-io', name: 'commons-io', version: '2.4' ]) { transitive = false }
+    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1']) { transitive = false }
+    compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
+    compile ([group: 'com.google.guava', name: 'guava', version: '12.0.1']) { transitive = false }
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.8.0'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '1.7.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,9 +36,9 @@ archivesBaseName = 'applicationinsights-core'
 
 dependencies {
     provided (project(':agent')) { transitive = false }
-    compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.4']) { transitive = false }
-    compile ([group: 'commons-io', name: 'commons-io', version: '2.4' ]) { transitive = false }
-    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1']) { transitive = false }
+    compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.4'])
+    compile ([group: 'commons-io', name: 'commons-io', version: '2.4' ])
+    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1']) 
     compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
     compile ([group: 'com.google.guava', name: 'guava', version: '12.0.1']) { transitive = false }
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -27,7 +27,7 @@ archivesBaseName = 'applicationinsights-web'
 dependencies {
     provided (project(':agent')) { transitive = false }
     compile (project(':core')) { transitive = false }
-    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1']) { transitive = false }
+    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1'])
     compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
     provided 'com.opensymphony:xwork:2.0.4' // Struts 2
     provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -25,8 +25,10 @@ apply from: "$buildScriptsDir/publishing.gradle"
 archivesBaseName = 'applicationinsights-web'
 
 dependencies {
-    provided project(':agent')
-    compile project(':core')
+    provided (project(':agent')) { transitive = false }
+    compile (project(':core')) { transitive = false }
+    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1']) { transitive = false }
+    compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
     provided 'com.opensymphony:xwork:2.0.4' // Struts 2
     provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'
     provided group: 'javax.servlet', name: 'servlet-api', version: '2.5'

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     provided (project(':agent')) { transitive = false }
     compile (project(':core')) { transitive = false }
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1'])
-    compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
+    compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.5'])
     provided 'com.opensymphony:xwork:2.0.4' // Struts 2
     provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'
     provided group: 'javax.servlet', name: 'servlet-api', version: '2.5'


### PR DESCRIPTION
Based on feed back from @isaac84 and PR #367  I've updated the core JAR to remove the transitive dependencies for guava, which depends on JSR305 which has it's own dependency on javax.annotation. 

I also removed the transitive dependency from core and agent, even though it's not really required in this situation as the web JAR could have a need for a shadow jar in the future. This will save on bug hunts later.

Lastly I updated to the latest version of the httpclient based on the recommendation of [CVE-2015-5262](https://nvd.nist.gov/vuln/detail/CVE-2015-5262) however this vulnerability is classified as a DoS. In short it is a bug in the httpclient that does not honor the SSL handshake timeout.