### PR TITLE
Fix usage of format strings in logger and better exception logging.

### DIFF
--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/AgentImplementation.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/AgentImplementation.java
@@ -60,7 +60,7 @@ public final class AgentImplementation {
             appendJarsToBootstrapClassLoader(inst);
             initializeCodeInjector(inst);
         } catch (Throwable throwable) {
-            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Agent is NOT activated: failed to load to bootstrap class loader: " + throwable.getMessage());
+            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Agent is NOT activated: failed to load to bootstrap class loader: %s", throwable.toString());
 			throwable.printStackTrace();
             System.exit(-1);
         }
@@ -100,7 +100,7 @@ public final class AgentImplementation {
 			}
             inst.addTransformer(codeInjector);
         } catch (Exception e) {
-            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to load the code injector, exception: %s", e.getMessage());
+            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to load the code injector, exception: %s", e.toString());
             throw e;
         }
     }
@@ -113,7 +113,7 @@ public final class AgentImplementation {
         for (File file : agentFolder.listFiles()) {
             if (file.getName().indexOf(AGENT_JAR_PREFIX) != -1) {
                 agentJarName = file.getName();
-                InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.INFO,"Agent jar name is " + agentJarName);
+                InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.INFO,"Agent jar name is %s", agentJarName);
                 break;
             }
         }
@@ -123,7 +123,7 @@ public final class AgentImplementation {
             throw new RuntimeException("Could not find agent jar");
         }
 
-        InternalAgentLogger.INSTANCE.info("Found jar: " + agentJarPath + " " + agentJarName);
+        InternalAgentLogger.INSTANCE.info("Found jar: %s %s", agentJarPath, agentJarName);
 
         URL configurationURL = new URL(agentJarPath + agentJarName);
 
@@ -142,7 +142,7 @@ public final class AgentImplementation {
                     String urlPath = url.getPath();
 
                     if (urlPath.indexOf(AGENT_JAR_PREFIX) != -1) {
-                        InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.INFO,"Agent jar found at " + urlPath);
+                        InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.INFO,"Agent jar found at %s", urlPath);
                         int index = urlPath.lastIndexOf('/');
                         urlPath = urlPath.substring(0, index + 1);
                         return urlPath;
@@ -151,7 +151,7 @@ public final class AgentImplementation {
                 }
             }
         } catch (Throwable throwable) {
-            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Error while trying to fetch Jar Location, Exception: " + throwable.getMessage());
+            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Error while trying to fetch Jar Location, Exception: %s", throwable.toString());
         }
 
         String stringPath = AgentImplementation.class.getProtectionDomain().getCodeSource().getLocation().getPath();
@@ -198,13 +198,13 @@ public final class AgentImplementation {
             throw new Exception(errorMessage);
         }
 
-        InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.TRACE, "Found jar: " + coreJarName);
+        InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.TRACE, "Found jar: %s", coreJarName);
 
         JarFile jarFile = null;
         try {
             jarFile = new JarFile(coreJarName);
         } catch (IOException e) {
-            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Could not load jar: " + coreJarName);
+            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Could not load jar: %s", coreJarName);
             throw e;
         }
         Enumeration<JarEntry> e = jarFile.entries();

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/CodeInjector.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/CodeInjector.java
@@ -54,7 +54,7 @@ public final class CodeInjector implements ClassFileTransformer {
             InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.INFO, "Agent is up");
         } catch (Throwable throwable) {
             throwable.printStackTrace();
-            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.INFO, "Agent is NOT activated: failed to initialize CodeInjector: '%s'", throwable.getMessage());
+            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.INFO, "Agent is NOT activated: failed to initialize CodeInjector: '%s'", throwable.toString());
         }
     }
 
@@ -81,7 +81,7 @@ public final class CodeInjector implements ClassFileTransformer {
                 return byteCodeTransformer.transform(originalBuffer, className, loader);
             } catch (Throwable throwable) {
                 throwable.printStackTrace();
-                InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to instrument '%s', exception: '%s': ", className, throwable.getMessage());
+                InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to instrument '%s', exception: '%s': ", className, throwable.toString());
             }
         }
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/DefaultClassDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/DefaultClassDataProvider.java
@@ -139,7 +139,7 @@ class DefaultClassDataProvider implements ClassDataProvider {
 					ClassInstrumentationData newClassInstrumentationData = new ClassInstrumentationData(className, classInstrumentationData.getClassType(), classInstrumentationData.getClassVisitorFactory());
 					newClassInstrumentationData.setMethodInstrumentationInfo(classInstrumentationData.getMethodInstrumentationInfo());
 					classInstrumentationData = newClassInstrumentationData;
-					InternalAgentLogger.INSTANCE.trace("Adding " + classInstrumentationData.getFullPackageName());
+					InternalAgentLogger.INSTANCE.trace("Adding %s", classInstrumentationData.getFullPackageName());
                }
             }
         }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/exceptions/RuntimeExceptionProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/exceptions/RuntimeExceptionProvider.java
@@ -58,7 +58,7 @@ public final class RuntimeExceptionProvider {
 
             classesToInstrument.put(RUNTIME_EXCEPTION_CLASS_NAME, data);
         } catch (Throwable t) {
-            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to load instrumentation for Jedis: '%s':'%s'", t.getClass().getName(), t.getMessage());
+            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to load instrumentation for Jedis: '%s'", t.toString());
         }
     }
 }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/http/HttpClassDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/http/HttpClassDataProvider.java
@@ -152,7 +152,7 @@ public final class HttpClassDataProvider {
                     REST_TEMPLATE_METTHOD,
                     null);
         } catch (Throwable t) {
-            InternalAgentLogger.INSTANCE.error("Exception while loading HTTP classes: '%s'", t.getMessage());
+            InternalAgentLogger.INSTANCE.error("Exception while loading HTTP classes: '%s'", t.toString());
         }
     }
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/jmx/JmxConnectorLoader.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/jmx/JmxConnectorLoader.java
@@ -48,15 +48,15 @@ public final class JmxConnectorLoader {
 			
 			return true;
         } catch (MalformedObjectNameException e) {
-            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'MalformedObjectNameException': '%s'", e.getMessage());
+            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'MalformedObjectNameException': '%s'", e.toString());
         } catch (NotCompliantMBeanException e) {
-            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'NotCompliantMBeanException': '%s'", e.getMessage());
+            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'NotCompliantMBeanException': '%s'", e.toString());
         } catch (InstanceAlreadyExistsException e) {
-            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'InstanceAlreadyExistsException': '%s'", e.getMessage());
+            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'InstanceAlreadyExistsException': '%s'", e.toString());
         } catch (MBeanRegistrationException e) {
-            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'MBeanRegistrationException': '%s'", e.getMessage());
+            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'MBeanRegistrationException': '%s'", e.toString());
         } catch (Throwable t) {
-            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'Throwable': '%s'", t.getMessage());
+            InternalAgentLogger.INSTANCE.error("Failed to register Jmx connector 'Throwable': '%s'", t.toString());
         }
 		
 		return false;

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/redis/JedisClassDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/redis/JedisClassDataProvider.java
@@ -59,7 +59,7 @@ public final class JedisClassDataProvider {
 
             classesToInstrument.put(JEDIS_CLASS_NAME, data);
         } catch (Throwable t) {
-            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to load instrumentation for Jedis: '%s':'%s'", t.getClass().getName(), t.getMessage());
+            InternalAgentLogger.INSTANCE.logAlways(InternalAgentLogger.LoggingLevel.ERROR, "Failed to load instrumentation for Jedis: '%s'", t.toString());
         }
     }
 }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/PreparedStatementClassDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/PreparedStatementClassDataProvider.java
