### PR TITLE
Fix Log Messages Being Dropped when Reporting Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Version 2.0.1
+- Logger Messages now being pushed as custom dimension when reporting exceptions via Loggers. (#400)
 - Enhanced Log4j2 appender to support basic parameters including Filters, Layouts and includeException. (#348)
 - Fixed performance issue on SDK startup.
 - Fixed PageView telemetry data not being reported. 

--- a/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/internal/ApplicationInsightsLogEvent.java
+++ b/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/internal/ApplicationInsightsLogEvent.java
@@ -75,6 +75,10 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
         addLogEventProperty("ThreadName", loggingEvent.getThreadName(), metaData);
         addLogEventProperty("TimeStamp", getFormattedDate(loggingEvent.getTimeStamp()), metaData);
 
+        if (isException()) {
+            addLogEventProperty("Logger Message", getMessage(), metaData);
+        }
+
         if (loggingEvent.locationInformationExists()) {
             LocationInfo locationInfo = loggingEvent.getLocationInformation();
 

--- a/logging/log4j1_2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v1_2/ApplicationInsightsAppenderTests.java
+++ b/logging/log4j1_2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v1_2/ApplicationInsightsAppenderTests.java
@@ -64,6 +64,15 @@ public class ApplicationInsightsAppenderTests {
         Assert.assertEquals(1, LogChannelMockVerifier.INSTANCE.getTelemetryCollection().size());
     }
 
+    @Test
+    public void testLoggerMessageIsRetainedWhenReportingException() {
+        Logger logger = LogManager.getRootLogger();
+        logger.error("This is an exception", new Exception("Fake Exception"));
+        Assert.assertEquals(1, LogChannelMockVerifier.INSTANCE.getTelemetryCollection().size());
+        Assert.assertTrue(LogChannelMockVerifier.INSTANCE.getTelemetryCollection().get(0).getProperties().containsKey("Logger Message"));
+        Assert.assertTrue(LogChannelMockVerifier.INSTANCE.getTelemetryCollection().get(0).getProperties().get("Logger Message").equals("This is an exception"));
+    }
+
     // endregion Tests
 
     // region Private methods

--- a/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEvent.java
+++ b/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEvent.java
@@ -75,6 +75,10 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
         addLogEventProperty("ThreadName", logEvent.getThreadName(), metaData);
         addLogEventProperty("TimeStamp", getFormattedDate(logEvent.getTimeMillis()), metaData);
 
+        if (isException()) {
+            addLogEventProperty("Logger Message", getMessage(), metaData);
+        }
+
         if (logEvent.isIncludeLocation()) {
             StackTraceElement stackTraceElement = logEvent.getSource();
 

--- a/logging/log4j2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppenderTests.java
+++ b/logging/log4j2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppenderTests.java
@@ -105,6 +105,15 @@ public class ApplicationInsightsAppenderTests {
         Assert.assertEquals(2, LogChannelMockVerifier.INSTANCE.getTelemetryCollection().size());
     }
 
+    @Test
+    public void testLoggerMessageIsRetainedWhenReportingException() {
+        Logger logger = LogManager.getRootLogger();
+        logger.error("This is an exception", new Exception("Fake Exception"));
+        Assert.assertEquals(1, LogChannelMockVerifier.INSTANCE.getTelemetryCollection().size());
+        Assert.assertTrue(LogChannelMockVerifier.INSTANCE.getTelemetryCollection().get(0).getProperties().containsKey("Logger Message"));
+        Assert.assertTrue(LogChannelMockVerifier.INSTANCE.getTelemetryCollection().get(0).getProperties().get("Logger Message").equals("This is an exception"));
+    }
+
 
     // endregion Tests
 

--- a/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/internal/ApplicationInsightsLogEvent.java
+++ b/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/internal/ApplicationInsightsLogEvent.java
@@ -71,6 +71,10 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
         addLogEventProperty("ThreadName", loggingEvent.getThreadName(), metaData);
         addLogEventProperty("TimeStamp", getFormattedDate(loggingEvent.getTimeStamp()), metaData);
 
+        if (isException()) {
+            addLogEventProperty("Logger Message", getMessage(), metaData);
+        }
+
         for (Map.Entry<String, String> entry : loggingEvent.getMDCPropertyMap().entrySet()) {
             addLogEventProperty(entry.getKey(), entry.getValue(), metaData);
         }

--- a/logging/logback/appenderSrc/test/java/com/microsoft/applicationinsights/logback/ApplicationInsightsAppenderTests.java
+++ b/logging/logback/appenderSrc/test/java/com/microsoft/applicationinsights/logback/ApplicationInsightsAppenderTests.java
@@ -33,6 +33,7 @@ import com.microsoft.applicationinsights.telemetry.Telemetry;
 import ch.qos.logback.classic.Logger;
 
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 public class ApplicationInsightsAppenderTests {
 
@@ -78,6 +79,23 @@ public class ApplicationInsightsAppenderTests {
         ApplicationInsightsAppender appender = (ApplicationInsightsAppender) logger.getAppender("test");
 
         return appender;
+    }
+
+    @Test
+    public void testLoggerMessageIsRetainedWhenReportingException() {
+        Logger logger = (Logger) LoggerFactory.getLogger("root");
+        logger.error("This is an exception", new Exception("Fake Exception"));
+        Assert.assertEquals(1, LogChannelMockVerifier.INSTANCE.getTelemetryCollection().size());
+        Assert.assertTrue(LogChannelMockVerifier.INSTANCE.getTelemetryCollection().get(0).getProperties().containsKey("Logger Message"));
+        Assert.assertTrue(LogChannelMockVerifier.INSTANCE.getTelemetryCollection().get(0).getProperties().get("Logger Message").equals("This is an exception"));
+    }
+
+    @Test
+    public void testMDCPropertiesAreBeingSetAsCustomDimensions() {
+        Logger logger = (Logger) LoggerFactory.getLogger("root");
+        MDC.put("key", "value");
+        logger.error("This is an exception", new Exception("Fake Exception"));
+        Assert.assertTrue(LogChannelMockVerifier.INSTANCE.getTelemetryCollection().get(0).getProperties().get("key").equals("value"));
     }
 
     private void setMockTelemetryChannelToAIAppender() {


### PR DESCRIPTION
This PR #400 fixes the Logger Messages not being pushed when reporting Exceptions via Logging Frameworks (Log4j1_2, Log4j2 and Logback)

They will be reported as Key-value pair in custom dimension of ExceptionTelemetry where Key's name would be "_Logger Message_" and value would be value set by Logger.


For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated
