### PR TITLE
Fixed cast error in CpuPerformanceCounterCalculator constructor 

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
@@ -48,6 +48,7 @@ public final class CpuPerformanceCounterCalculator {
     public CpuPerformanceCounterCalculator() {
         OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
         numberOfCpus = operatingSystemMXBean.getAvailableProcessors();
+        
     }
 
     public double getProcessCpuUsage() {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
@@ -76,7 +76,6 @@ public final class CpuPerformanceCounterCalculator {
     private long getProcessCpuTime() throws Exception {
         MBeanServer bsvr = ManagementFactory.getPlatformMBeanServer();
         ObjectName oname = ObjectName.getInstance(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
-        Attribute cpuTimeAttrib = (Attribute) bsvr.getAttribute(oname, "ProcessCpuTime");
-        return (Long)cpuTimeAttrib.getValue();
+        return (Long)bsvr.getAttribute(oname, "ProcessCpuTime");
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
@@ -31,7 +31,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.OperatingSystemMXBean;
 
-import javax.management.Attribute;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
@@ -43,6 +43,8 @@ public final class CpuPerformanceCounterCalculator {
 
     private long prevUpTime, prevProcessCpuTime;
 
+    private ObjectName osBean;
+
     public CpuPerformanceCounterCalculator() {
         OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
         numberOfCpus = operatingSystemMXBean.getAvailableProcessors();
@@ -74,7 +76,9 @@ public final class CpuPerformanceCounterCalculator {
 
     private long getProcessCpuTime() throws Exception {
         MBeanServer bsvr = ManagementFactory.getPlatformMBeanServer();
-        ObjectName oname = ObjectName.getInstance(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
-        return (Long)bsvr.getAttribute(oname, "ProcessCpuTime");
+        if (osBean == null) {
+            osBean = ObjectName.getInstance(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
+        }
+        return (Long)bsvr.getAttribute(osBean, "ProcessCpuTime");
     }
 }


### PR DESCRIPTION
Corrected issue where the constructor was expecting the `com.sun.management` implementation of the OperatingSystemMXBean.

Since there isn't a getter for ProcessCpuTime in the OperatingSystemMXBean interface, I opted to lookup the metric in the MBeanServer.

Fix #432 