### PR TITLE
removing escape for single quote, not needed for Json sanitization

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
@@ -362,9 +362,6 @@ public final class JsonTelemetryDataSerializer {
             if( curr == '\"' ){
                 result.append("\\\"");
             }
-            else if (curr == '\'') {
-                result.append("\\\'");
-            }
             else if(curr == '\\'){
                 result.append("\\\\");
             }


### PR DESCRIPTION
Fix #443 

Updating the sanitization logic. There is no need to sanitize single quotes according to JSON Standards. 
(https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringEscapeUtils.html#escapeJson-java.lang.String-)

Further, I am not sure what all types of languages and character schema we support. However, this sanitization logic matches the dot net logic in most possible ways.