@@ -71,7 +71,7 @@ public final class PreparedStatementClassDataProvider {
 
             addSqlite();
         } catch (Throwable t) {
-            InternalAgentLogger.INSTANCE.error("Exception while loading HTTP classes: '%s'", t.getMessage());
+            InternalAgentLogger.INSTANCE.error("Exception while loading HTTP classes: '%s'", t.toString());
         }
     }
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/StatementClassDataDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/sql/StatementClassDataDataProvider.java
@@ -76,7 +76,7 @@ public class StatementClassDataDataProvider {
             addStatements();
             addPossibleQueryLimit();
         } catch (Throwable t) {
-            InternalAgentLogger.INSTANCE.error("Exception while loading HTTP classes: '%s'", t.getMessage());
+            InternalAgentLogger.INSTANCE.error("Exception while loading HTTP classes: '%s'", t.toString());
         }
     }
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentConfigurationBuilderFactory.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentConfigurationBuilderFactory.java
@@ -40,7 +40,7 @@ public class AgentConfigurationBuilderFactory {
                 return (AgentConfigurationBuilder)builder;
             }
         } catch (Throwable t) {
-            InternalAgentLogger.INSTANCE.error("Failed to create builder: '%s'" + t.getMessage());
+            InternalAgentLogger.INSTANCE.error("Failed to create builder: '%s'", t.toString());
         }
 
         return null;

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationBuilder.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationBuilder.java
@@ -146,7 +146,7 @@ final class XmlAgentConfigurationBuilder implements AgentConfigurationBuilder {
             agentConfiguration.setRequestedClassesToInstrument(classesToInstrument);
             return agentConfiguration;
         } catch (Throwable e) {
-            InternalAgentLogger.INSTANCE.error("Exception while parsing Agent configuration file: '%s'" + e.getMessage());
+            InternalAgentLogger.INSTANCE.error("Exception while parsing Agent configuration file: '%s'",  e.toString());
             return null;
         }
     }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/coresync/impl/ImplementationsCoordinator.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/coresync/impl/ImplementationsCoordinator.java
@@ -276,7 +276,7 @@ public enum ImplementationsCoordinator implements AgentNotificationsHandler {
 
             return implementationName;
         } catch (Throwable throwable) {
-            InternalAgentLogger.INSTANCE.error("Exception: '%s'", throwable.getMessage());
+            InternalAgentLogger.INSTANCE.error("Exception: '%s'", throwable.toString());
             return null;
         }
     }
@@ -290,7 +290,7 @@ public enum ImplementationsCoordinator implements AgentNotificationsHandler {
             mainHandler = handler;
             InternalAgentLogger.INSTANCE.trace("Setting main handler");
         } catch (Throwable throwable) {
-            InternalAgentLogger.INSTANCE.error("Exception: '%s'", throwable.getMessage());
+            InternalAgentLogger.INSTANCE.error("Exception: '%s'", throwable.toString());
         }
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -413,7 +413,7 @@ public class TelemetryClient {
         try {
             telemetry.getContext().initialize(ctx);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.error("Exception while telemetry context's initialization: '%s'", t.getMessage());
+            InternalLogger.INSTANCE.error("Exception while telemetry context's initialization: '%s'", t.toString());
         }
 
         activateInitializers(telemetry);
@@ -434,7 +434,7 @@ public class TelemetryClient {
         try {
             getChannel().send(telemetry);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.error("Exception while sending telemetry: '%s'",t.getMessage());
+            InternalLogger.INSTANCE.error("Exception while sending telemetry: '%s'",t.toString());
         }
     }
 
@@ -443,7 +443,7 @@ public class TelemetryClient {
             try {
                 initializer.initialize(telemetry);
             } catch (Throwable e) {
-                InternalLogger.INSTANCE.error("Failed during telemetry initialization class '%s', exception: %s", initializer.getClass().getName(), e.getMessage());
+                InternalLogger.INSTANCE.error("Failed during telemetry initialization class '%s', exception: %s", initializer.getClass().getName(), e.toString());
             }
         }
     }
@@ -455,7 +455,7 @@ public class TelemetryClient {
                     return false;
                 }
             } catch (Throwable t) {
-                InternalLogger.INSTANCE.error("Exception while processing telemetry: '%s'",t.getMessage());
+                InternalLogger.INSTANCE.error("Exception while processing telemetry: '%s'",t.toString());
             }
         }
 
@@ -487,7 +487,7 @@ public class TelemetryClient {
             try {
                 init.initialize(ctx);
             } catch (Throwable t) {
-                InternalLogger.INSTANCE.error("Exception in context initializer: '%s'", t.getMessage());
+                InternalLogger.INSTANCE.error("Exception in context initializer: '%s'", t.toString());
             }
         }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/channel/concrete/inprocess/InProcessTelemetryChannel.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/channel/concrete/inprocess/InProcessTelemetryChannel.java
