### PR TITLE
Removing the call for empty method et.setExceptionHandledAt() and ass…

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -273,7 +273,6 @@ public class TelemetryClient {
         }
 
         ExceptionTelemetry et = new ExceptionTelemetry(exception);
-        et.setExceptionHandledAt(ExceptionHandledAt.UserCode);
 
         if (properties != null && properties.size() > 0) {
             MapUtil.copy(properties, et.getContext().getProperties());

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionHandledAt.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionHandledAt.java
@@ -25,6 +25,7 @@ package com.microsoft.applicationinsights.telemetry;
  * This enumeration is used by ExceptionTelemetry to identify if and where exception was handled.
  *
  * This Enum is now deprecated.
+ * @deprecated As of 1.0.11
  */
 @Deprecated
 public enum ExceptionHandledAt

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionHandledAt.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionHandledAt.java
@@ -23,7 +23,10 @@ package com.microsoft.applicationinsights.telemetry;
 
 /**
  * This enumeration is used by ExceptionTelemetry to identify if and where exception was handled.
+ *
+ * This Enum is now deprecated.
  */
+@Deprecated
 public enum ExceptionHandledAt
 {
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
@@ -21,17 +21,15 @@
 
 package com.microsoft.applicationinsights.telemetry;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ConcurrentMap;
-
+import com.google.common.base.Strings;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.StackFrame;
-
-import com.google.common.base.Strings;
 import com.microsoft.applicationinsights.internal.util.Sanitizer;
-import org.apache.http.annotation.Obsolete;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Telemetry type used to track exceptions sent to Azure Application Insights.
@@ -57,7 +55,6 @@ public final class ExceptionTelemetry extends BaseSampleSourceTelemetry<Exceptio
         super();
         data = new ExceptionData();
         initialize(data.getProperties());
-        setExceptionHandledAt(ExceptionHandledAt.Unhandled);
     }
 
     /**

--- a/core/src/test/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetryTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetryTest.java
@@ -55,14 +55,6 @@ public final class ExceptionTelemetryTest {
     }
 
     @Test
-    public void getAndSetExceptionHandledAtNotThrows() {
-        NullPointerException exception = new NullPointerException("mock");
-        ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception);
-        exceptionTelemetry.setExceptionHandledAt(ExceptionHandledAt.Platform);
-        exceptionTelemetry.getExceptionHandledAt();
-    }
-
-    @Test
     public void testExceptions() {
         Exception exception = new IOException("mocka", new IllegalArgumentException("mockb"));
         ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception);


### PR DESCRIPTION
Removing the calls to empty method setExceptionHandledAt() and deprecating its associated enum.  Also removed associated phantom test which cleans up the build too (no warnings about tests of deprecated methods).

