### PR TITLE
Delaying retry on send when HostUnknownException is thrown

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionNetworkOutput.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionNetworkOutput.java
@@ -168,6 +168,8 @@ public final class TransmissionNetworkOutput implements TransmissionOutput {
                 }
             } catch (UnknownHostException e) {
                 InternalLogger.INSTANCE.error("Failed to send, wrong host address or cannot reach address due to network issues, exception: %s", e.getMessage());
+                // backoff retry if host unknown
+                transmissionPolicyManager.suspendInSeconds(TransmissionPolicy.BLOCKED_BUT_CAN_BE_PERSISTED, DEFAULT_BACKOFF_TIME_SECONDS);
             } catch (IOException ioe) {
                 InternalLogger.INSTANCE.error("Failed to send, exception: %s", ioe.getMessage());
                 // backoff retry if no connection is found


### PR DESCRIPTION
I get different exception between production and sandbox environment. I get the exact log lines "Failed to send, wrong host address or cannot reach address due to network issues" which is the UnknownHostException 