@@ -104,8 +104,7 @@ public final class InProcessTelemetryChannel implements TelemetryChannel {
             }
         } catch (Throwable t) {
             developerMode = false;
-            InternalLogger.INSTANCE.trace("%s generated exception in parsing," +
-                    "stack trace is %s", DEVELOPER_MODE_SYSTEM_PROPRETY_NAME, ExceptionUtils.getStackTrace(t));
+            InternalLogger.INSTANCE.trace("%s generated exception in parsing, stack trace is %s", DEVELOPER_MODE_SYSTEM_PROPRETY_NAME, ExceptionUtils.getStackTrace(t));
         }
         initialize(null,
                 null,

--- a/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/DockerContextInitializer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/DockerContextInitializer.java
@@ -105,7 +105,7 @@ public class DockerContextInitializer implements TelemetryInitializer {
         try {
             fileFactory.create(sdkInfoFilePath, sdkInfo);
         } catch (IOException e) {
-            InternalLogger.INSTANCE.error("Failed to write SDK info file for Docker awareness. Error: " + e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to write SDK info file for Docker awareness. Error: %s", e.toString());
         }
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/internal/DockerContextPoller.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/internal/DockerContextPoller.java
@@ -48,7 +48,7 @@ public class DockerContextPoller extends Thread {
 
     @Override
     public void run() {
-        InternalLogger.INSTANCE.info("Starting to poll for Docker context file under: " + this.contextFile.getAbsolutePath());
+        InternalLogger.INSTANCE.info("Starting to poll for Docker context file under: %s", this.contextFile.getAbsolutePath());
 
         boolean fileExists = false;
         while (!fileExists){
@@ -71,7 +71,7 @@ public class DockerContextPoller extends Thread {
             this.dockerContext = this.dockerContextFactory.createDockerContext(this.contextFile);
             InternalLogger.INSTANCE.info("Docker context file has been deserialized successfully");
         } catch (Exception e) {
-            InternalLogger.INSTANCE.error("Docker context file failed to be parsed with error: " + e.getMessage());
+            InternalLogger.INSTANCE.error("Docker context file failed to be parsed with error: %s",  e.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/agent/AgentConnector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/agent/AgentConnector.java
@@ -78,7 +78,7 @@ public enum AgentConnector {
                     coreDataAgent = new CoreAgentNotificationsHandler(name);
                     agentKey = ImplementationsCoordinator.INSTANCE.register(classLoader, coreDataAgent);
                 } catch (Throwable t) {
-                    InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Could not find Agent: '%s'", t.getMessage());
+                    InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Could not find Agent: '%s'", t.toString());
                     agentKey = null;
                 }
 
@@ -111,7 +111,7 @@ public enum AgentConnector {
                 try {
                     coreDataAgent = new CoreAgentNotificationsHandler("app");
                 } catch (Throwable t) {
-                    InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Could not find Agent: '%s'", t.getMessage());
+                    InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Could not find Agent: '%s'", t.toString());
                     return false;
                 }
                 ImplementationsCoordinator.INSTANCE.registerSelf(coreDataAgent);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/annotation/AnnotationPackageScanner.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/annotation/AnnotationPackageScanner.java
@@ -57,7 +57,7 @@ public final class AnnotationPackageScanner {
         try {
             annotationDetector.detect(packageToScan);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.error("Failed to scan packages '%s': exception: '%s'", packageToScan, t.getMessage());
+            InternalLogger.INSTANCE.error("Failed to scan packages '%s': exception: '%s'", packageToScan, t.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(t));
         }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ActiveTransmissionLoader.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ActiveTransmissionLoader.java
@@ -95,9 +95,9 @@ public final class ActiveTransmissionLoader implements TransmissionsLoader {
                     try {
                         barrier.await();
                     } catch (InterruptedException e) {
-                        InternalLogger.INSTANCE.error("Interrupted during barrier wait, exception: %s", e.getMessage());
+                        InternalLogger.INSTANCE.error("Interrupted during barrier wait, exception: %s", e.toString());
                     } catch (BrokenBarrierException e) {
-                        InternalLogger.INSTANCE.error("Failed during barrier wait, exception: %s", e.getMessage());
+                        InternalLogger.INSTANCE.error("Failed during barrier wait, exception: %s", e.toString());
                     }
 
                     // Avoid un-expected exit of threads
@@ -150,9 +150,9 @@ public final class ActiveTransmissionLoader implements TransmissionsLoader {
             barrier.await();
             return true;
         } catch (InterruptedException e) {
-            InternalLogger.INSTANCE.error("Interrupted during barrier wait, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Interrupted during barrier wait, exception: %s", e.toString());
         } catch (BrokenBarrierException e) {
-            InternalLogger.INSTANCE.error("Failed during barrier wait, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed during barrier wait, exception: %s", e.toString());
         }
 
         return false;
@@ -166,7 +166,7 @@ public final class ActiveTransmissionLoader implements TransmissionsLoader {
                 thread.interrupt();
                 thread.join();
             } catch (InterruptedException e) {
-                InternalLogger.INSTANCE.error("Interrupted during join of active transmission loader, exception: %s", e.getMessage());
+                InternalLogger.INSTANCE.error("Interrupted during join of active transmission loader, exception: %s", e.toString());
             }
         }
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -64,7 +64,7 @@ final class ApacheSender43 implements ApacheSender {
                 ((CloseableHttpResponse)response).close();
             }
         } catch (IOException e) {
-            InternalLogger.INSTANCE.error("Failed to send or failed to close response, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to send or failed to close response, exception: %s", e.toString());
         }
     }
 
@@ -73,7 +73,7 @@ final class ApacheSender43 implements ApacheSender {
         try {
             httpClient.close();
         } catch (IOException e) {
-            InternalLogger.INSTANCE.error("Failed to close http client, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to close http client, exception: %s", e.toString());
         }
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/GzipTelemetrySerializer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/GzipTelemetrySerializer.java
@@ -67,9 +67,9 @@ public final class GzipTelemetrySerializer implements TelemetrySerializer {
                 try {
                     succeeded = compress(zipStream, telemetries);
                 } catch (Exception e) {
-                    InternalLogger.INSTANCE.error("Failed to serialize , exception: %s", e.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to serialize , exception: %s", e.toString());
                 } catch (Throwable t) {
-                    InternalLogger.INSTANCE.error("Failed to serialize, unknown exception: %s", t.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to serialize, unknown exception: %s", t.toString());
                 } finally {
                     zipStream.close();
                 }
@@ -82,7 +82,7 @@ public final class GzipTelemetrySerializer implements TelemetrySerializer {
                 }
             }
         } catch(Exception e) {
-            InternalLogger.INSTANCE.error("Failed to serialize , exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to serialize , exception: %s", e.toString());
         }
 
         return Optional.fromNullable(result);
@@ -106,7 +106,7 @@ public final class GzipTelemetrySerializer implements TelemetrySerializer {
                 zipStream.write(telemetry.getBytes());
                 ++counter;
             } catch (Exception e) {
-                InternalLogger.INSTANCE.error("Failed to serialize , exception: %s", e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to serialize , exception: %s", e.toString());
             }
 
             if (counter < telemetries.size()) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionFileSystemOutput.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionFileSystemOutput.java
@@ -250,11 +250,11 @@ public final class TransmissionFileSystemOutput implements TransmissionOutput {
             input = new ObjectInputStream (buffer);
             transmission = (Transmission)input.readObject();
         } catch (FileNotFoundException e) {
-            InternalLogger.INSTANCE.error("Failed to load transmission, file not found, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to load transmission, file not found, exception: %s", e.toString());
         } catch (ClassNotFoundException e) {
-            InternalLogger.INSTANCE.error("Failed to load transmission, non transmission, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to load transmission, non transmission, exception: %s", e.toString());
         } catch (IOException e) {
-            InternalLogger.INSTANCE.error("Failed to load transmission, io exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to load transmission, io exception: %s", e.toString());
         } finally{
             if (input != null) {
                 try {
@@ -275,7 +275,7 @@ public final class TransmissionFileSystemOutput implements TransmissionOutput {
             size.addAndGet(fileLength);
             return true;
         } catch (Exception e) {
-            InternalLogger.INSTANCE.error("Rename To Permanent Name failed, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Rename To Permanent Name failed, exception: %s", e.toString());
         }
 
         return false;
@@ -289,7 +289,7 @@ public final class TransmissionFileSystemOutput implements TransmissionOutput {
             size.addAndGet(-renamedFile.length());
             transmissionFile = renamedFile;
         } catch (Exception ignore) {
-            InternalLogger.INSTANCE.error("Rename To Temporary Name failed, exception: %s", ignore.getMessage());
+            InternalLogger.INSTANCE.error("Rename To Temporary Name failed, exception: %s", ignore.toString());
             // Consume the exception, since there isn't anything 'smart' to do now
         }
 
@@ -304,7 +304,7 @@ public final class TransmissionFileSystemOutput implements TransmissionOutput {
             try{
                 output.writeObject(transmission);
             } catch (IOException e) {
-                InternalLogger.INSTANCE.error("Failed to save transmission, exception: %s", e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to save transmission, exception: %s", e.toString());
             } finally{
                 try {
                     output.close();
@@ -314,7 +314,7 @@ public final class TransmissionFileSystemOutput implements TransmissionOutput {
             }
             return true;
         } catch (IOException e) {
-            InternalLogger.INSTANCE.error("Failed to save transmission, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to save transmission, exception: %s", e.toString());
         }
 
         return false;
@@ -325,7 +325,7 @@ public final class TransmissionFileSystemOutput implements TransmissionOutput {
         try {
             file = File.createTempFile(TRANSMISSION_FILE_PREFIX, null, folder);
         } catch (IOException e) {
-            InternalLogger.INSTANCE.error("Failed to create temporary file, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to create temporary file, exception: %s", e.toString());
         }
 
         return Optional.fromNullable(file);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionNetworkOutput.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionNetworkOutput.java
@@ -162,16 +162,16 @@ public final class TransmissionNetworkOutput implements TransmissionOutput {
                 InternalLogger.INSTANCE.error("Failed to send, socket timeout exception");
                 shouldBackoff = true;
             } catch (UnknownHostException e) {
-                InternalLogger.INSTANCE.error("Failed to send, wrong host address or cannot reach address due to network issues, exception: %s", e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to send, wrong host address or cannot reach address due to network issues, exception: %s", e.toString());
                 shouldBackoff = true;
             } catch (IOException ioe) {
-                InternalLogger.INSTANCE.error("Failed to send, exception: %s", ioe.getMessage());
+                InternalLogger.INSTANCE.error("Failed to send, exception: %s", ioe.toString());
                 shouldBackoff = true;
             } catch (Exception e) {
-                InternalLogger.INSTANCE.error("Failed to send, unexpected exception: %s", e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to send, unexpected exception: %s", e.toString());
                 shouldBackoff = true;
             } catch (Throwable t) {
-                InternalLogger.INSTANCE.error("Failed to send, unexpected error: %s", t.getMessage());
+                InternalLogger.INSTANCE.error("Failed to send, unexpected error: %s", t.toString());
                 shouldBackoff = true;
             }
             finally {
@@ -209,7 +209,7 @@ public final class TransmissionNetworkOutput implements TransmissionOutput {
             long retryAfterAsSeconds = (date.getTime() - convertToDateToGmt(now).getTime())/1000;
             transmissionPolicyManager.suspendInSeconds(suspensionPolicy, retryAfterAsSeconds);
         } catch (Throwable e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Throttled but failed to block transmission, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Throttled but failed to block transmission, exception: %s", e.toString());
         }
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
@@ -129,7 +129,7 @@ public final class TransmissionPolicyManager implements Stoppable {
 
             InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.TRACE, "App is throttled, telemetries are blocked from now, for %s seconds", suspendInSeconds);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "App is throttled but failed to block transmission exception: %s", t.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "App is throttled but failed to block transmission exception: %s", t.toString());
         }
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -128,7 +128,7 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
     public void setSamplingPercentage(String samplingPercentage) {
         try {
             this.samplingPercentage = Double.valueOf(samplingPercentage);
-            InternalLogger.INSTANCE.info("Sampling rate set to " + samplingPercentage);
+            InternalLogger.INSTANCE.info("Sampling rate set to %s", samplingPercentage);
         }
         catch (NumberFormatException ex) {
             this.samplingPercentage = 100.0;
@@ -202,7 +202,7 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
     public void addToExcludedType(String value) {
 
         setIncludedOrExcludedTypes(value, excludedTypes);
-        InternalLogger.INSTANCE.trace(value + " added as excluded to sampling");
+        InternalLogger.INSTANCE.trace("%s added as excluded to sampling", value);
 
     }
 
@@ -214,7 +214,7 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
     public void addToIncludedType(String value) {
 
         setIncludedOrExcludedTypes(value, includedTypes);
-        InternalLogger.INSTANCE.trace(value + " added as included to sampling");
+        InternalLogger.INSTANCE.trace("%s added as included to sampling", value);
 
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocator.java
@@ -101,9 +101,9 @@ public final class ConfigurationFileLocator {
 
     private static void logException(Throwable t, String message) {
         if (t.getCause() != null) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.WARN, "Failed to find configuration file, exception while fetching from %s: '%s'", message, t.getCause().getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.WARN, "Failed to find configuration file, exception while fetching from %s: '%s'", message, t.getCause().toString());
         } else {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.WARN, "Failed to find configuration file, exception while fetching from %s: '%s'", message, t.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.WARN, "Failed to find configuration file, exception while fetching from %s: '%s'", message, t.toString());
         }
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilder.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilder.java
@@ -51,9 +51,9 @@ class JaxbAppInsightsConfigurationBuilder implements AppInsightsConfigurationBui
             return applicationInsights;
         } catch (JAXBException e) {
             if (e.getCause() != null) {
-                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to parse configuration file: '%s'", e.getCause().getMessage());
+                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to parse configuration file: '%s'", e.getCause().toString());
             } else {
-                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to parse configuration file: '%s'", e.getMessage());
+                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to parse configuration file: '%s'", e.toString());
             }
         } catch (NullPointerException e) {
             e.printStackTrace();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ReflectionUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ReflectionUtils.java
@@ -60,15 +60,15 @@ public final class ReflectionUtils {
 
             return instance;
         } catch (ClassCastException e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         } catch (ClassNotFoundException e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         } catch (InstantiationException e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         } catch (IllegalAccessException e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         } catch (Exception e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         }
 
         return null;
@@ -101,15 +101,15 @@ public final class ReflectionUtils {
             T instance = (T)clazzConstructor.newInstance(argument);
             return instance;
         } catch (ClassCastException e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         } catch (ClassNotFoundException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to create %s, %s", className, e.toString());
         } catch (InstantiationException e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         } catch (IllegalAccessException e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         } catch (Exception e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create %s, %s", className, e.toString());
         }
 
         return null;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -111,7 +111,7 @@ public enum TelemetryConfigurationFactory {
 
             initializeComponents(configuration);
         } catch (Exception e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to initialize configuration, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to initialize configuration, exception: %s", e.toString());
         }
     }
 
@@ -258,7 +258,7 @@ public enum TelemetryConfigurationFactory {
                 configuration.setInstrumentationKey(ikey);
             }
         } catch (Exception e) {
-            InternalLogger.INSTANCE.error("Failed to set instrumentation key: '%s'", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to set instrumentation key: '%s'", e.toString());
         }
     }
 
@@ -302,7 +302,7 @@ public enum TelemetryConfigurationFactory {
                     try {
                         awareModule.addConfigurationData(performanceConfigurationData);
                     } catch (Exception e) {
-                        InternalLogger.INSTANCE.error("Failed to add configuration data to performance module: '%s'", e.getMessage());
+                        InternalLogger.INSTANCE.error("Failed to add configuration data to performance module: '%s'", e.toString());
                     }
                 }
                 modules.add(module);
@@ -386,11 +386,11 @@ public enum TelemetryConfigurationFactory {
                         InternalLogger.INSTANCE.trace("Failed to register JMX performance counter '%s'", entry.getKey());
                     }
                 } catch (Exception e) {
-                    InternalLogger.INSTANCE.error("Failed to register JMX performance counter '%s': '%s'", entry.getKey(), e.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to register JMX performance counter '%s': '%s'", entry.getKey(), e.toString());
                 }
             }
         } catch (Exception e) {
-            InternalLogger.INSTANCE.error("Failed to register JMX performance counters: '%s'", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to register JMX performance counters: '%s'", e.toString());
         }
     }
 
@@ -425,7 +425,7 @@ public enum TelemetryConfigurationFactory {
             configuration.setChannel(channel);
             return true;
         } catch (Exception e) {
-            InternalLogger.INSTANCE.error("Failed to create InProcessTelemetryChannel, exception: %s, will create the default one with default arguments", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to create InProcessTelemetryChannel, exception: %s, will create the default one with default arguments", e.toString());
             TelemetryChannel channel = new InProcessTelemetryChannel();
             channel.setSampler(telemetrySampler);
             configuration.setChannel(channel);
@@ -444,11 +444,11 @@ public enum TelemetryConfigurationFactory {
         for (TelemetryProcessorXmlElement classData : classesFromConfigration) {
             TelemetryProcessor processor = creator.Create(classData);
             if (processor == null) {
-                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Processor " + classData.getType() + " failure during initialization");
+                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Processor %s failure during initialization", classData.getType());
                 continue;
             }
 
-            InternalLogger.INSTANCE.trace("Processor " + classData.getType() + " was added successfully");
+            InternalLogger.INSTANCE.trace("Processor %s was added successfully", classData.getType());
             list.add(processor);
         }
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorCreator.java
@@ -56,12 +56,12 @@ public final class TelemetryProcessorCreator {
                     for (String paramExcluded : confClass.getExcludedTypes().getExcludedType()) {
                         try {
                             if (!ReflectionUtils.activateMethod(processor, "addToExcludedType" , paramExcluded, String.class)) {
-                                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToExcludedType" + "failed, the class will not be used.");
+                                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "%s: method 'addToExcludedType' failed, the class will not be used.", confClass.getType());
                                 return null;
                             }
                         }
                         catch (Throwable t) {
-                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
+                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "%s: failed to activate method 'methodName', exception: %s, the class will not be used.", confClass.getType(), t.toString());
                             return null;
                         }
                     }
@@ -84,12 +84,12 @@ public final class TelemetryProcessorCreator {
                     for (String paramIncluded : confClass.getIncludedTypes().getIncludedType()) {
                         try {
                             if (!ReflectionUtils.activateMethod(processor, "addToIncludedType" , paramIncluded, String.class)) {
-                                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + "addToIncludeType" + "failed, the class will not be used.");
+                                InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "%s: method 'addToIncludeType' failed, the class will not be used.", confClass.getType());
                                 return null;
                             }
                         }
                         catch (Throwable t) {
-                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + "methodName" + ", exception: " + t.getMessage() + ", the class will not be used.");
+                            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "%s: failed to activate method 'methodName', exception: , the class will not be used.", confClass.getType(), t.toString());
                             return null;
                         }
                     }
@@ -107,16 +107,16 @@ public final class TelemetryProcessorCreator {
                 String methodName = "set" + param.getName();
                 try {
                     if (!ReflectionUtils.activateMethod(processor, methodName, param.getValue(), String.class)) {
-                        InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": method " + methodName + "failed, the class will not be used.");
+                        InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "%s: method %s failed, the class will not be used.", confClass.getType(), methodName);
                         return null;
                     }
                 } catch (Throwable t) {
-                    InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": failed to activate method " + methodName + ", exception: " + t.getMessage() + ", the class will not be used.");
+                    InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "%s: failed to activate method %s, exception: %s, the class will not be used.", confClass.getType(), methodName, t.toString());
                     return null;
                 }
             }
         } catch (Throwable throwable) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, confClass.getType() + ": unexpected exception while creating processor " + confClass.getType() + ", exception: " + throwable.getMessage() + ", the class will not be used.");
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "%s: unexpected exception while creating processor %s, exception: %s, the class will not be used.", confClass.getType(), confClass.getType(), throwable.toString());
             return null;
         }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/jmx/JmxDataFetcher.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/jmx/JmxDataFetcher.java
@@ -72,7 +72,7 @@ public class JmxDataFetcher {
                 Collection<Object> resultForAttribute = fetch(server, objects, attribute.name, attribute.type);
                 result.put(attribute.displayName, resultForAttribute);
             } catch (Exception e) {
-                InternalLogger.INSTANCE.error("Failed to fetch JMX object '%s' with attribute '%s': '%s'", objectName, attribute.name, e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to fetch JMX object '%s' with attribute '%s': '%s'", objectName, attribute.name, e.toString());
                 throw e;
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/logger/FileLoggerOutput.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/logger/FileLoggerOutput.java
@@ -153,7 +153,7 @@ public final class FileLoggerOutput implements LoggerOutput {
                 logFileProxy.writeLine(message);
             }
         } catch (IOException e) {
-            fallbackLoggerOutput.log(String.format("Failed to write to log to file exception: %s. Message '%s'", e.getMessage(), message));
+            fallbackLoggerOutput.log(String.format("Failed to write to log to file exception: %s. Message '%s'", e.toString(), message));
         }
     }
 
@@ -192,7 +192,7 @@ public final class FileLoggerOutput implements LoggerOutput {
                 currentLogger.close();
             } catch (IOException e) {
                 // Failed to close but that should not stop us
-                fallbackLoggerOutput.log(String.format("Failed to close log file, exception: %s", e.getMessage()));
+                fallbackLoggerOutput.log(String.format("Failed to close log file, exception: %s", e.toString()));
             }
         }
 
@@ -210,7 +210,7 @@ public final class FileLoggerOutput implements LoggerOutput {
                 currentLogger.delete();
             } catch (Exception e) {
                 // Failed to delete but that should not stop us
-                fallbackLoggerOutput.log(String.format("Failed to delete log file, exception: %s", e.getMessage()));
+                fallbackLoggerOutput.log(String.format("Failed to delete log file, exception: %s", e.toString()));
             }
         }
 
@@ -228,7 +228,7 @@ public final class FileLoggerOutput implements LoggerOutput {
             attachToExisting(oldLogs);
         } catch (Exception e) {
             // Failed to delete but that should not stop us
-            fallbackLoggerOutput.log(String.format("Failed to delete old log file, exception: %s", e.getMessage()));
+            fallbackLoggerOutput.log(String.format("Failed to delete old log file, exception: %s", e.toString()));
         }
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
@@ -262,7 +262,7 @@ public enum InternalLogger {
                 try {
                     loggerOutput = new FileLoggerOutput(loggerData);
                 } catch (Exception e) {
-                    onInitializationError(String.format("SDK Internal Logger internal error while initializing 'FILE': '%s'.", e.getMessage()));
+                    onInitializationError(String.format("SDK Internal Logger internal error while initializing 'FILE': '%s'.", e.toString()));
                 }
                 return;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
@@ -79,18 +79,18 @@ public abstract class AbstractJmxPerformanceCounter implements PerformanceCounte
                     try {
                         send(telemetryClient, displayAndValues.getKey(), value);
                     } catch (Exception e) {
-                        InternalLogger.INSTANCE.error("Error while sending JMX data: '%s'", e.getMessage());
+                        InternalLogger.INSTANCE.error("Error while sending JMX data: '%s'", e.toString());
                         InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
                     }
                 }
             }
         } catch (Exception e) {
             if (firstTime) {
-                InternalLogger.INSTANCE.error("Error while fetching JMX data: '%s', The PC will be ignored", e.getMessage());
+                InternalLogger.INSTANCE.error("Error while fetching JMX data: '%s', The PC will be ignored", e.toString());
                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
                 relevant = false;
             } else {
-                InternalLogger.INSTANCE.error("Error while fetching JMX data: '%s'", e.getMessage());
+                InternalLogger.INSTANCE.error("Error while fetching JMX data: '%s'", e.toString());
                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
             }
         } finally {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractPerformanceCounterModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractPerformanceCounterModule.java
@@ -51,7 +51,7 @@ public abstract class AbstractPerformanceCounterModule implements TelemetryModul
             try {
                 PerformanceCounterContainer.INSTANCE.register(performanceCounter);
             } catch (Throwable e) {
-                InternalLogger.INSTANCE.error("Failed to register performance counter '%s': '%s'", performanceCounter.getId(), e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to register performance counter '%s': '%s'", performanceCounter.getId(), e.toString());
                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxPerformanceCounter.java
@@ -112,7 +112,7 @@ public final class JmxPerformanceCounter implements PerformanceCounter {
                     value += Double.parseDouble(String.valueOf(obj));
                 } catch (Exception e) {
                     ok = false;
-                    InternalLogger.INSTANCE.error("Error while parsing JMX value for '%s:%s': '%s'", getId(), displayAndValues.getKey(), e.getMessage());
+                    InternalLogger.INSTANCE.error("Error while parsing JMX value for '%s:%s': '%s'", getId(), displayAndValues.getKey(), e.toString());
                     break;
                 }
             }
@@ -123,7 +123,7 @@ public final class JmxPerformanceCounter implements PerformanceCounter {
                     InternalLogger.INSTANCE.trace("JMX Metric: %s:%s: %s", telemetry.getCategoryName(), telemetry.getCounterName(), value);
                     telemetryClient.track(telemetry);
                 } catch (Exception e) {
-                    InternalLogger.INSTANCE.error("Error while sending JMX data for '%s': '%s'", getId(), e.getMessage());
+                    InternalLogger.INSTANCE.error("Error while sending JMX data for '%s': '%s'", getId(), e.toString());
                 }
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
@@ -78,7 +78,7 @@ public final class JniPCConnector {
         } catch (Throwable e) {
             InternalLogger.INSTANCE.error(
                 "Failed to load native dll, Windows performance counters will not be used. " +
-                "Please make sure that Visual C++ Redistributable is properly installed: %s.", e.getMessage());
+                "Please make sure that Visual C++ Redistributable is properly installed: %s.", e.toString());
 
             return false;
         }
@@ -190,14 +190,14 @@ public final class JniPCConnector {
                 try {
                     in.close();
                 } catch (IOException e) {
-                    InternalLogger.INSTANCE.error("Failed to close input stream for dll extraction: %s", e.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to close input stream for dll extraction: %s", e.toString());
                 }
             }
             if (out != null) {
                 try {
                     out.close();
                 } catch (IOException e) {
-                    InternalLogger.INSTANCE.error("Failed to close output stream for dll extraction: %s", e.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to close output stream for dll extraction: %s", e.toString());
                 }
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JvmPerformanceCountersFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JvmPerformanceCountersFactory.java
@@ -65,7 +65,7 @@ public class JvmPerformanceCountersFactory implements PerformanceCountersFactory
 
             pcs.add(dlpc);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create DeadLockDetector, exception: %s", t.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create DeadLockDetector, exception: %s", t.toString());
         }
     }
 
@@ -79,7 +79,7 @@ public class JvmPerformanceCountersFactory implements PerformanceCountersFactory
             JvmHeapMemoryUsedPerformanceCounter mpc = new JvmHeapMemoryUsedPerformanceCounter();
             pcs.add(mpc);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create JvmHeapMemoryUsedPerformanceCounter, exception: %s", t.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create JvmHeapMemoryUsedPerformanceCounter, exception: %s", t.toString());
         }
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/PerformanceCounterContainer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/PerformanceCounterContainer.java
@@ -234,7 +234,7 @@ public enum PerformanceCounterContainer implements Stoppable {
                             try {
                                 performanceCounter.report(telemetryClient);
                             } catch (Throwable e) {
-                                InternalLogger.INSTANCE.error("Exception while reporting performance counter '%s': '%s'", performanceCounter.getId(), e.getMessage());
+                                InternalLogger.INSTANCE.error("Exception while reporting performance counter '%s': '%s'", performanceCounter.getId(), e.toString());
                                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
                             }
                         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessBuiltInPerformanceCountersFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessBuiltInPerformanceCountersFactory.java
@@ -54,7 +54,7 @@ final class ProcessBuiltInPerformanceCountersFactory implements PerformanceCount
                 InternalLogger.INSTANCE.error("Unknown OS, performance counters are not created.");
             }
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.error("Error while creating performance counters: '%s'", t.getMessage());
+            InternalLogger.INSTANCE.error("Error while creating performance counters: '%s'", t.toString());
         }
 
         return Collections.emptyList();
@@ -100,14 +100,14 @@ final class ProcessBuiltInPerformanceCountersFactory implements PerformanceCount
                 windowsPCsData = null;
             }
         } catch (Throwable e) {
-            InternalLogger.INSTANCE.error("Failed to create WindowsPerformanceCounterAsMetric: '%s'", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to create WindowsPerformanceCounterAsMetric: '%s'", e.toString());
         }
 
         try {
             WindowsPerformanceCounterAsPC pcWindowsPCs = new WindowsPerformanceCounterAsPC();
             performanceCounters.add(pcWindowsPCs);
         } catch (Throwable e) {
-            InternalLogger.INSTANCE.error("Failed to create WindowsPerformanceCounterAsPC: '%s'", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to create WindowsPerformanceCounterAsPC: '%s'", e.toString());
         }
 
         return performanceCounters;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessCpuPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessCpuPerformanceCounter.java
@@ -42,7 +42,7 @@ final class ProcessCpuPerformanceCounter extends AbstractPerformanceCounter {
             cpuPerformanceCounterCalculator = new CpuPerformanceCounterCalculator();
         } catch (Throwable t) {
             cpuPerformanceCounterCalculator = null;
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create ProcessCpuPerformanceCounter: %s", t.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to create ProcessCpuPerformanceCounter: %s", t.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(t));
             throw new RuntimeException("Failed to create ProcessCpuPerformanceCounter");
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessPerformanceCountersModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessPerformanceCountersModule.java
@@ -85,7 +85,7 @@ public final class ProcessPerformanceCountersModule extends AbstractPerformanceC
 
                 configurationRequests.add(data);
             } catch (Throwable e) {
-                InternalLogger.INSTANCE.error("Failed to initialize Windows performance counter '%s'.", e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to initialize Windows performance counter '%s'.", e.toString());
             }
         }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOPerformanceCounter.java
@@ -98,14 +98,14 @@ final class UnixProcessIOPerformanceCounter extends AbstractUnixPerformanceCount
             result = parser.getValue();
         } catch (Exception e) {
             result = Constants.DEFAULT_DOUBLE_VALUE;
-            logError("Error while parsing file: '%s'", getId(), e.getMessage());
+            logError("Error while parsing file: '%s'", getId(), e.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         } finally {
             if (bufferedReader != null ) {
                 try {
                     bufferedReader.close();
                 } catch (Exception e) {
-                    logError("Error while closing file : '%s'", e.getMessage());
+                    logError("Error while closing file : '%s'", e.toString());
                     InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
                 }
             }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
@@ -99,14 +99,14 @@ final class UnixTotalCpuPerformanceCounter extends AbstractUnixPerformanceCounte
             bufferedReader = new BufferedReader(new FileReader(getProcessFile()));
             line = bufferedReader.readLine();
         } catch (Exception e) {
-            logError("Error while parsing file: '%s'", e.getMessage());
+            logError("Error while parsing file: '%s'", e.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         } finally {
             if (bufferedReader != null ) {
                 try {
                     bufferedReader.close();
                 } catch (Exception e) {
-                    logError("Error while closing file : '%s'", e.getMessage());
+                    logError("Error while closing file : '%s'", e.toString());
                     InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
                 }
             }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalMemoryPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalMemoryPerformanceCounter.java
@@ -77,13 +77,13 @@ final class UnixTotalMemoryPerformanceCounter extends AbstractUnixPerformanceCou
             result = reader.getValue() * KB;
         } catch (Exception e) {
             result = Constants.DEFAULT_DOUBLE_VALUE;
-            logError("Error while parsing file: '%s'", e.getMessage());
+            logError("Error while parsing file: '%s'", e.toString());
         } finally {
             if (bufferedReader != null ) {
                 try {
                     bufferedReader.close();
                 } catch (Exception e) {
-                    logError("Error while closing file : '%s'", e.getMessage());
+                    logError("Error while closing file : '%s'", e.toString());
                 }
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
@@ -86,7 +86,7 @@ public final class WindowsPerformanceCounterAsMetric extends AbstractWindowsPerf
                     InternalLogger.INSTANCE.trace("Sent metric performance counter for '%s': '%s'", entry.getValue(), value);
                 }
             } catch (Throwable e) {
-                InternalLogger.INSTANCE.error("Failed to send metric performance counter for '%s': '%s'", entry.getValue(), e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to send metric performance counter for '%s': '%s'", entry.getValue(), e.toString());
                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsPC.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsPC.java
@@ -78,7 +78,7 @@ public final class WindowsPerformanceCounterAsPC extends AbstractWindowsPerforma
                             pcData.displayName, pcData.categoryName, pcData.counterName, pcData.instanceName, value);
                 }
             } catch (Throwable e) {
-                InternalLogger.INSTANCE.error("Failed to send performance counter for '%s': '%s'", entry.getValue().displayName, e.getMessage());
+                InternalLogger.INSTANCE.error("Failed to send performance counter for '%s': '%s'", entry.getValue().displayName, e.toString());
                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterData.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterData.java
@@ -65,7 +65,7 @@ public final class WindowsPerformanceCounterData {
             translatedInstanceName = JniPCConnector.translateInstanceName(instanceName);
             this.instanceName = translatedInstanceName;
         } catch (Throwable e) {
-            InternalLogger.INSTANCE.error("Failed to translate instance name '%s': '%s'", instanceName, e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to translate instance name '%s': '%s'", instanceName, e.toString());
             throw e;
         }
         return this;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/processor/PageViewTelemetryFilter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/processor/PageViewTelemetryFilter.java
@@ -128,9 +128,9 @@ public final class PageViewTelemetryFilter implements TelemetryProcessor {
 
                 this.notNeededUrls.add(ready);
             }
-            InternalLogger.INSTANCE.trace("PageViewTelemetryFilter: set " + notNeededUrls);
+            InternalLogger.INSTANCE.trace("PageViewTelemetryFilter: set %s", notNeededUrls);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "PageViewTelemetryFilter: failed to parse NotNeededUrls: " + notNeededUrls);
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "PageViewTelemetryFilter: failed to parse NotNeededUrls: %s", notNeededUrls);
             throw t;
         }
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/processor/RequestTelemetryFilter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/processor/RequestTelemetryFilter.java
@@ -105,9 +105,9 @@ public final class RequestTelemetryFilter implements TelemetryProcessor {
     public void setMinimumDurationInMS(String minimumDurationInMS) throws Throwable {
         try {
             this.minimumDurationInMS = Long.valueOf(minimumDurationInMS);
-            InternalLogger.INSTANCE.trace("RequestTelemetryFilter: successfully set MinimumDurationInMS " + this.minimumDurationInMS);
+            InternalLogger.INSTANCE.trace("RequestTelemetryFilter: successfully set MinimumDurationInMS = %d", this.minimumDurationInMS);
         } catch (Throwable e) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "RequestTelemetryFilter: failed to set minimum duration " + minimumDurationInMS);
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "RequestTelemetryFilter: failed to set minimum duration: %s", minimumDurationInMS);
             throw e;
         }
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/shutdown/SDKShutdownActivity.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/shutdown/SDKShutdownActivity.java
@@ -100,7 +100,7 @@ public enum SDKShutdownActivity {
                         channelToStop.stop(1L, TimeUnit.SECONDS);
                     }
                 } catch (Throwable t) {
-                    InternalLogger.INSTANCE.error("Failed to stop channel: '%s'", t.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to stop channel: '%s'", t.toString());
                     InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(t));
                 }
             }
