### PR TITLE
Dhaval/revert set sample rate null check

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/Envelope.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/Envelope.java
@@ -139,11 +139,8 @@ public class Envelope
     /**
      * Sets the SampleRate property.
      */
-    public void setSampleRate(Double value) {
-        if (value != null) {
+    public void setSampleRate(double value) {
             this.sampleRate = value;
-        }
-
     }
     
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/Envelope.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/Envelope.java
@@ -139,8 +139,11 @@ public class Envelope
     /**
      * Sets the SampleRate property.
      */
-    public void setSampleRate(double value) {
-        this.sampleRate = value;
+    public void setSampleRate(Double value) {
+        if (value != null) {
+            this.sampleRate = value;
+        }
+
     }
     
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseSampleSourceTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseSampleSourceTelemetry.java
@@ -17,6 +17,8 @@ public abstract class BaseSampleSourceTelemetry<T extends Domain> extends BaseTe
     @Override
     protected void setSampleRate(Envelope envelope) {
         Double currentSP = getSamplingPercentage();
-        envelope.setSampleRate(currentSP);
+        if (currentSP != null) {
+            envelope.setSampleRate(currentSP);
+        }
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
@@ -69,7 +69,7 @@ public final class JsonTelemetryDataSerializer {
 
     public void write(String name, Duration value) throws IOException {
         writeName(name);
-        out.write(String.valueOf(value));
+        write(String.valueOf(value));
         separator = JSON_SEPARATOR;
     }
 


### PR DESCRIPTION
Fixing RequestTelemetry sending bug with SchemaV2. Re-introduced null check in setSampleRate() and fixed the write method.


For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated
