### PR TITLE
Delay retrying to send telemetry if an exception is hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Obsolete methods of `RequestTelemetry`: `getHttpMethod`, `setHttpMethod`.
 - Add option to configure instrumentation key via `APPINSIGHTS_INSTRUMENTATIONKEY` environment variable for consistency with other SDKs.
 - Fix the issue where `track(...)` of `TelemetryClient` class was overwriting the provided telemetry timestamp. 
+- Changed the policy on failed sent requests to delay retrying for 5 minutes instead of immediately retrying.
 
 ## Version 1.0.9
 - Fix the issue of infinite retry and connection drain on certificate error by updating the version of http client packaged with the SDK.


### PR DESCRIPTION
I originally made changes to delay retries on specific exceptions but users are hitting this for more reasons such as working offline, working through a proxy, etc. They see >500 requests in less than a minute in these cases which have taken down their proxy. I don't know any reason why there shouldn't be backoff if there is an exception in general instead of constantly retrying. I made the change to delay no matter the exception. I tested on my personal machine and I stopped seeing the constant retries every second.