@@ -113,7 +113,7 @@ public enum SDKShutdownActivity {
                 try {
                     stoppable.stop(1L, TimeUnit.SECONDS);
                 } catch (Throwable t) {
-                    InternalLogger.INSTANCE.error("Failed to stop stoppable class '%s': '%s'", stoppable.getClass().getName(), t.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to stop stoppable class '%s': '%s'", stoppable.getClass().getName(), t.toString());
                     InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(t));
                 }
             }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/system/SystemInformation.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/system/SystemInformation.java
@@ -66,7 +66,7 @@ public enum SystemInformation {
                     processId = processIdAsString;
                     return;
                 } catch (Exception e) {
-                    InternalLogger.INSTANCE.error("Failed to fetch process id: '%s'", e.getMessage());
+                    InternalLogger.INSTANCE.error("Failed to fetch process id: '%s'", e.toString());
                 }
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/DeviceInfo.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/DeviceInfo.java
@@ -65,7 +65,7 @@ public class DeviceInfo
         }
         catch (UnknownHostException e)
         {
-            InternalLogger.INSTANCE.error("Failed to get canonical host name, exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to get canonical host name, exception: %s", e.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         }
         return null;

--- a/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/ApplicationInsightsAppender.java
+++ b/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/ApplicationInsightsAppender.java
@@ -107,7 +107,7 @@ public class ApplicationInsightsAppender extends AppenderSkeleton {
         } catch (Exception e) {
             // Appender failure must not fail the running application.
             this.isInitialized = false;
-            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s.", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s.", e.toString());
         }
     }
 

--- a/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppender.java
+++ b/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppender.java
@@ -116,8 +116,7 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         } catch (Exception e) {
             // Appender failure must not fail the running application.
             this.isInitialized = false;
-            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s. " +
-                    " Generated Stack trace is %s.", e.getMessage(), ExceptionUtils.getStackTrace(e));
+            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s. Generated Stack trace is %s.", e.toString(), ExceptionUtils.getStackTrace(e));
         }
     }
 
@@ -140,8 +139,7 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         } catch (Exception e) {
             // Appender failure must not fail the running application.
             this.isInitialized = false;
-            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s. " +
-                    " Generated Stack trace is %s.", e.getMessage(), ExceptionUtils.getStackTrace(e));
+            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s. Generated Stack trace is %s.", e.toString(), ExceptionUtils.getStackTrace(e));
         }
     }
 

--- a/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/ApplicationInsightsAppender.java
+++ b/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/ApplicationInsightsAppender.java
@@ -85,7 +85,7 @@ public class ApplicationInsightsAppender extends AppenderBase<ILoggingEvent> {
         } catch (Exception e) {
             // Appender failure must not fail the running application.
             this.isInitialized = false;
-            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s.", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to initialize appender with exception: %s.", e.toString());
         }
     }
 }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -100,7 +100,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
 
         } catch (Exception e) {
             String moduleClassName = this.getClass().getSimpleName();
-            InternalLogger.INSTANCE.error("Telemetry module " + moduleClassName + " onBeginRequest failed with exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Telemetry module %s onBeginRequest failed with exception: %s", moduleClassName, e.toString());
         }
     }
 
@@ -139,7 +139,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
             telemetryClient.track(telemetry);
         } catch (Exception e) {
             String moduleClassName = this.getClass().getSimpleName();
-            InternalLogger.INSTANCE.error("Telemetry module " + moduleClassName + " onEndRequest failed with exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.error("Telemetry module %s onEndRequest failed with exception: %s", moduleClassName, e.toString());
         }
     }
 
@@ -160,8 +160,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
 
             isInitialized = true;
         } catch (Exception e) {
-            InternalLogger.INSTANCE.error(
-                    "Failed to initialize telemetry module " + this.getClass().getSimpleName() + ". Exception: %s.", e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to initialize telemetry module %s. Exception: %s.", this.getClass().getSimpleName(), e.toString());
         }
     }
 

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebModulesContainer.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebModulesContainer.java
@@ -58,8 +58,7 @@ public class WebModulesContainer {
             try {
                 module.onBeginRequest(req, res);
             } catch (Exception e) {
-                InternalLogger.INSTANCE.error(
-                        "Web module " + module.getClass().getSimpleName() + " failed on BeginRequest with exception: %s", e.getMessage());
+                InternalLogger.INSTANCE.error("Web module %s failed on BeginRequest with exception: %s", module.getClass().getSimpleName(), e.toString());
                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
             }
         }
