### PR TITLE
Upgrading (source|target)Compatibility version to 1.7, i.e. ending support for Java 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Introducing Telemetry Processor 'com.microsoft.applicationinsights.internal.channel.samplingV2.FixedRateSamplingTelemetryProcessor'
 - Introducing FixedRate Sampling v2 Using Telemetry Processors
 - Fixed issue #436 (TraceTelemetry with Severity is not shown in UI). This fixes a regression issue with `TelemetryClient.trackTrace` and `TelemetryClient.trackException`.
+- Compilation now targets Java 1.7. Java 1.6 is no longer supported.
 
 ## Version 1.0.10
 - `track()` method of 'com.microsoft.applicationinsights.TelemetryClient' is now modified. No longer performing pre-sanitization

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -27,25 +27,27 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat;
 
 apply plugin: 'java'
 
-def java6JreDir = System.env.'JAVA_JRE_6'
-if (java6JreDir) {
-    def requiredJava6Archives = ["rt.jar", "jsse.jar"]
+def java7JreDir = System.env.'JAVA_JRE_7'
+if (java7JreDir) {
+    def requiredJavaBootArchives = ["rt.jar", "jsse.jar"]
     def bootClasspath = ""
-    requiredJava6Archives.each { a ->
-        def archivePath = new File(java6JreDir, "lib/$a")
+    requiredJavaBootArchives.each { a ->
+        def archivePath = new File(java7JreDir, "lib/$a")
         if (!archivePath.exists()) {
-            throw new ProjectConfigurationException("Archive $archivePath required for building in Java 6 could not be found.", null)
+            throw new ProjectConfigurationException("Archive $archivePath required for building in Java 7 could not be found.", null)
         }
         logger.info "Archive '$archivePath' added to boot class path"
         bootClasspath += "$archivePath;"
     }
     tasks.withType(JavaCompile) {
-        sourceCompatibility = 1.6
-        targetCompatibility = 1.6
+        sourceCompatibility = 1.7
+        targetCompatibility = 1.7
         options.bootClasspath = bootClasspath
     }
 } else {
-    logger.warn "Environment variable 'JAVA_JRE_6' is not defined - falling back to use machine default Java SDK"
+    // FIXME this warning only makes sense if the JDK version being used is > 1.7.
+    // FIXME if this warning makes sense, it should be fatal if this is intended for release
+    logger.warn "IMPORTANT: Environment variable 'JAVA_JRE_7' is not defined - Install JRE 7 and set 'JAVA_JRE_7' to prevent runtime compatibility issues!"
 }
 
 if (hasProperty("JDKToUse")) {
@@ -63,6 +65,7 @@ if (hasProperty("JDKToUse")) {
     tasks.withType(AbstractCompile) {
         options.with {
             fork = true
+            // FIXME forkOptions.executable is deprecated
             forkOptions.executable = javaExecutables.javac
         }
     }


### PR DESCRIPTION
This changes the source compatibility version to 1.7 and Java 1.6 is no longer supported.

Previously, the `JAVA_JRE_6` variable held the home of the Java 6 jars for setting the boot classpath. The build script now checks the `JAVA_JRE_7` for the same reason.

- [x] Design discussion issue #468
- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated
