### PR TITLE
Upgrade dependencies

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -20,7 +20,7 @@
  */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.github.johnrengelman.shadow' version '2.0.1'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"
@@ -47,8 +47,8 @@ jar {
 dependencies {
     compile group: 'org.ow2.asm', name: 'asm-commons', version: '5.2'
     compile group: 'org.ow2.asm', name: 'asm-all', version: '5.2'
-    testCompile group: 'commons-io', name: 'commons-io', version: '2.4'
-    testCompile group: 'junit', name: 'junit', version: '4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.8.0'
+    testCompile group: 'commons-io', name: 'commons-io', version: '2.6'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
 }
 

--- a/collectd/build.gradle
+++ b/collectd/build.gradle
@@ -20,7 +20,7 @@
  */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.github.johnrengelman.shadow' version '2.0.1'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"
@@ -61,8 +61,8 @@ sourceSets {
 dependencies {
     compile project(':core')
     provided files(collectDLibPath)
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.8.0'
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
 // Building the shadow (fat) jar after compiling sources.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.github.johnrengelman.shadow' version '2.0.1'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"
@@ -36,14 +36,14 @@ archivesBaseName = 'applicationinsights-core'
 
 dependencies {
     provided (project(':agent')) { transitive = false }
-    compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.4'])
-    compile ([group: 'commons-io', name: 'commons-io', version: '2.4' ])
-    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1']) 
+    compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.5'])
+    compile ([group: 'commons-io', name: 'commons-io', version: '2.6' ])
+    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
     compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
-    compile ([group: 'com.google.guava', name: 'guava', version: '12.0.1'])
-    testCompile group: 'junit', name: 'junit', version: '4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.8.0'
-    testCompile group: 'com.google.code.gson', name: 'gson', version: '1.7.2'
+    compile ([group: 'com.google.guava', name: 'guava', version: '23.0'])
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
 }
 
 shadowJar {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     compile ([group: 'commons-io', name: 'commons-io', version: '2.6' ])
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
     compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
-    compile ([group: 'com.google.guava', name: 'guava', version: '23.0'])
+    compile ([group: 'com.google.guava', name: 'guava', version: '20.0'])
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'

--- a/core/native.gradle
+++ b/core/native.gradle
@@ -26,7 +26,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'commons-io', name: 'commons-io', version: '2.4'
+        classpath group: 'commons-io', name: 'commons-io', version: '2.6'
     }
 }
 

--- a/distributions/build.gradle
+++ b/distributions/build.gradle
@@ -20,7 +20,7 @@
  */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.github.johnrengelman.shadow' version '2.0.1'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -32,7 +32,7 @@ if (java7JreDir) {
     def requiredJavaBootArchives = ["rt.jar", "jsse.jar"]
     def bootClasspath = ""
     requiredJavaBootArchives.each { a ->
-        def archivePath = new File(java7JreDir, "lib/$a")
+        def archivePath = new File(java7JreDir, "jre/lib/$a")
         if (!archivePath.exists()) {
             throw new ProjectConfigurationException("Archive $archivePath required for building in Java 7 could not be found.", null)
         }

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -32,7 +32,7 @@ if (java7JreDir) {
     def requiredJavaBootArchives = ["rt.jar", "jsse.jar"]
     def bootClasspath = ""
     requiredJavaBootArchives.each { a ->
-        def archivePath = new File(java7JreDir, "jre/lib/$a")
+        def archivePath = new File(java7JreDir, "lib/$a")
         if (!archivePath.exists()) {
             throw new ProjectConfigurationException("Archive $archivePath required for building in Java 7 could not be found.", null)
         }

--- a/logging/logging.gradle
+++ b/logging/logging.gradle
@@ -68,7 +68,7 @@ whenPomConfigured = { p ->
 
 dependencies {
     compile project(':core')
-    testCompile group: 'junit', name: 'junit', version: '4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.8.0'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
 }
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -20,7 +20,7 @@
  */
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.github.johnrengelman.shadow' version '2.0.1'
 }
 
 apply from: "$buildScriptsDir/common-java.gradle"
@@ -31,13 +31,13 @@ archivesBaseName = 'applicationinsights-web'
 dependencies {
     provided (project(':agent')) { transitive = false }
     compile (project(':core')) { transitive = false }
-    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.1'])
+    compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
     compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
     provided 'com.opensymphony:xwork:2.0.4' // Struts 2
     provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'
     provided group: 'javax.servlet', name: 'servlet-api', version: '2.5'
     provided group: 'javax.enterprise', name: 'cdi-api', version: '1.1' // Java EE
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.8.0'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '7.0.0.M0'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '7.0.0.M0'


### PR DESCRIPTION
This pull request updates all the dependencies used by AI-Java SDK to latest versions except Google Guava which is updated to 20.0 as the later versions do no support JDK 1.7

#410 is similar and this PR updates to more recent versions of dependencies

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