@@ -75,8 +74,7 @@ public class WebModulesContainer {
             try {
                 module.onEndRequest(req, res);
             } catch (Exception e) {
-                InternalLogger.INSTANCE.error(
-                        "Web module " + module.getClass().getSimpleName() + " failed on EndRequest with exception: %s", e.getMessage());
+                InternalLogger.INSTANCE.error("Web module %s failed on EndRequest with exception: %s",module.getClass().getSimpleName(), e.toString());
                 InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
             }
         }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -113,7 +113,7 @@ public final class WebRequestTrackingFilter implements Filter {
 
     private void onException(Exception e, ServletRequest req, ServletResponse res, boolean isRequestProcessedSuccessfully) {
         try {
-            InternalLogger.INSTANCE.trace("Unhandled application exception: %s", e.getMessage());
+            InternalLogger.INSTANCE.trace("Unhandled application exception: %s", e.toString());
             if (telemetryClient != null) {
                 telemetryClient.trackException(e);
             }
@@ -146,7 +146,7 @@ public final class WebRequestTrackingFilter implements Filter {
             String filterName = this.getClass().getSimpleName();
             InternalLogger.INSTANCE.info(
                     "Application Insights filter %s has been failed to initialized.\n" +
-                            "Web request tracking filter will be disabled. Exception: %s", filterName, e.getMessage());
+                            "Web request tracking filter will be disabled. Exception: %s", filterName, e.toString());
         }
     }
 
@@ -174,7 +174,7 @@ public final class WebRequestTrackingFilter implements Filter {
             webModulesContainer.invokeOnBeginRequest(req, res);
         } catch (Exception e) {
             InternalLogger.INSTANCE.error(
-                    "Failed to invoke OnBeginRequest on telemetry modules with the following exception: %s", e.getMessage());
+                    "Failed to invoke OnBeginRequest on telemetry modules with the following exception: %s", e.toString());
 
             success = false;
         }
