### PR TITLE
Fixing FixedRateSampling to work in old and new version of sampling

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/FixedRateTelemetrySampler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/FixedRateTelemetrySampler.java
@@ -113,7 +113,7 @@ public final class FixedRateTelemetrySampler implements TelemetrySampler {
 
                         return false;
                     }
-                    samplingSupportingTelemetry.setSamplingPercentage(telemetrySamplingScore);
+                    samplingSupportingTelemetry.setSamplingPercentage(testedPercentage);
                 }
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -157,16 +157,21 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
                 if (samplingSupportingTelemetry.getSamplingPercentage() == null) {
 
                     samplingSupportingTelemetry.setSamplingPercentage(samplingPercentage);
-
-                    if (SamplingScoreGeneratorV2.getSamplingScore(telemetry) >= samplingPercentage) {
-
-                        InternalLogger.INSTANCE.info("Item %s sampled out", telemetry.getClass());
-                        return false;
-                    }
+                                        
+                    
                 } else {
                     InternalLogger.INSTANCE.info("Item has sampling percentage already set to :"
                             + samplingSupportingTelemetry.getSamplingPercentage());
+                    
+                    samplingPercentage = samplingSupportingTelemetry.getSamplingPercentage();
                 }
+                
+                if (SamplingScoreGeneratorV2.getSamplingScore(telemetry) >= samplingPercentage) {
+
+                    InternalLogger.INSTANCE.info("Item %s sampled out", telemetry.getClass());
+                    return false;
+                }
+                
             } else {
                 InternalLogger.INSTANCE.trace("Skip sampling since %s type is not sampling applicable", telemetry.getClass());
             }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessorTest.java
@@ -56,16 +56,16 @@ public class FixedRateSamplingTelemetryProcessorTest {
     }
 
     @Test
-    public void telemetryItemSamplingIsSkippedWhenSetByUser() {
+    public void telemetryItemSamplingWorksWhenSetByUser() {
         FixedRateSamplingTelemetryProcessor processor = new FixedRateSamplingTelemetryProcessor();
-        processor.setSamplingPercentage("0.0");
+        processor.setSamplingPercentage("100.0");
         Telemetry requestTelemetry = new RequestTelemetry();
-        ((SupportSampling)requestTelemetry).setSamplingPercentage(100.0);
+        ((SupportSampling)requestTelemetry).setSamplingPercentage(0.0);
         int sentCount = 0;
         if (processor.process(requestTelemetry)) {
             ++sentCount;
         }
-        Assert.assertEquals(1, sentCount);
+        Assert.assertEquals(0, sentCount);
     }
 
     @Test


### PR DESCRIPTION
Fix #535 

Fixed both the below issues in this commit.

1. New version of FixedRate Sampling worked only with global sampling percentage and not with user set sampling percentage.

2. Old version of FixedRate Sampling sets sampling score as SamplingPercentage once sampled in. It has to be sampling percentage.
