### PR TITLE
Changing to a more reliable way to detect os for build

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,10 @@ plugins {
 
 apply from: "$buildScriptsDir/common-java.gradle"
 apply from: "$buildScriptsDir/publishing.gradle"
-if (System.env."windir" != null) {
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     apply from: "native.gradle"
 } else {
     logger.warn("Native binaries build is only supported on Windows systems; native components will not be built.")


### PR DESCRIPTION
The checking for the environment variable was not reliable. I've been using gitbash as my shell in VS Code and it didn't pick up the "windir" env var for some reason. This way it works regardless (and nothing in the build script seems to depend on the windir variable).