@@ -189,7 +189,7 @@ public final class WebRequestTrackingFilter implements Filter {
             }
         } catch (Exception e) {
             InternalLogger.INSTANCE.error(
-                    "Failed to invoke OnEndRequest on telemetry modules with the following exception: %s", e.getMessage());
+                    "Failed to invoke OnEndRequest on telemetry modules with the following exception: %s", e.toString());
         }
     }
 
@@ -203,7 +203,7 @@ public final class WebRequestTrackingFilter implements Filter {
 
                     // This means that the Agent is not present and therefore we will stop trying
                     agentIsUp = false;
-                    InternalLogger.INSTANCE.error("setKeyOnTLS: Failed to find AgentTLS: '%s'", e.getMessage());
+                    InternalLogger.INSTANCE.error("setKeyOnTLS: Failed to find AgentTLS: '%s'", e.toString());
                 }
             }
         }
@@ -232,7 +232,7 @@ public final class WebRequestTrackingFilter implements Filter {
 
             InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.INFO, "Successfully registered the filter '%s'", FILTER_NAME);
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to register '%s', exception: '%s'", FILTER_NAME, t.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Failed to register '%s', exception: '%s'", FILTER_NAME, t.toString());
         }
     }
 
@@ -287,7 +287,7 @@ public final class WebRequestTrackingFilter implements Filter {
                 name = contextPath.substring(1);
             }
         } catch (Throwable t) {
-            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Exception while fetching WebApp name: '%s'", t.getMessage());
+            InternalLogger.INSTANCE.logAlways(InternalLogger.LoggingLevel.ERROR, "Exception while fetching WebApp name: '%s'", t.toString());
         }
         appName = name;
         return name;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/Cookie.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/Cookie.java
@@ -75,7 +75,7 @@ public class Cookie {
         try {
             instance = eClass.getConstructor(javax.servlet.http.Cookie.class).newInstance(httpCookie);
         } catch (Exception e) {
-            InternalLogger.INSTANCE.error("Failed to create %s cookie with error: %s", cookieName, e.getMessage());
+            InternalLogger.INSTANCE.error("Failed to create %s cookie with error: %s", cookieName, e.toString());
         }
 
         return instance;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/SessionCookie.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/SessionCookie.java
@@ -175,7 +175,7 @@ public class SessionCookie extends com.microsoft.applicationinsights.web.interna
             acquisitionDate = parseDateWithBackwardCompatibility(split[CookieFields.SESSION_ACQUISITION_DATE.getValue()]);
             renewalDate = parseDateWithBackwardCompatibility(split[CookieFields.SESSION_LAST_UPDATE_DATE.getValue()]);
         } catch (Exception e) {
-            String errorMessage = String.format("Failed to parse session cookie with exception: %s", e.getMessage());
+            String errorMessage = String.format("Failed to parse session cookie with exception: %s", e.toString());
 
             // TODO: dedicated exception
             throw new Exception(errorMessage);

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/UserCookie.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/cookies/UserCookie.java
@@ -106,7 +106,7 @@ public class UserCookie extends com.microsoft.applicationinsights.web.internal.c
             userId = split[CookieFields.USER_ID.getValue()];
             acquisitionDate = DateTimeUtils.parseRoundTripDateString(split[CookieFields.ACQUISITION_DATE.getValue()]);
         } catch (Exception e) {
-            String errorMessage = String.format("Failed to parse user cookie with exception: %s", e.getMessage());
+            String errorMessage = String.format("Failed to parse user cookie with exception: %s", e.toString());
 
             // TODO: dedicated exception
             throw new Exception(errorMessage);

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
@@ -98,7 +98,7 @@ public class TelemetryCorrelationUtils {
 			addTargetAppIdForResponseHeader(response);
 		}
 		catch(Exception ex) {
-			InternalLogger.INSTANCE.error("Failed to resolve correlation. Exception information: " + ex);
+			InternalLogger.INSTANCE.error("Failed to resolve correlation. Exception information: %s", ex.toString());
 			InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(ex));
 		}
 	}
@@ -125,7 +125,7 @@ public class TelemetryCorrelationUtils {
 			return requestTelemetry.getId() + context.incrementChildId() + ".";
 		}
 		catch (Exception ex) {
-			InternalLogger.INSTANCE.error("Failed to generate child ID. Exception information: " + ex);
+			InternalLogger.INSTANCE.error("Failed to generate child ID. Exception information: %s", ex.toString());
 			InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(ex));
 		}
 
@@ -213,7 +213,7 @@ public class TelemetryCorrelationUtils {
 
 			String requestContext = request.getHeader(REQUEST_CONTEXT_HEADER_NAME);
 			if (requestContext == null || requestContext.isEmpty()) {
-				InternalLogger.INSTANCE.info("Skip resolving request source as the following header was not found: " + REQUEST_CONTEXT_HEADER_NAME);
+				InternalLogger.INSTANCE.info("Skip resolving request source as the following header was not found: %s", REQUEST_CONTEXT_HEADER_NAME);
 				return;
 			}
 
@@ -226,7 +226,7 @@ public class TelemetryCorrelationUtils {
 			requestTelemetry.setSource(source);
 		}
 		catch(Exception ex) {
-			InternalLogger.INSTANCE.error("Failed to resolve request source. Exception information: " + ex);
+			InternalLogger.INSTANCE.error("Failed to resolve request source. Exception information: %s", ex.toString());
 			InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(ex));
 		}
 	}
@@ -252,7 +252,7 @@ public class TelemetryCorrelationUtils {
 		Enumeration<String> baggages = request.getHeaders(CORRELATION_CONTEXT_HEADER_NAME);
 
 		if (baggages == null) {
-			InternalLogger.INSTANCE.warn("Could not access header information: " + CORRELATION_CONTEXT_HEADER_NAME);
+			InternalLogger.INSTANCE.warn("Could not access header information: %s", CORRELATION_CONTEXT_HEADER_NAME);
 			return;
 		}
 

--- a/web/src/main/java/com/microsoft/applicationinsights/web/javaee/RequestNameInterceptor.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/javaee/RequestNameInterceptor.java
@@ -58,7 +58,7 @@ public class RequestNameInterceptor {
             InternalLogger.INSTANCE.error(
                     "Failed to invoke interceptor '%s' with exception: %s.",
                     this.getClass().getSimpleName(),
-                    e.getMessage());
+                    e.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         }
     }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/spring/RequestNameHandlerInterceptorAdapter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/spring/RequestNameHandlerInterceptorAdapter.java
@@ -68,7 +68,7 @@ public class RequestNameHandlerInterceptorAdapter extends HandlerInterceptorAdap
             InternalLogger.INSTANCE.error(
                 "Failed to invoke interceptor '%s' with exception: %s.",
                 this.getClass().getSimpleName(),
-                e.getMessage());
+                e.toString());
         }
 
         return true;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/struts/RequestNameInterceptor.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/struts/RequestNameInterceptor.java
@@ -91,7 +91,7 @@ public class RequestNameInterceptor implements Interceptor {
             InternalLogger.INSTANCE.error(
                     "Failed to invoke interceptor '%s' with exception: %s.",
                     this.getClass().getSimpleName(),
-                    e.getMessage());
+                    e.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         }
     }


### PR DESCRIPTION
Got an error from the agent thrown from String.format because 'F' was not a recognized format string token. This is because it was printing a URL encoded string, which had "Program%20Files" in the text. This caused the error.

So, we should _always_ be using format strings in the logger to prevent this kind of issue.

Also, use `Throwable.toString()` instead of `getMessage()` because it provides the exception name in addition to its message. [See here](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/lang/Throwable.java#Throwable.toString%28%29)