### PR TITLE
Fixes custom telemetry timestamp bug

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -394,7 +394,9 @@ public class TelemetryClient {
             return;
         }
 
-        telemetry.setTimestamp(new Date());
+        if (telemetry.getTimestamp() == null) {
+            telemetry.setTimestamp(new Date());
+        }
 
         TelemetryContext ctx = this.getContext();
 

--- a/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientTests.java
@@ -382,6 +382,15 @@ public final class TelemetryClientTests {
     }
 
     @Test
+    public void testTrackWithCustomTelemetryTimestamp() {
+        Date timestamp = new Date(10000);
+        client.track(new RequestTelemetry("Name", timestamp, 1, "200", true));
+
+        Telemetry telemetry = verifyAndGetLastEventSent();
+        assertEquals(telemetry.getTimestamp(), timestamp);
+    }
+
+    @Test
     public void testTrack() {
         TraceTelemetry telemetry = new TraceTelemetry("test");
         client.track(telemetry);


### PR DESCRIPTION
Do not set telemetry timestamp if it already exists

Fixes a bug where track function of TelemetryClient class is overwriting the timestamp that was previously set for the telemetry. This results in not able to specify the order of different events.

For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #
- [x] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
