### PR TITLE
Fix shadow jar

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -1,6 +1,5 @@
 package com.microsoft.applicationinsights.internal.channel.samplingV2;
 
-import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
 import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
 import com.microsoft.applicationinsights.internal.annotation.BuiltInProcessor;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
@@ -11,6 +10,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This processor is used to Perform Sampling on User specified sampling rate
@@ -99,9 +100,9 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
 
     private void setIncludedOrExcludedTypes(String value, Set<Class> typeSet) {
 
-        if (!StringUtils.isNullOrEmpty(value)) {
+        if (!StringUtils.isEmpty(value)) {
             value = value.trim();
-            if (!StringUtils.isNullOrEmpty(value) && allowedTypes.containsKey(value)) {
+            if (!StringUtils.isEmpty(value) && allowedTypes.containsKey(value)) {
                 typeSet.add(allowedTypes.get(value));
             } else {
                 InternalLogger.INSTANCE.error("Item is either not allowed to sample or is empty");

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
@@ -1,9 +1,9 @@
 package com.microsoft.applicationinsights.internal.channel.samplingV2;
 
-import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
 
 import java.util.Random;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Created by Dhaval Doshi Oct 2017
@@ -24,7 +24,7 @@ public class SamplingScoreGeneratorV2 {
 
         double samplingScore = 0.0;
 
-        if (!StringUtils.isNullOrEmpty(telemetry.getContext().getOperation().getId())) {
+        if (!StringUtils.isEmpty(telemetry.getContext().getOperation().getId())) {
             samplingScore =  ((double) getSamplingHashCode(telemetry.getContext().getOperation().getId()) / Integer.MAX_VALUE);
         }
 
@@ -37,7 +37,7 @@ public class SamplingScoreGeneratorV2 {
     }
 
      static int getSamplingHashCode(String input) {
-        if (StringUtils.isNullOrEmpty(input)) {
+        if (StringUtils.isEmpty(input)) {
             return 0;
         }
 

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
@@ -3,13 +3,13 @@ package com.microsoft.applicationinsights.internal.channel.samplingV2;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.TestFramework.StubTelemetryChannel;
-import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
 import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
 import com.microsoft.applicationinsights.telemetry.PageViewTelemetry;
 import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.telemetry.SupportSampling;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -513,7 +513,7 @@ public class FixedRateSamplingTelemetryProcessorTest {
         processor.setSamplingPercentage(String.valueOf(samplingRate));
         if (includeTypes != null) {
             for (String includeType : includeTypes) {
-                if (!StringUtils.isNullOrEmpty(includeType)) {
+                if (!StringUtils.isEmpty(includeType)) {
                     processor.addToIncludedType(includeType);
                 }
             }
@@ -521,7 +521,7 @@ public class FixedRateSamplingTelemetryProcessorTest {
 
         if (excludeTypes != null) {
             for (String excludeType : excludeTypes) {
-                if (!StringUtils.isNullOrEmpty(excludeType)) {
+                if (!StringUtils.isEmpty(excludeType)) {
                     processor.addToExcludedType(excludeType);
                 }
             }
@@ -559,7 +559,7 @@ public class FixedRateSamplingTelemetryProcessorTest {
         processor.setSamplingPercentage(String.valueOf(samplingRate));
         if (includeTypes != null) {
             for (String includeType : includeTypes) {
-                if (!StringUtils.isNullOrEmpty(includeType)) {
+                if (!StringUtils.isEmpty(includeType)) {
                     processor.addToIncludedType(includeType);
                 }
             }
@@ -567,7 +567,7 @@ public class FixedRateSamplingTelemetryProcessorTest {
 
         if (excludeTypes != null) {
             for (String excludeType : excludeTypes) {
-                if (!StringUtils.isNullOrEmpty(excludeType)) {
+                if (!StringUtils.isEmpty(excludeType)) {
                     processor.addToExcludedType(excludeType);
                 }
             }

--- a/gradle/provided-configuration.gradle
+++ b/gradle/provided-configuration.gradle
@@ -19,21 +19,18 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-// Adding the "provided" configuration
-
-ext {
-    PROVIDED_CONFIGURATION_NAME = "provided"
-}
-
+// Defines the "provided" configuration for dependencies that the client is responsible for including on the classpath
 configurations {
-    provided {
-        // Remove the provided dependencies from the default configuration so
-        // these dependencies won't be derived by projects that has a dependency on
-        // the project using the provided scope
-        dependencies.all { dep ->
-            configurations.default.exclude group: dep.group, module: dep.name
-        }
-    }
-    compile.extendsFrom provided
+    provided
 }
 
+sourceSets {
+    main {
+        compileClasspath += configurations.provided
+        runtimeClasspath += configurations.provided
+    }
+    test {
+        compileClasspath += configurations.provided
+        runtimeClasspath += configurations.provided
+    }
+}

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     provided (project(':agent')) { transitive = false }
     compile (project(':core')) { transitive = false }
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
-    compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
     provided 'com.opensymphony:xwork:2.0.4' // Struts 2
     provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'
     provided group: 'javax.servlet', name: 'servlet-api', version: '2.5'
@@ -45,11 +44,11 @@ dependencies {
     testCompile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.1'
     testCompile group: 'org.json', name:'json', version:'20090211'
     testCompile group: 'com.microsoft.azure', name: 'azure-storage', version: '2.1.0'
+    testCompile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
 }
 
 shadowJar {
     classifier=''
-    relocate 'org.apache.http', 'com.microsoft.applicationinsights.web.dependencies.http'
     relocate 'org.apache.commons', 'com.microsoft.applicationinsights.web.dependencies.apachecommons'
 }
 


### PR DESCRIPTION
The shadowJar was repackaging way more than it should. This fixes it. 

Here's the gist:
* By default, shadowJar repackages everything in the **runtime** configuration
* `runtime.extendsFrom compile` i.e. **runtime** inherits all behaviors from **compile**.
* Since **provided** was defined so **compile** inherited its behaviors, this created an unwanted transitive link causing everything defined as **provided** to be repackaged. Really, we just need these on the classpath (see changes to provided-configuration).

As a result of fixing what is repackaged:
* Classes in _:agent_ are no longer accessible and shouldn't be, hence the changes to java files.
* Apache's poorly named method `StringUtils.isEmpty` actually does check for `null` :)

Also,
* There's no reference to the Apache HttpClient in _:web_; only in its tests. So, that dependency was reclassified.