### PR TITLE
Log test status

### DIFF
--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -22,6 +22,8 @@
 // region Shared java configuration
 
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.api.tasks.testing.logging.TestLogEvent;
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat;
 
 apply plugin: 'java'
 
@@ -153,6 +155,28 @@ task vscode(dependsOn: vscodeJavaconfigFile) {
     group 'vscode'
 }
 
+tasks.withType(Test) {
+    testLogging {
+        info {
+            events  TestLogEvent.FAILED,
+                    TestLogEvent.PASSED,
+                    TestLogEvent.SKIPPED,
+                    TestLogEvent.STANDARD_OUT,
+                    TestLogEvent.STANDARD_ERROR
+
+            exceptionFormat TestExceptionFormat.FULL
+            showExceptions true
+            showCauses true
+            showStackTraces true
+        }
+        
+        debug {
+            events = info.events
+            events << TestLogEvent.STARTED
+            exceptionFormat = info.exceptionFormat
+        }
+    }
+}
 
 
 // endregion Shared java configuration

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -157,11 +157,16 @@ task vscode(dependsOn: vscodeJavaconfigFile) {
 
 tasks.withType(Test) {
     testLogging {
+        afterSuite { desc, result -> 
+            if (!desc.parent) { // only print when the top-level test suite completes
+                logger.lifecycle("${desc.name} complete. Ran ${result.testCount} tests. ${result.failedTestCount} failed, ${result.skippedTestCount} skipped.")
+            }
+        }
+
         info {
             events  TestLogEvent.FAILED,
                     TestLogEvent.PASSED,
                     TestLogEvent.SKIPPED,
-                    TestLogEvent.STANDARD_OUT,
                     TestLogEvent.STANDARD_ERROR
 
             exceptionFormat TestExceptionFormat.FULL
@@ -169,11 +174,16 @@ tasks.withType(Test) {
             showCauses true
             showStackTraces true
         }
-        
+
         debug {
             events = info.events
             events << TestLogEvent.STARTED
+            events << TestLogEvent.STANDARD_OUT
+            
             exceptionFormat = info.exceptionFormat
+            showExceptions = info.showExceptions
+            showCauses = info.showCauses
+            showStackTraces = info.showStackTraces
         }
     }
 }


### PR DESCRIPTION
I added some more detail to the output of the test run, but it's behind gradle's `--info` and `--debug` command line options. I also added a simple message displaying the results of the top-level test suite. This should help when debugging unit tests.