### PR TITLE
Add second environment variable to configure ikey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#CHANGELOG
+# CHANGELOG
 
 ## Version 1.0.10
 - Schema updated to the latest version. Changes in internal namespace `core/src/main/java/com/microsoft/applicationinsights/internal/schemav2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Methods `getExceptionHandledAt` and `setExceptionHandledAt` of `ExceptionTelemetry` marked obsolete and do not do anything. 
 - Obsolete methods of `RemoteDependencyTelemetry`:  `getCount`, `setCount`, `getMin`, `setMin`, `getMax`, `setMax`, `getStdDev`, `setStdDev`, `getDependencyKind`, `setDependencyKind`, `getAsync`, `setAsync`, `getDependencySource`, `setDependencySource`.
 - Obsolete methods of `RequestTelemetry`: `getHttpMethod`, `setHttpMethod`.
+- Add option to configure instrumentation key via `APPINSIGHTS_INSTRUMENTATIONKEY` environment variable for consistency with other SDKs.
 
 ## Version 1.0.9
 - Fix the issue of infinite retry and connection drain on certificate error by updating the version of http client packaged with the SDK.

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -60,6 +60,7 @@ public enum TelemetryConfigurationFactory {
     private String performanceCountersSection = DEFAULT_PERFORMANCE_MODULES_PACKAGE;
 
     final static String EXTERNAL_PROPERTY_IKEY_NAME = "APPLICATION_INSIGHTS_IKEY";
+    final static String EXTERNAL_PROPERTY_IKEY_NAME_SECONDARY = "APPINSIGHTS_INSTRUMENTATIONKEY";
 
     private AppInsightsConfigurationBuilder builder = new JaxbAppInsightsConfigurationBuilder();
 
@@ -208,24 +209,35 @@ public enum TelemetryConfigurationFactory {
 
     /**
      * Setting an instrumentation key:
-     * First we try the system property '-DAPPLICATION_INSIGHTS_IKEY=i_key'
-     * Next we will try the environment variable 'APPLICATION_INSIGHTS_IKEY',
+     * First we try the system property '-DAPPLICATION_INSIGHTS_IKEY=i_key' or '-DAPPINSIGHTS_INSTRUMENTATIONKEY=i_key'
+     * Next we will try the environment variable 'APPLICATION_INSIGHTS_IKEY' or 'APPINSIGHTS_INSTRUMENTATIONKEY'
      * Next we will try to fetch the i-key from the ApplicationInsights.xml
      * @param userConfiguration The configuration that was represents the user's configuration in ApplicationInsights.xml.
      * @param configuration The configuration class.
      */
     private void setInstrumentationKey(ApplicationInsightsXmlConfiguration userConfiguration, TelemetryConfiguration configuration) {
         try {
-            // First, check whether an i-key was provided as a java system property i.e. '-DAPPLICATION_INSIGHTS_IKEY=i_key'
-            String ikey = System.getProperty(EXTERNAL_PROPERTY_IKEY_NAME);
+            String ikey;
 
+            // First, check whether an i-key was provided as a java system property i.e. '-DAPPLICATION_INSIGHTS_IKEY=i_key', or '-DAPPINSIGHTS_INSTRUMENTATIONKEY=i_key'
+            ikey = System.getProperty(EXTERNAL_PROPERTY_IKEY_NAME);
+            if (!Strings.isNullOrEmpty(ikey)) {
+                configuration.setInstrumentationKey(ikey);
+                return;
+            }
+            ikey = System.getProperty(EXTERNAL_PROPERTY_IKEY_NAME_SECONDARY);
             if (!Strings.isNullOrEmpty(ikey)) {
                 configuration.setInstrumentationKey(ikey);
                 return;
             }
 
-            // Second, try to find the i-key as an environment variable 'APPLICATION_INSIGHTS_IKEY'
+            // Second, try to find the i-key as an environment variable 'APPLICATION_INSIGHTS_IKEY' or 'APPINSIGHTS_INSTRUMENTATIONKEY'
             ikey = System.getenv(EXTERNAL_PROPERTY_IKEY_NAME);
+            if (!Strings.isNullOrEmpty(ikey)) {
+                configuration.setInstrumentationKey(ikey);
+                return;
+            }
+            ikey = System.getenv(EXTERNAL_PROPERTY_IKEY_NAME_SECONDARY);
             if (!Strings.isNullOrEmpty(ikey)) {
                 configuration.setInstrumentationKey(ikey);
                 return;

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactoryTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactoryTest.java
@@ -118,6 +118,17 @@ public final class TelemetryConfigurationFactoryTest {
     }
 
     @Test
+    public void systemPropertyIKeySecondaryBeforeConfigurationIKeyTest() {
+        try {
+            System.setProperty(TelemetryConfigurationFactory.EXTERNAL_PROPERTY_IKEY_NAME_SECONDARY, APP_INSIGHTS_IKEY_TEST_VALUE);
+            ikeyTest(MOCK_IKEY, APP_INSIGHTS_IKEY_TEST_VALUE);
+        } finally {
+            // Avoid any influence on other unit tests
+            System.getProperties().remove(TelemetryConfigurationFactory.EXTERNAL_PROPERTY_IKEY_NAME_SECONDARY);
+        }
+    }
+
+    @Test
     public void testWithEmptySections() {
         AppInsightsConfigurationBuilder mockParser = Mockito.mock(AppInsightsConfigurationBuilder.class);
 


### PR DESCRIPTION
None of the other SDKs use the `APPLICATION_INSIGHTS_IKEY` environment variable to configure the instrumentation key for Application Insights and instead use `APPINSIGHTS_INSTRUMENTATIONKEY`.

For consistency with the other SDKs (e.g. [Dot-Net](https://aka.ms/n2ruy1) or [Node](https://aka.ms/v8r0pk)) this Java SDK should also support the  more common environment variable name to avoid confusion for developers who have experience with the non-Java SDKs.