### PR TITLE
Prevent Multiple Initialization of Configuration

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
@@ -63,7 +63,7 @@ public final class TelemetryConfiguration {
      * @return The 'Active' instance
      */
     public static TelemetryConfiguration getActive() {
-        if (!initialized) {
+        if (!initialized && active == null) {
             synchronized (s_lock) {
                 if (!initialized) {
                     active = new TelemetryConfiguration();

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
@@ -42,8 +42,7 @@ public final class TelemetryConfiguration {
 
     // Synchronization for instance initialization
     private final static Object s_lock = new Object();
-    private static volatile boolean initialized = false;
-    private static TelemetryConfiguration active;
+    private static volatile TelemetryConfiguration active;
 
     private String instrumentationKey;
 
@@ -63,12 +62,11 @@ public final class TelemetryConfiguration {
      * @return The 'Active' instance
      */
     public static TelemetryConfiguration getActive() {
-        if (!initialized && active == null) {
+        if (active == null) {
             synchronized (s_lock) {
-                if (!initialized) {
+                if (active == null) {
                     active = new TelemetryConfiguration();
                     TelemetryConfigurationFactory.INSTANCE.initialize(active);
-                    initialized = true;
                 }
             }
         }


### PR DESCRIPTION
Fix #503 

Added a check to prevent initialization twice. (basically happens when the TelemetryConfiguration class's getActive() method is invoked inside itself before the call of the first method completes - specifically takes place when initializing quick pulse module)

This duplicate initialization can cause degraded start-up performance.