### PR TITLE
Fix low hanging issues for "QuickPulse Broken #360"

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataSender.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataSender.java
@@ -57,8 +57,9 @@ final class DefaultQuickPulseDataSender implements QuickPulseDataSender {
                 }
 
                 final long sendTime = System.nanoTime();
+                HttpResponse response = null;
                 try {
-                    HttpResponse response = apacheSender.sendPostRequest(post);
+                    response = apacheSender.sendPostRequest(post);
                     if (networkHelper.isSuccess(response)) {
                         final QuickPulseStatus quickPulseResultStatus = networkHelper.getQuickPulseStatus(response);
                         switch (quickPulseResultStatus) {
@@ -78,6 +79,10 @@ final class DefaultQuickPulseDataSender implements QuickPulseDataSender {
                     }
                 } catch (IOException e) {
                     onPostError(sendTime);
+                } finally {
+                	if (response != null) {
+                		apacheSender.dispose(response);
+                	}
                 }
             }
         } catch (Throwable t) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
@@ -36,7 +36,7 @@ import com.microsoft.applicationinsights.internal.channel.common.ApacheSender;
  * Created by gupele on 12/12/2016.
  */
 final class DefaultQuickPulsePingSender implements QuickPulsePingSender {
-    private final static String QP_BASE_URI = "https://rt.services.visualstudio.com/QuickPulseService.svc/ping?ikey=";
+    private final static String QP_BASE_URI = "https://rt.services.visualstudio.com/QuickPulseService.svc/";
 
     private final String quickPulsePingUri;
     private final ApacheSender apacheSender;
@@ -51,18 +51,15 @@ final class DefaultQuickPulsePingSender implements QuickPulsePingSender {
         quickPulsePingUri = QP_BASE_URI + "ping?ikey=" + ikey;
 
         final StrBuilder sb = new StrBuilder();
-        sb.append("\"Instance\":\"" + instanceName + "\"," + "\"InstrumentationKey\":");
-        sb.append(ikey);
-        sb.append(",\"InvariantVersion\":2,\"MachineName\":\"");
-        sb.append(instanceName);
-        sb.append("\"");
-        sb.append(",\"Version\":\"2.2.0-424\"");
-        sb.append(",\"StreamId\":");
-        sb.append(quickPulseId);
-
-        sb.append(",\"Documents\":null");
-        sb.append(",\"Metrics\":null");
-        sb.append(",\"Timestamp\": \"\\/Date(");
+        sb.append("{");
+        sb.append("\"Documents\": null,");
+        sb.append("\"Instance\":\"" + instanceName + "\",");
+        sb.append("\"InstrumentationKey\": null,");
+        sb.append("\"InvariantVersion\": 2,");
+        sb.append("\"MachineName\":\"" + instanceName + "\",");
+        sb.append("\"Metrics\": null,");
+        sb.append("\"StreamId\": \"" + quickPulseId + "\",");
+        sb.append("\"Timestamp\": \"\\/Date(");
 
         pingPrefix = sb.toString();
     }
@@ -102,7 +99,9 @@ final class DefaultQuickPulsePingSender implements QuickPulsePingSender {
 
         StrBuilder sb = new StrBuilder(pingPrefix);
         sb.append(timeInMillis);
-        sb.append(")\\\\/\\\"\"");
+        sb.append(")\\/\",");
+        sb.append("\"Version\":\"2.2.0-738\"");
+        sb.append("}");
         ByteArrayEntity bae = new ByteArrayEntity(sb.toString().getBytes());
         return bae;
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
@@ -36,82 +36,89 @@ import com.microsoft.applicationinsights.internal.channel.common.ApacheSender;
  * Created by gupele on 12/12/2016.
  */
 final class DefaultQuickPulsePingSender implements QuickPulsePingSender {
-    private final static String QP_BASE_URI = "https://rt.services.visualstudio.com/QuickPulseService.svc/";
+	private final static String QP_BASE_URI = "https://rt.services.visualstudio.com/QuickPulseService.svc/";
 
-    private final String quickPulsePingUri;
-    private final ApacheSender apacheSender;
-    private final QuickPulseNetworkHelper networkHelper = new QuickPulseNetworkHelper();
-    private String pingPrefix;
-    private long lastValidTransmission = 0;
+	private final String quickPulsePingUri;
+	private final ApacheSender apacheSender;
+	private final QuickPulseNetworkHelper networkHelper = new QuickPulseNetworkHelper();
+	private String pingPrefix;
+	private long lastValidTransmission = 0;
 
-    public DefaultQuickPulsePingSender(final ApacheSender apacheSender, final String instanceName, final String quickPulseId) {
-        this.apacheSender = apacheSender;
+	public DefaultQuickPulsePingSender(final ApacheSender apacheSender, final String instanceName,
+			final String quickPulseId) {
+		this.apacheSender = apacheSender;
 
-        final String ikey = TelemetryConfiguration.getActive().getInstrumentationKey();
-        quickPulsePingUri = QP_BASE_URI + "ping?ikey=" + ikey;
+		final String ikey = TelemetryConfiguration.getActive().getInstrumentationKey();
+		quickPulsePingUri = QP_BASE_URI + "ping?ikey=" + ikey;
 
-        final StrBuilder sb = new StrBuilder();
-        sb.append("{");
-        sb.append("\"Documents\": null,");
-        sb.append("\"Instance\":\"" + instanceName + "\",");
-        sb.append("\"InstrumentationKey\": null,");
-        sb.append("\"InvariantVersion\": 2,");
-        sb.append("\"MachineName\":\"" + instanceName + "\",");
-        sb.append("\"Metrics\": null,");
-        sb.append("\"StreamId\": \"" + quickPulseId + "\",");
-        sb.append("\"Timestamp\": \"\\/Date(");
+		final StrBuilder sb = new StrBuilder();
+		sb.append("{");
+		sb.append("\"Documents\": null,");
+		sb.append("\"Instance\":\"" + instanceName + "\",");
+		sb.append("\"InstrumentationKey\": null,");
+		sb.append("\"InvariantVersion\": 2,");
+		sb.append("\"MachineName\":\"" + instanceName + "\",");
+		sb.append("\"Metrics\": null,");
+		sb.append("\"StreamId\": \"" + quickPulseId + "\",");
+		sb.append("\"Timestamp\": \"\\/Date(");
 
-        pingPrefix = sb.toString();
-    }
+		pingPrefix = sb.toString();
+	}
 
-    @Override
-    public QuickPulseStatus ping() {
-        final Date currentDate = new Date();
-        final HttpPost request = networkHelper.buildRequest(currentDate, quickPulsePingUri);
+	@Override
+	public QuickPulseStatus ping() {
+		final Date currentDate = new Date();
+		final HttpPost request = networkHelper.buildRequest(currentDate, quickPulsePingUri);
 
-        final ByteArrayEntity pingEntity = buildPingEntity(currentDate.getTime());
-        request.setEntity(pingEntity);
+		final ByteArrayEntity pingEntity = buildPingEntity(currentDate.getTime());
+		request.setEntity(pingEntity);
 
-        final long sendTime = System.nanoTime();
-        try {
-            HttpResponse response = apacheSender.sendPostRequest(request);
-            if (networkHelper.isSuccess(response)) {
-                final QuickPulseStatus quickPulseResultStatus = networkHelper.getQuickPulseStatus(response);
-                switch (quickPulseResultStatus) {
-                    case QP_IS_OFF:
-                    case QP_IS_ON:
-                        lastValidTransmission = sendTime;
-                        return quickPulseResultStatus;
+		final long sendTime = System.nanoTime();
+		HttpResponse response = null;
+		try {
+			response = apacheSender.sendPostRequest(request);
+			if (networkHelper.isSuccess(response)) {
+				final QuickPulseStatus quickPulseResultStatus = networkHelper.getQuickPulseStatus(response);
+				switch (quickPulseResultStatus) {
+				case QP_IS_OFF:
+				case QP_IS_ON:
+					lastValidTransmission = sendTime;
+					return quickPulseResultStatus;
 
-                    case ERROR:
-                        break;
+				case ERROR:
+					break;
 
-                    default:
-                        break;
-                }
-            }
-        } catch (IOException e) {
-        }
-        return onPingError(sendTime);
-    }
+				default:
+					break;
+				}
+			}
+		} catch (IOException e) {
 
-    private ByteArrayEntity buildPingEntity(long timeInMillis) {
+		} finally {
+			if (response != null) {
+				apacheSender.dispose(response);
+			}
+		}
+		return onPingError(sendTime);
+	}
 
-        StrBuilder sb = new StrBuilder(pingPrefix);
-        sb.append(timeInMillis);
-        sb.append(")\\/\",");
-        sb.append("\"Version\":\"2.2.0-738\"");
-        sb.append("}");
-        ByteArrayEntity bae = new ByteArrayEntity(sb.toString().getBytes());
-        return bae;
-    }
+	private ByteArrayEntity buildPingEntity(long timeInMillis) {
 
-    private QuickPulseStatus onPingError(long sendTime) {
-        final double timeFromLastValidTransmission = (sendTime - lastValidTransmission) / 1000000000.0;
-        if (timeFromLastValidTransmission >= 60.0) {
-            return QuickPulseStatus.ERROR;
-        }
+		StrBuilder sb = new StrBuilder(pingPrefix);
+		sb.append(timeInMillis);
+		sb.append(")\\/\",");
+		sb.append("\"Version\":\"2.2.0-738\"");
+		sb.append("}");
+		ByteArrayEntity bae = new ByteArrayEntity(sb.toString().getBytes());
+		return bae;
+	}
 
-        return QuickPulseStatus.QP_IS_OFF;
-    }
+	private QuickPulseStatus onPingError(long sendTime) {
+		final double timeFromLastValidTransmission = (sendTime - lastValidTransmission) / 1000000000.0;
+		if (timeFromLastValidTransmission >= 60.0) {
+			return QuickPulseStatus.ERROR;
+		}
+
+		return QuickPulseStatus.QP_IS_OFF;
+	}
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
@@ -36,89 +36,89 @@ import com.microsoft.applicationinsights.internal.channel.common.ApacheSender;
  * Created by gupele on 12/12/2016.
  */
 final class DefaultQuickPulsePingSender implements QuickPulsePingSender {
-	private final static String QP_BASE_URI = "https://rt.services.visualstudio.com/QuickPulseService.svc/";
+    private final static String QP_BASE_URI = "https://rt.services.visualstudio.com/QuickPulseService.svc/";
 
-	private final String quickPulsePingUri;
-	private final ApacheSender apacheSender;
-	private final QuickPulseNetworkHelper networkHelper = new QuickPulseNetworkHelper();
-	private String pingPrefix;
-	private long lastValidTransmission = 0;
+    private final String quickPulsePingUri;
+    private final ApacheSender apacheSender;
+    private final QuickPulseNetworkHelper networkHelper = new QuickPulseNetworkHelper();
+    private String pingPrefix;
+    private long lastValidTransmission = 0;
 
-	public DefaultQuickPulsePingSender(final ApacheSender apacheSender, final String instanceName,
-			final String quickPulseId) {
-		this.apacheSender = apacheSender;
+    public DefaultQuickPulsePingSender(final ApacheSender apacheSender, final String instanceName,
+            final String quickPulseId) {
+        this.apacheSender = apacheSender;
 
-		final String ikey = TelemetryConfiguration.getActive().getInstrumentationKey();
-		quickPulsePingUri = QP_BASE_URI + "ping?ikey=" + ikey;
+        final String ikey = TelemetryConfiguration.getActive().getInstrumentationKey();
+        quickPulsePingUri = QP_BASE_URI + "ping?ikey=" + ikey;
 
-		final StrBuilder sb = new StrBuilder();
-		sb.append("{");
-		sb.append("\"Documents\": null,");
-		sb.append("\"Instance\":\"" + instanceName + "\",");
-		sb.append("\"InstrumentationKey\": null,");
-		sb.append("\"InvariantVersion\": 2,");
-		sb.append("\"MachineName\":\"" + instanceName + "\",");
-		sb.append("\"Metrics\": null,");
-		sb.append("\"StreamId\": \"" + quickPulseId + "\",");
-		sb.append("\"Timestamp\": \"\\/Date(");
+        final StrBuilder sb = new StrBuilder();
+        sb.append("{");
+        sb.append("\"Documents\": null,");
+        sb.append("\"Instance\":\"" + instanceName + "\",");
+        sb.append("\"InstrumentationKey\": null,");
+        sb.append("\"InvariantVersion\": 2,");
+        sb.append("\"MachineName\":\"" + instanceName + "\",");
+        sb.append("\"Metrics\": null,");
+        sb.append("\"StreamId\": \"" + quickPulseId + "\",");
+        sb.append("\"Timestamp\": \"\\/Date(");
 
-		pingPrefix = sb.toString();
-	}
+        pingPrefix = sb.toString();
+    }
 
-	@Override
-	public QuickPulseStatus ping() {
-		final Date currentDate = new Date();
-		final HttpPost request = networkHelper.buildRequest(currentDate, quickPulsePingUri);
+    @Override
+    public QuickPulseStatus ping() {
+        final Date currentDate = new Date();
+        final HttpPost request = networkHelper.buildRequest(currentDate, quickPulsePingUri);
 
-		final ByteArrayEntity pingEntity = buildPingEntity(currentDate.getTime());
-		request.setEntity(pingEntity);
+        final ByteArrayEntity pingEntity = buildPingEntity(currentDate.getTime());
+        request.setEntity(pingEntity);
 
-		final long sendTime = System.nanoTime();
-		HttpResponse response = null;
-		try {
-			response = apacheSender.sendPostRequest(request);
-			if (networkHelper.isSuccess(response)) {
-				final QuickPulseStatus quickPulseResultStatus = networkHelper.getQuickPulseStatus(response);
-				switch (quickPulseResultStatus) {
-				case QP_IS_OFF:
-				case QP_IS_ON:
-					lastValidTransmission = sendTime;
-					return quickPulseResultStatus;
+        final long sendTime = System.nanoTime();
+        HttpResponse response = null;
+        try {
+            response = apacheSender.sendPostRequest(request);
+            if (networkHelper.isSuccess(response)) {
+                final QuickPulseStatus quickPulseResultStatus = networkHelper.getQuickPulseStatus(response);
+                switch (quickPulseResultStatus) {
+                case QP_IS_OFF:
+                case QP_IS_ON:
+                    lastValidTransmission = sendTime;
+                    return quickPulseResultStatus;
 
-				case ERROR:
-					break;
+                case ERROR:
+                    break;
 
-				default:
-					break;
-				}
-			}
-		} catch (IOException e) {
+                default:
+                    break;
+                }
+            }
+        } catch (IOException e) {
 
-		} finally {
-			if (response != null) {
-				apacheSender.dispose(response);
-			}
-		}
-		return onPingError(sendTime);
-	}
+        } finally {
+            if (response != null) {
+                apacheSender.dispose(response);
+            }
+        }
+        return onPingError(sendTime);
+    }
 
-	private ByteArrayEntity buildPingEntity(long timeInMillis) {
+    private ByteArrayEntity buildPingEntity(long timeInMillis) {
 
-		StrBuilder sb = new StrBuilder(pingPrefix);
-		sb.append(timeInMillis);
-		sb.append(")\\/\",");
-		sb.append("\"Version\":\"2.2.0-738\"");
-		sb.append("}");
-		ByteArrayEntity bae = new ByteArrayEntity(sb.toString().getBytes());
-		return bae;
-	}
+        StrBuilder sb = new StrBuilder(pingPrefix);
+        sb.append(timeInMillis);
+        sb.append(")\\/\",");
+        sb.append("\"Version\":\"2.2.0-738\"");
+        sb.append("}");
+        ByteArrayEntity bae = new ByteArrayEntity(sb.toString().getBytes());
+        return bae;
+    }
 
-	private QuickPulseStatus onPingError(long sendTime) {
-		final double timeFromLastValidTransmission = (sendTime - lastValidTransmission) / 1000000000.0;
-		if (timeFromLastValidTransmission >= 60.0) {
-			return QuickPulseStatus.ERROR;
-		}
+    private QuickPulseStatus onPingError(long sendTime) {
+        final double timeFromLastValidTransmission = (sendTime - lastValidTransmission) / 1000000000.0;
+        if (timeFromLastValidTransmission >= 60.0) {
+            return QuickPulseStatus.ERROR;
+        }
 
-		return QuickPulseStatus.QP_IS_OFF;
-	}
+        return QuickPulseStatus.QP_IS_OFF;
+    }
 }


### PR DESCRIPTION
 This will get us over the hump of providing Quick Pulse until we can implement the latest features.

**This PR contains the following fixes for QuickPulse in Java.**
- Clean up of string builder JSON creation
- Changing telemetry names to match version 2.2.0-738
- Fix bug where QP would exhaust the PoolingHttpClientConnectionManager connections

**It does not implement**
- Aggregation
- Per process CPU time
- Real time error and exception messages
