### PR TITLE
Added check for TelemetryConfiguration#getInstrumentationKey emptiness

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -106,8 +106,8 @@ public class TelemetryClient {
      * @return 'true' if tracking is disabled, 'false' otherwise.
      */
     public boolean isDisabled() {
-        return
-                Strings.isNullOrEmpty(getContext().getInstrumentationKey()) || configuration.isTrackingDisabled();
+        return (Strings.isNullOrEmpty(configuration.getInstrumentationKey()) && Strings.isNullOrEmpty(getContext().getInstrumentationKey()))
+                || configuration.isTrackingDisabled();
     }
 
     /**


### PR DESCRIPTION
Without this change it is impossible to load instrumentation key from active configuration if it was updated after `TelemetryClient` creation.
I need this in order to pick up instrumentation key that was set from spring configuration.


  