### PR TITLE
Introducing Fixed Rate Sampling v2 (Using Processors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
 ## Version 1.0.11
+- Introducing public method 'getIncludedTypes' and 'getExcludedTypes' in TelemetryProcessorXmlElement.
+- Introducing class 'com.microsoft.applicationinsights.internal.config.ParamIncludedTypeXmlElement'.
+- Introducing class 'com.microsoft.applicationinsights.internal.config.ParamExcludedTypeXmlElement'
+- Introducing class 'com.microsoft.applicationinsights.internal.channel.samplingV2.SamplingScoreGeneratorV2'
+- Introducing Telemetry Processor 'com.microsoft.applicationinsights.internal.channel.samplingV2.FixedRateSamplingTelemetryProcessor'
+- Introducing FixedRate Sampling v2 Using Telemetry Processors
 - Fixed issue #436 (TraceTelemetry with Severity is not shown in UI). This fixes a regression issue with `TelemetryClient.trackTrace` and `TelemetryClient.trackException`.
 
 ## Version 1.0.10

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -15,6 +15,16 @@ import java.util.Set;
 /**
  * Created by Dhaval Doshi Oct 2017
  * This processor is used to Perform Sampling on User specified sampling rate
+ *
+ * How to use in ApplicationInsights Configuration :
+ *
+ * <BuiltInProcessors>
+     <Processor type = "FixedRateSamplingTelemetryProcessor">
+         <Add name = "SamplingPercentage" value = "50" />
+         <Add name = "ExcludedTypes" value="Trace" />
+        <Add name = "IncludedTypes" value="Trace;Request" />
+     </Processor>
+ </BuiltInProcessors>
  */
 @BuiltInProcessor("FixedRateSamplingTelemetryProcessor")
 public final class FixedRateSamplingTelemetryProcessor implements TelemetryProcessor {
@@ -35,7 +45,9 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
     private String includedTypesString;
     private Set<Class> includedTypesHashSet;
 
-    public double samplingPercentage;
+    /// All sampling percentage must be in a ratio of 100/N where N is a whole number (2, 3, 4, …). E.g. 50 for 1/2 or 33.33 for 1/3.
+    /// Failure to follow this pattern can result in unexpected / incorrect computation of values in the portal.
+    private double samplingPercentage;
 
     /**
      * constructor is responsible of initializing this processor
@@ -43,7 +55,6 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
      */
     public FixedRateSamplingTelemetryProcessor() {
         this.samplingPercentage = 100.00;
-        this.samplingPercentage = samplingPercentage;
         this.includedTypesHashSet = new HashSet<Class>();
         this.excludedTypesHashSet = new HashSet<Class>();
         try {
@@ -55,23 +66,33 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
                 put(requestTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.RequestTelemetry"));
                 put(traceTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.TraceTelemetry"));
             }};
-        }
-        catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException e) {
             InternalLogger.INSTANCE.trace("Unable to locate telemetry classes");
         }
     }
 
-    public String getExcludedTypesString() {
-        return excludedTypesString;
+    /**
+     * This method returns a set of classes of excluded types specified by user
+     *
+     * @return
+     */
+    public Set<Class> getExcludedTypesHashSet() {
+        return excludedTypesHashSet;
     }
 
-    public String getIncludedTypesString() {
-        return includedTypesString;
+    /**
+     * This method returns a set of classes of included types specified by user
+     *
+     * @return
+     */
+    public Set<Class> getIncludedTypesHashSet() {
+        return includedTypesHashSet;
     }
 
     /**
      * This method takes a string of user specified excluded
      * types and parses it to into set containing respective references
+     *
      * @param value
      */
     public void setExcludedTypes(String value) {
@@ -84,6 +105,7 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
     /**
      * This method takes a string of user specified included
      * types and parses it to into set containing respective references
+     *
      * @param value
      */
     public void setIncludedTypes(String value) {
@@ -100,17 +122,23 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
                 item.trim();
                 if (!StringUtils.isNullOrEmpty(item) && allowedTypes.containsKey(item)) {
                     typeSet.add(allowedTypes.get(item));
+                } else {
+                    InternalLogger.INSTANCE.error("item is either not allowed to sample or is empty");
                 }
             }
         }
     }
 
-    public double getSamplingPercentage() {
+    /**
+     * Gets the sample rate currently set
+     */
+    double getSamplingPercentage() {
         return samplingPercentage;
     }
 
     /**
      * Sets the user defined sampling percentage
+     *
      * @param samplingPercentage
      */
     public void setSamplingPercentage(String samplingPercentage) {
@@ -119,44 +147,45 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
 
     /**
      * This method determines if the telemetry needs to be sampled or not.
+     *
      * @param telemetry
      * @return
      */
     @Override
     public boolean process(Telemetry telemetry) {
 
-        double samplingPercentage  = this.samplingPercentage;
+        double samplingPercentage = this.samplingPercentage;
 
-        if (!(telemetry instanceof SupportSampling)) {
-            return true;
+        if (telemetry instanceof SupportSampling) {
+
+            if (isSamplingApplicable(telemetry.getClass())) {
+
+                SupportSampling samplingSupportingTelemetry = ((SupportSampling) telemetry);
+
+                if (samplingSupportingTelemetry.getSamplingPercentage() == null) {
+
+                    samplingSupportingTelemetry.setSamplingPercentage(samplingPercentage);
+
+                    if (SamplingScoreGeneratorV2.getSamplingScore(telemetry) >= samplingPercentage) {
+
+                        InternalLogger.INSTANCE.info("Item %s sampled out", telemetry.getClass());
+                        return false;
+                    }
+                } else {
+                    InternalLogger.INSTANCE.info("Item has sampling percentage already set to :"
+                            + samplingSupportingTelemetry.getSamplingPercentage());
+                }
+            } else {
+                InternalLogger.INSTANCE.trace("Skip sampling since %s type is not sampling applicable", telemetry.getClass());
+            }
         }
 
-        if (!isSamplingApplicable(telemetry.getClass())) {
-            InternalLogger.INSTANCE.trace("Skip sampling since %s type is not sampling applicable", telemetry.getClass());
-            return true;
-        }
-
-        SupportSampling samplingSupportingTelemetry = ((SupportSampling)telemetry);
-        if (samplingSupportingTelemetry.getSamplingPercentage() != null) {
-            return true;
-        }
-
-        samplingSupportingTelemetry.setSamplingPercentage(samplingPercentage);
-
-
-        if (SamplingScoreGeneratorV2.getSamplingScore(telemetry) < samplingPercentage) {
-            return true;
-        }
-
-        else {
-            InternalLogger.INSTANCE.info("Item %s sampled out", telemetry.getClass());
-        }
-
-        return false;
+        return true;
     }
 
     /**
      * Determines if the argument is applicable for sampling
+     *
      * @param item : Denotes the class item to be determined applicable for sampling
      * @return boolean
      */

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -6,12 +6,9 @@ import com.microsoft.applicationinsights.internal.annotation.BuiltInProcessor;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.telemetry.SupportSampling;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
-import org.omg.CORBA.INTERNAL;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,13 +22,13 @@ import java.util.Set;
         <Processor type = "FixedRateSamplingTelemetryProcessor">
             <Add name = "SamplingPercentage" value = "50" />
             <ExcludedTypes>
-                <excludedType>Request</excludedType>
+                <ExcludedType>Request</ExcludedType>
             </ExcludedTypes>
             <IncludedTypes>
-                <includedType>Request</includedType>
-                <includedType>Trace</includedType>
-                <includedType>Dependency</includedType>
-                <includedType>Exception</includedType>
+                <IncludedType>Request</IncludedType>
+                <IncludedType>Trace</IncludedType>
+                <IncludedType>Dependency</IncludedType>
+                <IncludedType>Exception</IncludedType>
             </IncludedTypes>
         </Processor>
     </BuiltInProcessors>
@@ -53,9 +50,10 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
 
     private Set<Class> includedTypes;
 
-
-    /// All sampling percentage must be in a ratio of 100/N where N is a whole number (2, 3, 4, …). E.g. 50 for 1/2 or 33.33 for 1/3.
-    /// Failure to follow this pattern can result in unexpected / incorrect computation of values in the portal.
+    /**
+     *  All sampling percentage must be in a ratio of 100/N where N is a whole number (2, 3, 4, …). E.g. 50 for 1/2 or 33.33 for 1/3.
+     *  Failure to follow this pattern can result in unexpected / incorrect computation of values in the portal.
+     */
     private double samplingPercentage;
 
     /**
@@ -126,7 +124,13 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
      * @param samplingPercentage
      */
     public void setSamplingPercentage(String samplingPercentage) {
-        this.samplingPercentage = Double.valueOf(samplingPercentage);
+        try {
+            this.samplingPercentage = Double.valueOf(samplingPercentage);
+        }
+        catch (NumberFormatException ex) {
+            this.samplingPercentage = 100.0;
+            InternalLogger.INSTANCE.error("Sampling rate specified in improper format, sampling rate is now set to 100.0 (default)");
+        }
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -20,13 +20,22 @@ import java.util.Set;
  * <p>
  * How to use in ApplicationInsights Configuration :
  * <p>
- * <BuiltInProcessors>
- * <Processor type = "FixedRateSamplingTelemetryProcessor">
- * <Add name = "SamplingPercentage" value = "50" />
- * <Add name = "ExcludedTypes" value="Trace" />
- * <Add name = "IncludedTypes" value="Trace;Request" />
- * </Processor>
- * </BuiltInProcessors>
+* <TelemetryProcessors>
+    <BuiltInProcessors>
+        <Processor type = "FixedRateSamplingTelemetryProcessor">
+            <Add name = "SamplingPercentage" value = "50" />
+            <ExcludedTypes>
+                <excludedType>Request</excludedType>
+            </ExcludedTypes>
+            <IncludedTypes>
+                <includedType>Request</includedType>
+                <includedType>Trace</includedType>
+                <includedType>Dependency</includedType>
+                <includedType>Exception</includedType>
+            </IncludedTypes>
+        </Processor>
+    </BuiltInProcessors>
+</TelemetryProcessors>
  */
 @BuiltInProcessor("FixedRateSamplingTelemetryProcessor")
 public final class FixedRateSamplingTelemetryProcessor implements TelemetryProcessor {
@@ -38,7 +47,6 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
     private static final String requestTelemetryName = "Request";
     private static final String traceTelemetryName = "Trace";
 
-    private static final String listSeparator = ";";
     private static Map<String, Class> allowedTypes;
 
     private Set<Class> excludedTypes;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -126,6 +126,7 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
     public void setSamplingPercentage(String samplingPercentage) {
         try {
             this.samplingPercentage = Double.valueOf(samplingPercentage);
+            InternalLogger.INSTANCE.info("Sampling rate set to " + samplingPercentage);
         }
         catch (NumberFormatException ex) {
             this.samplingPercentage = 100.0;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -1,0 +1,175 @@
+package com.microsoft.applicationinsights.internal.channel.samplingV2;
+
+import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
+import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
+import com.microsoft.applicationinsights.internal.annotation.BuiltInProcessor;
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import com.microsoft.applicationinsights.telemetry.SupportSampling;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by Dhaval Doshi Oct 2017
+ * This processor is used to Perform Sampling on User specified sampling rate
+ */
+@BuiltInProcessor("FixedRateSamplingTelemetryProcessor")
+public final class FixedRateSamplingTelemetryProcessor implements TelemetryProcessor {
+
+    private final String dependencyTelemetryName = "Dependency";
+    private static final String eventTelemetryName = "Event";
+    private static final String exceptionTelemetryName = "Exception";
+    private static final String pageViewTelemetryName = "PageView";
+    private static final String requestTelemetryName = "Request";
+    private static final String traceTelemetryName = "Trace";
+
+    private static final String listSeparator = ";";
+    private static Map<String, Class> allowedTypes;
+
+    private String excludedTypesString;
+    private Set<Class> excludedTypesHashSet;
+
+    private String includedTypesString;
+    private Set<Class> includedTypesHashSet;
+
+    public double samplingPercentage;
+
+    /**
+     * constructor is responsible of initializing this processor
+     * to default settings
+     */
+    public FixedRateSamplingTelemetryProcessor() {
+        this.samplingPercentage = 100.00;
+        this.samplingPercentage = samplingPercentage;
+        this.includedTypesHashSet = new HashSet<Class>();
+        this.excludedTypesHashSet = new HashSet<Class>();
+        try {
+            this.allowedTypes = new HashMap<String, Class>() {{
+                put(dependencyTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry"));
+                put(eventTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.EventTelemetry"));
+                put(exceptionTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry"));
+                put(pageViewTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.PageViewTelemetry"));
+                put(requestTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.RequestTelemetry"));
+                put(traceTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.TraceTelemetry"));
+            }};
+        }
+        catch (ClassNotFoundException e) {
+            InternalLogger.INSTANCE.trace("Unable to locate telemetry classes");
+        }
+    }
+
+    public String getExcludedTypesString() {
+        return excludedTypesString;
+    }
+
+    public String getIncludedTypesString() {
+        return includedTypesString;
+    }
+
+    /**
+     * This method takes a string of user specified excluded
+     * types and parses it to into set containing respective references
+     * @param value
+     */
+    public void setExcludedTypes(String value) {
+        this.excludedTypesString = value;
+        Set<Class> newExcludedTypesHashSet = new HashSet<Class>();
+        setIncludedOrExcludedTypes(value, newExcludedTypesHashSet);
+        excludedTypesHashSet = newExcludedTypesHashSet;
+    }
+
+    /**
+     * This method takes a string of user specified included
+     * types and parses it to into set containing respective references
+     * @param value
+     */
+    public void setIncludedTypes(String value) {
+        this.includedTypesString = value;
+        Set<Class> newIncludedTypesHashSet = new HashSet<Class>();
+        setIncludedOrExcludedTypes(value, newIncludedTypesHashSet);
+        includedTypesHashSet = newIncludedTypesHashSet;
+    }
+
+    private void setIncludedOrExcludedTypes(String value, Set<Class> typeSet) {
+        if (!StringUtils.isNullOrEmpty(value)) {
+            String[] splitList = value.split(listSeparator);
+            for (String item : splitList) {
+                item.trim();
+                if (!StringUtils.isNullOrEmpty(item) && allowedTypes.containsKey(item)) {
+                    typeSet.add(allowedTypes.get(item));
+                }
+            }
+        }
+    }
+
+    public double getSamplingPercentage() {
+        return samplingPercentage;
+    }
+
+    /**
+     * Sets the user defined sampling percentage
+     * @param samplingPercentage
+     */
+    public void setSamplingPercentage(String samplingPercentage) {
+        this.samplingPercentage = Double.valueOf(samplingPercentage);
+    }
+
+    /**
+     * This method determines if the telemetry needs to be sampled or not.
+     * @param telemetry
+     * @return
+     */
+    @Override
+    public boolean process(Telemetry telemetry) {
+
+        double samplingPercentage  = this.samplingPercentage;
+
+        if (!(telemetry instanceof SupportSampling)) {
+            return true;
+        }
+
+        if (!isSamplingApplicable(telemetry.getClass())) {
+            InternalLogger.INSTANCE.trace("Skip sampling since %s type is not sampling applicable", telemetry.getClass());
+            return true;
+        }
+
+        SupportSampling samplingSupportingTelemetry = ((SupportSampling)telemetry);
+        if (samplingSupportingTelemetry.getSamplingPercentage() != null) {
+            return true;
+        }
+
+        samplingSupportingTelemetry.setSamplingPercentage(samplingPercentage);
+
+
+        if (SamplingScoreGeneratorV2.getSamplingScore(telemetry) < samplingPercentage) {
+            return true;
+        }
+
+        else {
+            InternalLogger.INSTANCE.info("Item %s sampled out", telemetry.getClass());
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if the argument is applicable for sampling
+     * @param item : Denotes the class item to be determined applicable for sampling
+     * @return boolean
+     */
+    private boolean isSamplingApplicable(Class item) {
+
+        if (excludedTypesHashSet.size() > 0 && excludedTypesHashSet.contains(item)) {
+            return false;
+        }
+
+        if (includedTypesHashSet.size() > 0 && !includedTypesHashSet.contains(item)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
@@ -1,0 +1,61 @@
+package com.microsoft.applicationinsights.internal.channel.samplingV2;
+
+import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
+
+import java.util.Random;
+
+/**
+ * Created by Dhaval Doshi Oct 2017
+ * This class generates the sample using the random number generator.
+ * It also contains the logic to preserve the correlated telemetry items.
+ */
+public class SamplingScoreGeneratorV2 {
+
+    private static Random random = new Random();
+
+    /**
+     * This method takes the telemetry and returns the hash of the operation id if it is present already
+     * or uses the random number generator to generate the sampling score.
+     * @param telemetry
+     * @return
+     */
+    public static double getSamplingScore(Telemetry telemetry) {
+
+        double samplingScore = 0.0;
+
+        if (!StringUtils.isNullOrEmpty(telemetry.getContext().getUser().getId())) {
+            samplingScore = (double) (getSamplingHashCode(telemetry.getContext().getUser().getId()) / Integer.MAX_VALUE);
+        }
+
+        else if (!StringUtils.isNullOrEmpty(telemetry.getContext().getOperation().getId())) {
+            samplingScore = (double) (getSamplingHashCode(telemetry.getContext().getOperation().getId()) / Integer.MAX_VALUE);
+        }
+
+        else {
+            long val = Math.abs(random.nextLong());
+            samplingScore =  ((double)Math.abs(val)/ Long.MAX_VALUE);
+        }
+
+        return samplingScore * 100;
+    }
+
+    private static int getSamplingHashCode(String input) {
+        if (StringUtils.isNullOrEmpty(input)) {
+            return 0;
+        }
+
+        StringBuilder inputBuilder = new StringBuilder(input);
+        while (inputBuilder.length() < 8) {
+            inputBuilder.append(input);
+        }
+
+        int hash = 5381;
+
+        for (int i = 0; i < inputBuilder.length(); ++i) {
+            hash = ((hash << 5) + hash) + (int) inputBuilder.charAt(i);
+        }
+
+        return hash == Integer.MIN_VALUE ? Integer.MAX_VALUE : Math.abs(hash);
+    }
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
@@ -24,12 +24,8 @@ public class SamplingScoreGeneratorV2 {
 
         double samplingScore = 0.0;
 
-        if (!StringUtils.isNullOrEmpty(telemetry.getContext().getUser().getId())) {
-            samplingScore = (double) (getSamplingHashCode(telemetry.getContext().getUser().getId()) / Integer.MAX_VALUE);
-        }
-
-        else if (!StringUtils.isNullOrEmpty(telemetry.getContext().getOperation().getId())) {
-            samplingScore = (double) (getSamplingHashCode(telemetry.getContext().getOperation().getId()) / Integer.MAX_VALUE);
+        if (!StringUtils.isNullOrEmpty(telemetry.getContext().getOperation().getId())) {
+            samplingScore =  ((double) getSamplingHashCode(telemetry.getContext().getOperation().getId()) / Integer.MAX_VALUE);
         }
 
         else {
@@ -40,7 +36,7 @@ public class SamplingScoreGeneratorV2 {
         return samplingScore * 100;
     }
 
-    private static int getSamplingHashCode(String input) {
+     static int getSamplingHashCode(String input) {
         if (StringUtils.isNullOrEmpty(input)) {
             return 0;
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
@@ -1,0 +1,21 @@
+package com.microsoft.applicationinsights.internal.config;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+//This is the class for binding the xml array list of <ExcludedTypes>
+
+@XmlRootElement(name = "ExcludedTypes")
+public class ParamExcludedTypeXmlElement {
+
+    public List<String> getExcludedType() {
+        return excludedType;
+    }
+
+    public void setExcludedType(List<String> excludedType) {
+        this.excludedType = excludedType;
+    }
+
+    private List<String> excludedType;
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
@@ -1,5 +1,6 @@
 package com.microsoft.applicationinsights.internal.config;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class ParamExcludedTypeXmlElement {
         return excludedType;
     }
 
+    @XmlElement(name = "ExcludedType")
     public void setExcludedType(List<String> excludedType) {
         this.excludedType = excludedType;
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
@@ -3,7 +3,9 @@ package com.microsoft.applicationinsights.internal.config;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
-//This is the class for binding the xml array list of <ExcludedTypes>
+/**
+ * This is the class for binding the xml array list of <ExcludedTypes>
+ */
 
 @XmlRootElement(name = "ExcludedTypes")
 public class ParamExcludedTypeXmlElement {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
@@ -1,5 +1,6 @@
 package com.microsoft.applicationinsights.internal.config;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class ParamIncludedTypeXmlElement {
         return includedType;
     }
 
+    @XmlElement(name = "IncludedType")
     public void setIncludedType(List<String> includedType) {
         this.includedType = includedType;
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
@@ -1,0 +1,21 @@
+package com.microsoft.applicationinsights.internal.config;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+//This class is used to bind the xml array list of <IncludeTypes>
+
+@XmlRootElement(name = "IncludedTypes")
+public class ParamIncludedTypeXmlElement {
+
+    public List<String> getIncludedType() {
+        return includedType;
+    }
+
+    public void setIncludedType(List<String> includedType) {
+        this.includedType = includedType;
+    }
+
+    private List<String> includedType;
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
@@ -3,7 +3,9 @@ package com.microsoft.applicationinsights.internal.config;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
-//This class is used to bind the xml array list of <IncludeTypes>
+/**
+ * This class is used to bind the xml array list of <IncludeTypes>
+ */
 
 @XmlRootElement(name = "IncludedTypes")
 public class ParamIncludedTypeXmlElement {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreator.java
@@ -23,10 +23,12 @@ package com.microsoft.applicationinsights.internal.config;
 
 import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import org.omg.CORBA.INTERNAL;
 
 /**
  * The class will try to create the {@link TelemetryProcessor}
- * and will activate any 'setXXX' method based on the configuration
+ * and will activate any 'setXXX' method based on the configuration. It will also populate the included
+ * and excluded types if present.
  *
  * Any exception thrown, or any setter method returns false will cause the processor to be ignored.
  *
@@ -46,7 +48,48 @@ public final class TelemetryProcessorCreator {
             return null;
         }
 
+
+        // If the <ExcludedTypes> tag is not empty
+
         try {
+            if (confClass.getExcludedTypes() != null) {
+                for (String paramExcluded : confClass.getExcludedTypes().getExcludedType()) {
+                    try {
+                        if (!ReflectionUtils.activateMethod(processor, "addToExcludedType" , paramExcluded, String.class)) {
+                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToExcludedType" + "failed, the class will not be used.");
+                            return null;
+                        }
+                    }
+                    catch (Throwable t) {
+                        InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
+                        return null;
+                    }
+                }
+            }
+            else {
+                InternalLogger.INSTANCE.error("Empty list of Excluded Types");
+            }
+
+            //If the <IncludedTypes> tag is not empty
+
+            if (confClass.getIncludedTypes() != null) {
+                for (String paramIncluded : confClass.getIncludedTypes().getIncludedType()) {
+                    try {
+                        if (!ReflectionUtils.activateMethod(processor, "addToIncludedType" , paramIncluded, String.class)) {
+                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToIncludeType" + "failed, the class will not be used.");
+                            return null;
+                        }
+                    }
+                    catch (Throwable t) {
+                        InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
+                        return null;
+                    }
+                }
+            }
+            else {
+                InternalLogger.INSTANCE.error("Empty list of Included Types");
+            }
+
             for (ParamXmlElement param : confClass.getAdds()){
                 String methodName = "set" + param.getName();
                 try {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreator.java
@@ -23,7 +23,6 @@ package com.microsoft.applicationinsights.internal.config;
 
 import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
-import org.omg.CORBA.INTERNAL;
 
 /**
  * The class will try to create the {@link TelemetryProcessor}
@@ -53,41 +52,55 @@ public final class TelemetryProcessorCreator {
 
         try {
             if (confClass.getExcludedTypes() != null) {
-                for (String paramExcluded : confClass.getExcludedTypes().getExcludedType()) {
-                    try {
-                        if (!ReflectionUtils.activateMethod(processor, "addToExcludedType" , paramExcluded, String.class)) {
-                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToExcludedType" + "failed, the class will not be used.");
+                if (confClass.getExcludedTypes().getExcludedType() != null) {
+                    for (String paramExcluded : confClass.getExcludedTypes().getExcludedType()) {
+                        try {
+                            if (!ReflectionUtils.activateMethod(processor, "addToExcludedType" , paramExcluded, String.class)) {
+                                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToExcludedType" + "failed, the class will not be used.");
+                                return null;
+                            }
+                        }
+                        catch (Throwable t) {
+                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
                             return null;
                         }
                     }
-                    catch (Throwable t) {
-                        InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
-                        return null;
-                    }
                 }
+                else {
+                    InternalLogger.INSTANCE.error("Empty list of Excluded Types");
+                }
+
             }
             else {
-                InternalLogger.INSTANCE.error("Empty list of Excluded Types");
+                InternalLogger.INSTANCE.info("Excluded types not specified falling back to default");
             }
 
             //If the <IncludedTypes> tag is not empty
 
+
             if (confClass.getIncludedTypes() != null) {
-                for (String paramIncluded : confClass.getIncludedTypes().getIncludedType()) {
-                    try {
-                        if (!ReflectionUtils.activateMethod(processor, "addToIncludedType" , paramIncluded, String.class)) {
-                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToIncludeType" + "failed, the class will not be used.");
+
+                if (confClass.getIncludedTypes().getIncludedType() != null) {
+                    for (String paramIncluded : confClass.getIncludedTypes().getIncludedType()) {
+                        try {
+                            if (!ReflectionUtils.activateMethod(processor, "addToIncludedType" , paramIncluded, String.class)) {
+                                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToIncludeType" + "failed, the class will not be used.");
+                                return null;
+                            }
+                        }
+                        catch (Throwable t) {
+                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
                             return null;
                         }
                     }
-                    catch (Throwable t) {
-                        InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
-                        return null;
-                    }
                 }
+                else {
+                    InternalLogger.INSTANCE.error("Empty list of Included Types");
+                }
+
             }
             else {
-                InternalLogger.INSTANCE.error("Empty list of Included Types");
+                InternalLogger.INSTANCE.info("Included types not specified falling back to default");
             }
 
             for (ParamXmlElement param : confClass.getAdds()){

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorXmlElement.java
@@ -33,6 +33,27 @@ import java.util.ArrayList;
 public class TelemetryProcessorXmlElement {
     private String type;
     private ArrayList<ParamXmlElement> adds = new ArrayList<ParamXmlElement>();
+    private ParamExcludedTypeXmlElement excludedTypes;
+    private ParamIncludedTypeXmlElement includedTypes;
+
+    public ParamExcludedTypeXmlElement getExcludedTypes() {
+        return excludedTypes;
+    }
+
+    @XmlElement(name = "ExcludedTypes")
+    public void setExcludedTypes(ParamExcludedTypeXmlElement excludedTypes) {
+        this.excludedTypes = excludedTypes;
+    }
+
+
+    public ParamIncludedTypeXmlElement getIncludedTypes() {
+        return includedTypes;
+    }
+
+    @XmlElement(name = "IncludedTypes")
+    public void setIncludedTypes(ParamIncludedTypeXmlElement includedTypes) {
+        this.includedTypes = includedTypes;
+    }
 
     public ArrayList<ParamXmlElement> getAdds() {
         return adds;
@@ -51,4 +72,6 @@ public class TelemetryProcessorXmlElement {
     public void setType(String type){
         this.type = type;
     }
+
+
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/TestFramework/StubTelemetryChannel.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/TestFramework/StubTelemetryChannel.java
@@ -1,0 +1,40 @@
+package com.microsoft.applicationinsights.TestFramework;
+
+import com.microsoft.applicationinsights.channel.TelemetryChannel;
+import com.microsoft.applicationinsights.channel.TelemetrySampler;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
+
+import java.util.concurrent.TimeUnit;
+
+public class StubTelemetryChannel implements TelemetryChannel {
+
+    @Override
+    public boolean isDeveloperMode() {
+        return false;
+    }
+
+    @Override
+    public void setDeveloperMode(boolean value) {
+
+    }
+
+    @Override
+    public void send(Telemetry item) {
+
+    }
+
+    @Override
+    public void stop(long timeout, TimeUnit timeUnit) {
+
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void setSampler(TelemetrySampler telemetrySampler) {
+
+    }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
@@ -468,7 +468,7 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryCollectionList, itemsToSend, null, null, 10.0);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, null, null, 50.0);
     }
 
     private List<Telemetry> getListOfTelemetry(String type, int count) {

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
@@ -203,10 +203,11 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        List<String> excludeTypes = new ArrayList<String>() {{add("Request");}};
         telemetryListCollection.add(dependencyTelemetry);
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Request", 10.0);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -215,14 +216,15 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        List<String> includeTypes = new ArrayList<String>() {{add("Request");}};
         telemetryListCollection.add(dependencyTelemetry);
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryListCollection, itemsToSend, "Request", null, 100.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 100.0);
         itemsToSend.clear();
         telemetryListCollection.clear();
         telemetryListCollection.add(dependencyTelemetry1);
-        testSampling(client, telemetryListCollection, itemsToSend, "Request", null, 10.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -231,9 +233,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> excludeTypes = new ArrayList<String>() {{add("Dependency");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Dependency", 10.0);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -243,13 +246,14 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> includeTypes = new ArrayList<String>() {{add("Dependency");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryListCollection, itemsToSend, "Dependency", null, 100.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 100.0);
         itemsToSend.clear();
         telemetryListCollection.clear();
         telemetryListCollection.add(dependencyTelemetry1);
-        testSampling(client, telemetryListCollection, itemsToSend, "Dependency", null, 10.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -258,9 +262,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> excludeTypes = new ArrayList<String>() {{add("Event");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Event", 10.0);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -270,13 +275,14 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> includeTypes = new ArrayList<String>() {{add("Event");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryListCollection, itemsToSend, "Event", null, 100.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 100.0);
         itemsToSend.clear();
         telemetryListCollection.clear();
         telemetryListCollection.add(dependencyTelemetry1);
-        testSampling(client, telemetryListCollection, itemsToSend, "Event", null, 10.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -284,10 +290,11 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry",100);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        List<String> excludeTypes = new ArrayList<String>() {{add("Exception");}};
         telemetryListCollection.add(dependencyTelemetry);
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Exception", 10.0);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -297,13 +304,14 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> includeTypes = new ArrayList<String>() {{add("Exception");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryListCollection, itemsToSend, "Exception", null, 100.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 100.0);
         itemsToSend.clear();
         telemetryListCollection.clear();
         telemetryListCollection.add(dependencyTelemetry1);
-        testSampling(client, telemetryListCollection, itemsToSend, "Exception", null, 10.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -312,9 +320,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> excludeTypes = new ArrayList<String>() {{add("PageView");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryListCollection, itemsToSend, null, "PageView", 10.0);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -324,13 +333,14 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> includeTypes = new ArrayList<String>() {{add("PageView");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryListCollection, itemsToSend, "PageView", null, 100.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 100.0);
         itemsToSend.clear();
         telemetryListCollection.clear();
         telemetryListCollection.add(dependencyTelemetry1);
-        testSampling(client, telemetryListCollection, itemsToSend, "PageView", null, 10.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -339,9 +349,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> excludeTypes = new ArrayList<String>() {{add("Trace");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Trace", 10.0);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -351,13 +362,14 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
         telemetryListCollection.add(dependencyTelemetry);
+        List<String> includeTypes = new ArrayList<String>() {{add("Trace");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryListCollection, itemsToSend, "Trace", null, 100.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 100.0);
         itemsToSend.clear();
         telemetryListCollection.clear();
         telemetryListCollection.add(dependencyTelemetry1);
-        testSampling(client, telemetryListCollection, itemsToSend, "Trace", null, 10.0);
+        testSampling(client, telemetryListCollection, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -368,9 +380,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         telemetryCollectionList.add(dependencyTelemetry);
         telemetryCollectionList.add(dependencyTelemetry1);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<String> excludeTypes = new ArrayList<String>() {{add("Trace"); add("Request");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryCollectionList, itemsToSend, null, "Trace;Request", 10.0);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -380,10 +393,11 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
         telemetryCollectionList.add(dependencyTelemetry);
         telemetryCollectionList.add(dependencyTelemetry1);
+        List<String> includeTypes = new ArrayList<String>() {{add("Trace"); add("Request");}};
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryCollectionList, itemsToSend, "Trace;Request", null, 10.0);
+        testSampling(client, telemetryCollectionList, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -394,9 +408,11 @@ public class FixedRateSamplingTelemetryProcessorTest {
         telemetryCollectionList.add(dependencyTelemetry);
         telemetryCollectionList.add(dependencyTelemetry1);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<String> includeTypes = new ArrayList<String>() {{add("Exception"); add("Request");}};
+        List<String> excludeTypes = new ArrayList<String>() {{add("PageView"); add("Request");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryCollectionList, itemsToSend, "Exception;Request", "PageView;Request", 10.0);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, includeTypes, excludeTypes, 10.0);
     }
 
     @Test
@@ -405,9 +421,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
         telemetryCollectionList.add(dependencyTelemetry);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<String> excludeTypes = new ArrayList<String>() {{add("aaa"); add("bbb");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryCollectionList, itemsToSend, null, "aaa;bbb", 10.0);
+        testSampling(client, telemetryCollectionList, itemsToSend, null, excludeTypes, 10.0);
     }
 
     @Test
@@ -416,31 +433,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
         telemetryCollectionList.add(dependencyTelemetry);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<String> includeTypes = new ArrayList<String>() {{add("aaa"); add("bbb");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryCollectionList, itemsToSend, "aaa;bbb", null, 10.0);
-    }
-
-    @Test
-    public void incorrectFormatDoesNotAffectCorrectExcludedType() {
-        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
-        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
-        telemetryCollectionList.add(dependencyTelemetry);
-        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
-        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
-        TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryCollectionList, itemsToSend, null, ";;;dfd;;;;s;re;;;PageView;;;;", 10.0);
-    }
-
-    @Test
-    public void incorrectFormatDoesNotAffectCorrectIncludeType() {
-        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
-        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
-        telemetryCollectionList.add(dependencyTelemetry);
-        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
-        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
-        TelemetryClient client = new TelemetryClient(configuration);
-        testNoSampling(client, telemetryCollectionList, itemsToSend, ";;;dfd;;;;s;re;;;Exception;;;;", null, 10.0);
+        testSampling(client, telemetryCollectionList, itemsToSend, includeTypes, null, 10.0);
     }
 
     @Test
@@ -449,9 +445,10 @@ public class FixedRateSamplingTelemetryProcessorTest {
         List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
         telemetryCollectionList.add(dependencyTelemetry);
         List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<String> includeTypes = new ArrayList<String>() {{add("Request");}};
         TelemetryConfiguration configuration = createConfiguration(itemsToSend);
         TelemetryClient client = new TelemetryClient(configuration);
-        testSampling(client, telemetryCollectionList, itemsToSend, "Request", null, 100.0);
+        testSampling(client, telemetryCollectionList, itemsToSend, includeTypes, null, 100.0);
     }
 
     @Test
@@ -509,18 +506,28 @@ public class FixedRateSamplingTelemetryProcessorTest {
     }
 
     private void testSampling(TelemetryClient client , List<List<Telemetry>> dependencyTelemetry,
-                              List<Telemetry> itemsToSend, String includeTypes, String excludeTypes, double samplingRate) {
+                              List<Telemetry> itemsToSend, List<String> includeTypes, List<String> excludeTypes, double samplingRate) {
 
 
         FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
         processor.setSamplingPercentage(String.valueOf(samplingRate));
-        if (!StringUtils.isNullOrEmpty(includeTypes)) {
-            processor.setIncludedTypes(includeTypes);
+        if (includeTypes != null) {
+            for (String includeType : includeTypes) {
+                if (!StringUtils.isNullOrEmpty(includeType)) {
+                    processor.addToIncludedType(includeType);
+                }
+            }
         }
 
-        if (!StringUtils.isNullOrEmpty(excludeTypes)) {
-            processor.setIncludedTypes(excludeTypes);
+        if (excludeTypes != null) {
+            for (String excludeType : excludeTypes) {
+                if (!StringUtils.isNullOrEmpty(excludeType)) {
+                    processor.addToExcludedType(excludeType);
+                }
+            }
         }
+
+
         int generatedCount = 0;
         for (int i = 0; i < dependencyTelemetry.get(0).size(); ++i) {
             for (int j = 0; j < dependencyTelemetry.size(); ++j) {
@@ -545,18 +552,27 @@ public class FixedRateSamplingTelemetryProcessorTest {
     }
 
     private void testNoSampling(TelemetryClient client , List<List<Telemetry>> dependencyTelemetry,
-                                List<Telemetry> itemsToSend, String includeTypes, String excludeTypes, double samplingRate) {
+                                List<Telemetry> itemsToSend, List<String> includeTypes, List<String> excludeTypes, double samplingRate) {
 
 
         FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
         processor.setSamplingPercentage(String.valueOf(samplingRate));
-        if (!StringUtils.isNullOrEmpty(includeTypes)) {
-            processor.setIncludedTypes(includeTypes);
+        if (includeTypes != null) {
+            for (String includeType : includeTypes) {
+                if (!StringUtils.isNullOrEmpty(includeType)) {
+                    processor.addToIncludedType(includeType);
+                }
+            }
         }
 
-        if (!StringUtils.isNullOrEmpty(excludeTypes)) {
-            processor.setExcludedTypes(excludeTypes);
+        if (excludeTypes != null) {
+            for (String excludeType : excludeTypes) {
+                if (!StringUtils.isNullOrEmpty(excludeType)) {
+                    processor.addToExcludedType(excludeType);
+                }
+            }
         }
+
         int generatedCount = 0;
         for (int i = 0; i < dependencyTelemetry.get(0).size(); ++i) {
             for (int j = 0; j < dependencyTelemetry.size(); ++j) {

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
@@ -1,0 +1,574 @@
+package com.microsoft.applicationinsights.internal.channel.samplingV2;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.TestFramework.StubTelemetryChannel;
+import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
+import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
+import com.microsoft.applicationinsights.telemetry.PageViewTelemetry;
+import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
+import com.microsoft.applicationinsights.telemetry.SupportSampling;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Dhaval Doshi 10/31/2017
+ * This class performs tests for FixedRateSamplingTelemetryProcessor
+ */
+
+public class FixedRateSamplingTelemetryProcessorTest {
+
+    @Test
+    public void defaultSamplingRateTest() {
+        FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
+        Assert.assertEquals(100.0, processor.getSamplingPercentage(), 12);
+    }
+
+    @Test
+    public void allTelemetrySentWithDefaultSampleRate() {
+        int sentCount = 0;
+        final int itemsToGenerate = 100;
+        TelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
+        for (int i = 0; i < itemsToGenerate; ++i) {
+            if (processor.process(new RequestTelemetry())) {
+                ++sentCount;
+            }
+        }
+        Assert.assertEquals(itemsToGenerate, sentCount, 0);
+    }
+
+    @Test
+    public void telemetryItemHasSamplingPercentageSet() {
+        List<Telemetry> telemetryList = new ArrayList<Telemetry>();
+        FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
+        processor.setSamplingPercentage("20.0");
+        telemetryList.add(new RequestTelemetry());
+        telemetryList.add(new PageViewTelemetry());
+        for (Telemetry t : telemetryList) {
+            processor.process(t);
+        }
+        Assert.assertEquals(20.0, ((SupportSampling)telemetryList.get(0)).getSamplingPercentage(), 0);
+    }
+
+    @Test
+    public void telemetryItemSamplingIsSkippedWhenSetByUser() {
+        FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
+        processor.setSamplingPercentage("0.0");
+        Telemetry requestTelemetry = new RequestTelemetry();
+        ((SupportSampling)requestTelemetry).setSamplingPercentage(100.0);
+        int sentCount = 0;
+        if (processor.process(requestTelemetry)) {
+            ++sentCount;
+        }
+        Assert.assertEquals(1, sentCount);
+    }
+
+    @Test
+    public void dependencyTelemetryIsSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+
+    }
+
+    @Test
+    public void eventTelemetryIsSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.EventTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.EventTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void exceptionTelemetryIsSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void pageViewTelemetryIsSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void requestTelemetryIsSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void traceTelemetryIsSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.TraceTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.TraceTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void metricTelemetryIsNotSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.MetricTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void performanceCounterTelemetryIsNotSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PerformanceCounterTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void sessionStateTelemetryIsNotSubjectToSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.SessionStateTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, null, 10.0);
+    }
+
+    @Test
+    public void requestCanBeExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Request", 10.0);
+    }
+
+    @Test
+    public void requestCanBeIncludedInSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, "Request", null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, "Request", null, 10.0);
+    }
+
+    @Test
+    public void dependencyCanBeExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Dependency", 10.0);
+    }
+
+    @Test
+    public void dependencyCanBeIncludedInSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, "Dependency", null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, "Dependency", null, 10.0);
+    }
+
+    @Test
+    public void eventCanBeExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.EventTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Event", 10.0);
+    }
+
+    @Test
+    public void eventCanBeIncludedInSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.EventTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.EventTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, "Event", null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, "Event", null, 10.0);
+    }
+
+    @Test
+    public void exceptionCanBeExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Exception", 10.0);
+    }
+
+    @Test
+    public void exceptionCanBeIncludedInSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, "Exception", null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, "Exception", null, 10.0);
+    }
+
+    @Test
+    public void pageViewCanBeExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, "PageView", 10.0);
+    }
+
+    @Test
+    public void pageViewCanBeIncludedInSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, "PageView", null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, "PageView", null, 10.0);
+    }
+
+    @Test
+    public void traceCanBeExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.TraceTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryListCollection, itemsToSend, null, "Trace", 10.0);
+    }
+
+    @Test
+    public void traceCanBeIncludedInSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.TraceTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.TraceTelemetry",100);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        List<List<Telemetry>> telemetryListCollection = new ArrayList<List<Telemetry>>();
+        telemetryListCollection.add(dependencyTelemetry);
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryListCollection, itemsToSend, "Trace", null, 100.0);
+        itemsToSend.clear();
+        telemetryListCollection.clear();
+        telemetryListCollection.add(dependencyTelemetry1);
+        testSampling(client, telemetryListCollection, itemsToSend, "Trace", null, 10.0);
+    }
+
+    @Test
+    public void multipleItemsCanBeExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.TraceTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        telemetryCollectionList.add(dependencyTelemetry1);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, null, "Trace;Request", 10.0);
+    }
+
+    @Test
+    public void multipleItemsCanBeIncludedInSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.TraceTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        telemetryCollectionList.add(dependencyTelemetry1);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryCollectionList, itemsToSend, "Trace;Request", null, 10.0);
+    }
+
+    @Test
+    public void includeDoNotOverrideExcludedFromSampling() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<Telemetry> dependencyTelemetry1 = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        telemetryCollectionList.add(dependencyTelemetry1);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, "Exception;Request", "PageView;Request", 10.0);
+    }
+
+    @Test
+    public void unknownExcludedTypesAreIgnored() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryCollectionList, itemsToSend, null, "aaa;bbb", 10.0);
+    }
+
+    @Test
+    public void unknownIncludedTypesAreIgnored() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryCollectionList, itemsToSend, "aaa;bbb", null, 10.0);
+    }
+
+    @Test
+    public void incorrectFormatDoesNotAffectCorrectExcludedType() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, null, ";;;dfd;;;;s;re;;;PageView;;;;", 10.0);
+    }
+
+    @Test
+    public void incorrectFormatDoesNotAffectCorrectIncludeType() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.PageViewTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, ";;;dfd;;;;s;re;;;Exception;;;;", null, 10.0);
+    }
+
+    @Test
+    public void noSamplingTracksSamplingRate() {
+        List<Telemetry> dependencyTelemetry = getListOfTelemetry("com.microsoft.applicationinsights.telemetry.RequestTelemetry",100);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testSampling(client, telemetryCollectionList, itemsToSend, "Request", null, 100.0);
+    }
+
+    @Test
+    public void testCorrelatedTelemetryDoesNotGetSampledOut() {
+        List<Telemetry> dependencyTelemetry = new ArrayList<Telemetry>();
+        Telemetry item = new RequestTelemetry();
+        item.getContext().getOperation().setId("abc");
+        Telemetry item2 = new RemoteDependencyTelemetry();
+        item2.getContext().getOperation().setId("abc");
+        dependencyTelemetry.add(item);
+        dependencyTelemetry.add(item2);
+        List<List<Telemetry>> telemetryCollectionList = new ArrayList<List<Telemetry>>();
+        telemetryCollectionList.add(dependencyTelemetry);
+        List<Telemetry> itemsToSend = new ArrayList<Telemetry>();
+        TelemetryConfiguration configuration = createConfiguration(itemsToSend);
+        TelemetryClient client = new TelemetryClient(configuration);
+        testNoSampling(client, telemetryCollectionList, itemsToSend, null, null, 10.0);
+    }
+
+    private List<Telemetry> getListOfTelemetry(String type, int count) {
+        List<Telemetry> telemetryList = new ArrayList<Telemetry>();
+        try {
+            for (int i = 0; i < count; ++i) {
+                if (type.contains("Exception")) {
+                    telemetryList.add((Telemetry) Class.forName(type).getConstructor(Throwable.class).newInstance(new Throwable()));
+                }
+                else {
+                    telemetryList.add((Telemetry) Class.forName(type).getConstructor().newInstance());
+                }
+
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        return telemetryList;
+
+    }
+
+    private TelemetryConfiguration createConfiguration(List<Telemetry> itemsToSend) {
+
+        TelemetryConfiguration configuration = new TelemetryConfiguration();
+        configuration.setInstrumentationKey("00000000-0000-0000-0000-000000000000");
+
+        class StubBufferTelemetryChannel extends StubTelemetryChannel {
+            @Override
+            public void send(Telemetry item) {
+               itemsToSend.add(item);
+               //item.reset();
+            }
+
+        }
+        configuration.setChannel(new StubBufferTelemetryChannel());
+        return configuration;
+    }
+
+    private void testSampling(TelemetryClient client , List<List<Telemetry>> dependencyTelemetry,
+                              List<Telemetry> itemsToSend, String includeTypes, String excludeTypes, double samplingRate) {
+
+
+        FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
+        processor.setSamplingPercentage(String.valueOf(samplingRate));
+        if (!StringUtils.isNullOrEmpty(includeTypes)) {
+            processor.setIncludedTypes(includeTypes);
+        }
+
+        if (!StringUtils.isNullOrEmpty(excludeTypes)) {
+            processor.setIncludedTypes(excludeTypes);
+        }
+        int generatedCount = 0;
+        for (int i = 0; i < dependencyTelemetry.get(0).size(); ++i) {
+            for (int j = 0; j < dependencyTelemetry.size(); ++j) {
+                ++generatedCount;
+                if (processor.process(dependencyTelemetry.get(j).get(i))) {
+                    client.track(dependencyTelemetry.get(j).get(i));
+                }
+            }
+        }
+
+        Assert.assertTrue(itemsToSend.get(0) instanceof SupportSampling);
+        Assert.assertTrue(itemsToSend.size() > 0);
+        Assert.assertEquals((Double)samplingRate, ((SupportSampling) itemsToSend.get(0)).getSamplingPercentage());
+
+        if (Double.compare(samplingRate, 100.0) == 0) {
+            Assert.assertTrue(itemsToSend.size() == generatedCount);
+        }
+
+        else {
+            Assert.assertTrue(itemsToSend.size() < generatedCount);
+        }
+    }
+
+    private void testNoSampling(TelemetryClient client , List<List<Telemetry>> dependencyTelemetry,
+                                List<Telemetry> itemsToSend, String includeTypes, String excludeTypes, double samplingRate) {
+
+
+        FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
+        processor.setSamplingPercentage(String.valueOf(samplingRate));
+        if (!StringUtils.isNullOrEmpty(includeTypes)) {
+            processor.setIncludedTypes(includeTypes);
+        }
+
+        if (!StringUtils.isNullOrEmpty(excludeTypes)) {
+            processor.setExcludedTypes(excludeTypes);
+        }
+        int generatedCount = 0;
+        for (int i = 0; i < dependencyTelemetry.get(0).size(); ++i) {
+            for (int j = 0; j < dependencyTelemetry.size(); ++j) {
+                ++generatedCount;
+                if (processor.process(dependencyTelemetry.get(j).get(i))) {
+                    //Mockito.doReturn(mockContext).when(dependencyTelemetry.get(i)).getContext();
+                    client.track(dependencyTelemetry.get(j).get(i));
+                }
+            }
+        }
+
+        Assert.assertTrue(itemsToSend.size() == generatedCount);
+
+    }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2Test.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2Test.java
@@ -1,0 +1,159 @@
+package com.microsoft.applicationinsights.internal.channel.samplingV2;
+
+import com.microsoft.applicationinsights.telemetry.EventTelemetry;
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+public class SamplingScoreGeneratorV2Test {
+
+    private static Random random = new Random();
+
+    @Test
+    public void samplingScoreGeneratedUsingOperationIdIfPresent() {
+
+        String operationId = generateRandomOperationId();
+
+        Telemetry eventTelemetry = new EventTelemetry();
+        eventTelemetry.getContext().getOperation().setId(operationId);
+
+        Telemetry requestTelemetry = new RequestTelemetry();
+        requestTelemetry.getContext().getOperation().setId(operationId);
+
+        double eventTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(eventTelemetry);
+        double requestTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(requestTelemetry);
+
+        Assert.assertEquals(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 0.0);
+    }
+
+    @Test
+    public void samplingScoreIsNotAffectedByPresenceOfUserId() {
+
+        String userId1 = generateRandomUserId();
+        String userId2 = generateRandomUserId();
+        String operationId = generateRandomOperationId();
+
+        Telemetry eventTelemetry = new EventTelemetry();
+        eventTelemetry.getContext().getUser().setId(userId1);
+        eventTelemetry.getContext().getOperation().setId(operationId);
+
+        Telemetry requestTelemetry = new RequestTelemetry();
+        requestTelemetry.getContext().getUser().setId(userId2);
+        requestTelemetry.getContext().getOperation().setId(operationId);
+
+        double eventTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(eventTelemetry);
+        double requestTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(requestTelemetry);
+
+        Assert.assertEquals(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 0.0);
+
+    }
+
+    @Test
+    public void samplingScoreIsRandomIfOperationIdIsNotPresent() {
+
+        Telemetry eventTelemetry = new EventTelemetry();
+        Telemetry requestTelemetry = new RequestTelemetry();
+        double eventTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(eventTelemetry);
+        double requestTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(requestTelemetry);
+        Assert.assertNotEquals(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 0.0);
+
+    }
+
+    @Test
+    public void samplingScoreIsRandomIfUserIdIsPresentWithoutOperationId() {
+
+        String userId = generateRandomUserId();
+        Telemetry eventTelemetry = new EventTelemetry();
+        eventTelemetry.getContext().getUser().setId(userId);
+
+        Telemetry requestTelemetry = new RequestTelemetry();
+        requestTelemetry.getContext().getUser().setId(userId);
+
+        double eventTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(eventTelemetry);
+        double requestTelemetrySamplingScore = SamplingScoreGeneratorV2.getSamplingScore(requestTelemetry);
+        Assert.assertNotEquals(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 0.0);
+    }
+
+    @Test
+    public void stringSamplingHashCodeProducesConsistentValues() {
+
+        // we have a predefined set of strings and their hash values
+        // the test allows us to make sure we can produce the same hashing
+        // results in different versions of sdk
+
+        Map<String, Integer> stringHashMap = new HashMap<String, Integer>() {{
+            put("ss", 1179811869);
+            put("kxi", 168993463);
+            put("wr", 1281077591);
+            put("ynehgfhyuiltaiqovbpyhpm", 2139623659);
+            put("iaxxtklcw", 1941943012);
+            put("hjwvqjiiwhoxrtsjma", 1824011880);
+            put("rpiauyg", 251412007);
+            put("jekvjvh", 9189387);
+            put("hq", 1807146729);
+            put("kgqxrftjhefkwlufcxibwjcy", 270215819);
+            put("lkfc", 1228617029);
+            put("skrnpybqqu", 223230949);
+            put("px", 70671963);
+            put("dtn", 2050473033);
+            put("nqfcxobaequ", 397313566);
+            put("togxlt", 948170633);
+            put("jvvdkhnahkaujxarkd", 1486894898);
+            put("mcloukvkamiaqja", 56804453);
+            put("ornuu", 1588005865);
+            put("otodvlhtvu", 1544494884);
+            put("uhpwhasnvmnykjkitla", 981289895);
+            put("itbnryqnjcgpmjemdghqtg", 1469591400);
+            put("wauetkdnivwlafbfhiedsfx", 2114415420);
+            put("fniwmeidbvd", 508699380);
+            put("vuwdgoxspstvj", 1821547235);
+            put("y", 1406544563);
+            put("pceqcixfb", 1282453766);
+            put("aentke", 255756533);
+            put("ni", 1696510239);
+            put("lbwehevltlnl", 1466602040);
+            put("ymxql", 1974582171);
+            put("mvqbaosfuip", 1560556398);
+            put("urmwofajwmmlornynglm", 701710403);
+            put("buptyvonyacerrt", 1315240646);
+            put("cxsqcnyieliatqnwc", 76148095);
+            put("svvco", 1849105799);
+            put("luwmjhwyt", 553630912);
+            put("lisvmmug", 822987687);
+            put("mmntilfbmxwuyij", 882214597);
+            put("hqmyv", 1510970959);
+        }};
+
+        for (String key : stringHashMap.keySet()) {
+            int calculatedHash = SamplingScoreGeneratorV2.getSamplingHashCode(key);
+            Assert.assertTrue(stringHashMap.get(key) == calculatedHash);
+        }
+
+    }
+
+    private static String generateRandomUserId() {
+        int max = 12;
+        int min = 3;
+        int userIdLength = getRandomInRange(min, max);
+        StringBuffer userId = new StringBuffer();
+        for (int i = 0; i < userIdLength; ++i) {
+            userId.append((char)('a' + getRandomInRange(0, 25)));
+        }
+        return userId.toString();
+
+    }
+
+    private static String generateRandomOperationId() {
+        return String.valueOf(random.nextLong());
+    }
+
+
+    private static int getRandomInRange(int min, int max) {
+        return random.nextInt((max - min) + 1) + min;
+    }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreatorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreatorTest.java
@@ -22,8 +22,12 @@
 package com.microsoft.applicationinsights.internal.config;
 
 import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by gupele on 8/7/2016.
@@ -115,6 +119,91 @@ public class TelemetryProcessorCreatorTest {
         param.setName("Property");
         param.setValue("value");
         element.getAdds().add(param);
+
+        TelemetryProcessor result = new TelemetryProcessorCreator().Create(element);
+
+        Assert.assertNull(result);
+    }
+
+    //This test tests correct initialization of included and excluded types in the processor
+    @Test
+    public void testProcessorWithIncludedExcludedTypes() {
+        TelemetryProcessorXmlElement element = new TelemetryProcessorXmlElement();
+        element.setType("com.microsoft.applicationinsights.internal.config.ValidProcessorWithIncludeExcludeType");
+        ParamIncludedTypeXmlElement paramIncludedTypeXmlElement = new ParamIncludedTypeXmlElement();
+        ParamExcludedTypeXmlElement paramExcludedTypeXmlElement = new ParamExcludedTypeXmlElement();
+        List<String> includedType = new ArrayList<String>() {{add("Trace"); add("Request");}};
+        List<String> excludedType = new ArrayList<String>() {{add("Exception");}};
+        paramIncludedTypeXmlElement.setIncludedType(includedType);
+        paramExcludedTypeXmlElement.setExcludedType(excludedType);
+        element.setIncludedTypes(paramIncludedTypeXmlElement);
+        element.setExcludedTypes(paramExcludedTypeXmlElement);
+
+        TelemetryProcessor result = new TelemetryProcessorCreator().Create(element);
+
+        Assert.assertTrue(result instanceof ValidProcessorWithIncludeExcludeType);
+
+    }
+
+    /*
+    This test is for situation when users config file looks like this :
+        <IncludedTypes>
+        </IncludedTypes>
+        i.e when there are no included types specified in the included types tag.
+     */
+    @Test
+    public void testProcessorWithNullIncludedType() {
+        TelemetryProcessorXmlElement element = new TelemetryProcessorXmlElement();
+        element.setType("com.microsoft.applicationinsights.internal.config.ValidProcessorWithIncludeExcludeType");
+        ParamIncludedTypeXmlElement paramIncludedTypeXmlElement = null;
+        element.setIncludedTypes(paramIncludedTypeXmlElement);
+
+        TelemetryProcessor result = new TelemetryProcessorCreator().Create(element);
+
+        Assert.assertTrue(result instanceof ValidProcessorWithIncludeExcludeType);
+    }
+
+
+    /*
+    This test is for situation when users config file looks like this :
+        <ExcludedTypes>
+        </ExcludedTypes>
+        i.e when there are no included types specified in the excluded types tag.
+     */
+    @Test
+    public void testProcessorWithNullExcludedTypes() {
+        TelemetryProcessorXmlElement element = new TelemetryProcessorXmlElement();
+        element.setType("com.microsoft.applicationinsights.internal.config.ValidProcessorWithIncludeExcludeType");
+        ParamExcludedTypeXmlElement paramExcludedTypeXmlElement = null;
+        element.setExcludedTypes(paramExcludedTypeXmlElement);
+        TelemetryProcessor result = new TelemetryProcessorCreator().Create(element);
+        Assert.assertTrue(result instanceof ValidProcessorWithIncludeExcludeType);
+    }
+
+    @Test
+    public void testProcessorThatThrowsOnIncludedTypes() {
+
+        TelemetryProcessorXmlElement element = new TelemetryProcessorXmlElement();
+        element.setType("com.microsoft.applicationinsights.internal.config.TestProcessorThatThrowsOnIncludedAndExcludedTypes");
+        ParamIncludedTypeXmlElement paramIncludedTypeXmlElement = new ParamIncludedTypeXmlElement();
+        List<String> includedType = new ArrayList<String>() {{add("Trace"); add("Request");}};
+        paramIncludedTypeXmlElement.setIncludedType(includedType);
+        element.setIncludedTypes(paramIncludedTypeXmlElement);
+
+        TelemetryProcessor result = new TelemetryProcessorCreator().Create(element);
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void testProcessorThatThrowsOnExcludedTypes() {
+
+        TelemetryProcessorXmlElement element = new TelemetryProcessorXmlElement();
+        element.setType("com.microsoft.applicationinsights.internal.config.TestProcessorThatThrowsOnIncludedAndExcludedTypes");
+        ParamExcludedTypeXmlElement paramExcludedTypeXmlElement = new ParamExcludedTypeXmlElement();
+        List<String> excludedType = new ArrayList<String>() {{add("Trace"); add("Request");}};
+        paramExcludedTypeXmlElement.setExcludedType(excludedType);
+        element.setExcludedTypes(paramExcludedTypeXmlElement);
 
         TelemetryProcessor result = new TelemetryProcessorCreator().Create(element);
 

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/TestProcessorThatThrowsOnIncludedAndExcludedTypes.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/TestProcessorThatThrowsOnIncludedAndExcludedTypes.java
@@ -1,0 +1,20 @@
+package com.microsoft.applicationinsights.internal.config;
+
+import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
+
+public class TestProcessorThatThrowsOnIncludedAndExcludedTypes implements TelemetryProcessor {
+
+    public void addToIncludedType(String item) throws Throwable{
+        throw new Throwable();
+    }
+
+    public void addToExcludedType(String item) throws Throwable{
+        throw new Throwable();
+    }
+
+    @Override
+    public boolean process(Telemetry telemetry) {
+        return false;
+    }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/ValidProcessorWithIncludeExcludeType.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/ValidProcessorWithIncludeExcludeType.java
@@ -1,0 +1,21 @@
+package com.microsoft.applicationinsights.internal.config;
+
+import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
+import com.microsoft.applicationinsights.telemetry.Telemetry;
+
+public class ValidProcessorWithIncludeExcludeType implements TelemetryProcessor {
+
+
+    public void addToIncludedType(String item) {
+
+    }
+
+    public void addToExcludedType(String item) {
+
+    }
+
+    @Override
+    public boolean process(Telemetry telemetry) {
+        return false;
+    }
+}


### PR DESCRIPTION
Introducing Fixed Rate Sampling v2 using TelemetryProcessors architecture. This is in addition to current FixedRateSampler and with then next major version this will be the standard. 

Eg. of creating FixedRateTelemetryProcessor:

In the ApplicationInsights.xml file add the following:

```
<TelemetryProcessors>
        <BuiltInProcessors>
            <Processor type = "FixedRateSamplingTelemetryProcessor">
                <Add name = "SamplingPercentage" value = "50" />
                <ExcludedTypes>
                    <ExcludedType>Request</ExcludedType>
                </ExcludedTypes>
                <IncludedTypes>
                    <IncludedType>Request</IncludedType>
                    <IncludedType>Trace</IncludedType>
                    <IncludedType>Dependency</IncludedType>
                    <IncludedType>Exception</IncludedType>
                </IncludedTypes>
            </Processor>
        </BuiltInProcessors>
    </TelemetryProcessors>

```
The sampling percentage should be between 0 - 100.  If something is specified in IncludeType that means only the particular category of telemetry would be eligible for Sampling. If something is specified in ExcludeType the particular type of telemetry item would not be subject to sampling. Exclude type takes priority over include type.

All correlated telemetry items will be sampled in. With this we plan to sample only using Operation Id. User Id based sampling would be stopped.

Some telemetry type is by default not subject to sampling: PerformanceCounterTelemetry, MetricTelemetry, SessionStateTelemetry.

_This is the part of upcoming changes in all Sampling Architecture in java._