### PR TITLE
Fixing the constants (envelope name and base type) solves page view t…

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/PageViewTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/PageViewTelemetry.java
@@ -40,13 +40,13 @@ public final class PageViewTelemetry extends BaseSampleSourceTelemetry<PageViewD
     /**
      * Envelope Name for this telemetry.
      */
-    private static final String ENVELOPE_NAME = "PerformanceCounter";
+    private static final String ENVELOPE_NAME = "PageView";
 
 
     /**
      * Base Type for this telemetry.
      */
-    private static final String BASE_TYPE = "PerformanceCounterData";
+    private static final String BASE_TYPE = "PageViewData";
 
     /**
      * Default Ctor


### PR DESCRIPTION
Fix #497

This PR fixes the incorrect constants which were inhibiting the PageViewTelemetry form flowing into the portal. 

Performed E2E test and saw page view data coming on the portal with the changes.

This a critical PR as it unblocks one full feature. I suggest quick review.