### PR TITLE
Fix null ref check in telemetry correlation Utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 2.0.0
+
+- Fix #506 Null Reference Check causing Null Pointer Exception in `TelemetryCorrelationUtils.java`
+
 ## Version 2.0.0-BETA
 - Updating various dependencies to latest version
 - Introducing public class CustomClassWriter in Agent to enable finding common super classes used for Agent instrumentation without loading it

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
@@ -148,7 +148,7 @@ public class TelemetryCorrelationUtils {
 
 		//check if context is null - no correlation will happen
 		if (ThreadContext.getRequestTelemetryContext() == null) {
-			InternalLogger.INSTANCE.error("No correlation wil happen, Thread context is null");
+			InternalLogger.INSTANCE.warn("No correlation wil happen, Thread context is null");
 			return "";
 		}
 
@@ -273,7 +273,7 @@ public class TelemetryCorrelationUtils {
 
 		//check if context is null - no correlation will happen
 		if (ThreadContext.getRequestTelemetryContext() == null) {
-			InternalLogger.INSTANCE.error("No correlation will happen " +
+			InternalLogger.INSTANCE.warn("No correlation will happen " +
 					"Thread context is null while resolving Correlation Context");
 			return;
 		}

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
@@ -111,7 +111,15 @@ public class TelemetryCorrelationUtils {
 	public static String generateChildDependencyId() {
 		
 		try {
+
 			RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
+
+			//check if context is null - no correlation will happen
+			if (context == null) {
+				InternalLogger.INSTANCE.warn("No Correlation will happen, Thread context is null while generating child dependency");
+				return "";
+			}
+
 			RequestTelemetry requestTelemetry = context.getHttpRequestTelemetry();
 
 			String parentId = requestTelemetry.getContext().getOperation().getParentId();
@@ -137,6 +145,13 @@ public class TelemetryCorrelationUtils {
 	 * @return The correlation context as a string.
 	 */
 	public static String retrieveCorrelationContext() {
+
+		//check if context is null - no correlation will happen
+		if (ThreadContext.getRequestTelemetryContext() == null) {
+			InternalLogger.INSTANCE.error("No correlation wil happen, Thread context is null");
+			return "";
+		}
+
 		CorrelationContext context = ThreadContext.getRequestTelemetryContext().getCorrelationContext();
 		return context.toString();
 	}
@@ -253,6 +268,13 @@ public class TelemetryCorrelationUtils {
 
 		if (baggages == null) {
 			InternalLogger.INSTANCE.warn("Could not access header information: " + CORRELATION_CONTEXT_HEADER_NAME);
+			return;
+		}
+
+		//check if context is null - no correlation will happen
+		if (ThreadContext.getRequestTelemetryContext() == null) {
+			InternalLogger.INSTANCE.error("No correlation will happen " +
+					"Thread context is null while resolving Correlation Context");
 			return;
 		}
 


### PR DESCRIPTION
Fix #506 .

This PR fixes the missing Null Reference checks in the TelemetryCorrelationUtils class which caused NullPointerExceptions.


For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated
