### PR TITLE
 Adding quotes around security level write method to fix serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Version 1.0.11
+- Fixed issue #436 (TraceTelemetry with Severity is not shown in UI)
+
 ## Version 1.0.10
 - `track()` method of 'com.microsoft.applicationinsights.TelemetryClient' is now modified. No longer performing pre-sanitization
 - All Sanitization will now occur in `com.microsoft.applicationinsights.telemetry.JsonTelemetryDataSerializer` class. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Version 1.0.11
-- Fixed issue #436 (TraceTelemetry with Severity is not shown in UI)
+- Fixed issue #436 (TraceTelemetry with Severity is not shown in UI). This fixes a regression issue with `TelemetryClient.trackTrace` and `TelemetryClient.trackException`.
 
 ## Version 1.0.10
 - `track()` method of 'com.microsoft.applicationinsights.TelemetryClient' is now modified. No longer performing pre-sanitization

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
@@ -95,7 +95,9 @@ public final class JsonTelemetryDataSerializer {
     public void write(String name, com.microsoft.applicationinsights.internal.schemav2.SeverityLevel value) throws IOException {
         if (value != null) {
             writeName(name);
+            out.write(JSON_COMMA);
             out.write(String.valueOf(value));
+            out.write(JSON_COMMA);
             separator = JSON_SEPARATOR;
         }
     }

--- a/core/src/test/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializerTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializerTest.java
@@ -288,7 +288,6 @@ public class JsonTelemetryDataSerializerTest {
         stubClass.serialize(tested);
         tested.close();
         String str = stringWriter.toString();
-        System.out.println("serailized=\n"+str);
 
         Gson gson = new Gson();
         StubClass bac = gson.fromJson(str, StubClass.class);


### PR DESCRIPTION
Fix #436 

This was a sanitization issue. Adding quotes around write(String name, com.microsoft.applicationinsights.internal.schemav2.SeverityLevel value) method fixed it.