### PR TITLE
allow specify directory of the configuration file explicitly

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocator.java
@@ -41,6 +41,10 @@ import com.google.common.base.Strings;
  * Created by gupele on 5/25/2015.
  */
 public final class ConfigurationFileLocator {
+
+    /** name of property containing path to directory with configuration file */
+    public static final String CONFIG_DIR_PROPERTY = "insights.configurationDirectory";
+
     private final String configurationFileName;
 
     public ConfigurationFileLocator(String configurationFileName) {
@@ -49,22 +53,34 @@ public final class ConfigurationFileLocator {
     }
 
     public InputStream getConfigurationFile() {
-        InputStream inputStream = ConfigurationFileLocator.class.getClassLoader().getResourceAsStream(configurationFileName);
-        if (inputStream != null) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.INFO, "Configuration file has been successfully found as resource");
-            return inputStream;
-        }
 
-        // Trying to load configuration as a resource.
-        String configurationFile = getConfigurationFromCurrentClassLoader();
+        String configurationFile;
+        InputStream inputStream;
 
-        // If not found as a resource, trying to load from the executing jar directory
-        if (configurationFile == null) {
-            configurationFile = getConfigurationFromLibraryLocation();
+        // first try to get from dir defined explicitly in system property insights.configurationFile
+        String configDirFromProperty = System.getProperty(CONFIG_DIR_PROPERTY);
+        if (configDirFromProperty != null) {
+            configurationFile = getConfigurationAbsolutePath(configDirFromProperty);
+        } else {
 
-            // If still not found try to get it from the class path
+            inputStream = ConfigurationFileLocator.class.getClassLoader().getResourceAsStream(configurationFileName);
+            if (inputStream != null) {
+                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.INFO,
+                                                  "Configuration file has been successfully found as resource");
+                return inputStream;
+            }
+
+            // Trying to load configuration as a resource.
+            configurationFile = getConfigurationFromCurrentClassLoader();
+
+            // If not found as a resource, trying to load from the executing jar directory
             if (configurationFile == null) {
-                configurationFile = getConfFromClassPath();
+                configurationFile = getConfigurationFromLibraryLocation();
+
+                // If still not found try to get it from the class path
+                if (configurationFile == null) {
+                    configurationFile = getConfFromClassPath();
+                }
             }
         }
 

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocatorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocatorTest.java
@@ -56,10 +56,30 @@ public final class ConfigurationFileLocatorTest {
     }
 
     @Test
+    public void testGetConfigurationFileWhereDirIsFromProperty() throws Exception {
+        System.setProperty(ConfigurationFileLocator.CONFIG_DIR_PROPERTY, "src/test/resources");
+
+        InputStream resourceFile = new ConfigurationFileLocator(EXISTING_CONF_TEST_FILE).getConfigurationFile();
+        verifyFile(resourceFile);
+    }
+
+    @Test
+    public void testNoConfigurationFoundWhereDirPropertySetWrong() throws Exception {
+        System.setProperty(ConfigurationFileLocator.CONFIG_DIR_PROPERTY, "this-directory-does-not-exist");
+
+        InputStream resourceFile = new ConfigurationFileLocator(EXISTING_CONF_TEST_FILE).getConfigurationFile();
+        System.clearProperty(ConfigurationFileLocator.CONFIG_DIR_PROPERTY);
+
+        assertNull(resourceFile);
+    }
+
+    @Test
     public void testGetConfigurationFileWhereFileIsResource() throws Exception {
         String configurationFileName = putConfigurationFileAsResourceInCurrentClassLoaderOnly();
 
         InputStream resourceFile = new ConfigurationFileLocator(configurationFileName).getConfigurationFile();
+        System.clearProperty(ConfigurationFileLocator.CONFIG_DIR_PROPERTY);
+
         verifyFile(resourceFile);
     }
 


### PR DESCRIPTION
allow to specify directory of the configuration file explicitly via system property;
property is named insights.configurationDirectory
