### PR TITLE
minor fixes for specifying custom applciationinsights jars for smoke tests

### DIFF
--- a/test/smoke/build.gradle
+++ b/test/smoke/build.gradle
@@ -10,9 +10,18 @@ allprojects {
 
 subprojects {
 	ext {
+		/* 	
+			By default, the Applciation Insights jars are built and used by the smokeTests.
+			To use different jars for smokeTests, reassign these variables to point the path to the jar using this 'files' function.
+			For example,
+				aiCoreJar = files('c:\\core_jar_from_previous_build\\applicationinsights-core-vSomething.jar')
+		*/
 		aiAgentJar = project(':agent')
 		aiCoreJar = project(':core')
 		aiWebJar =  project(':web')
+		aiLog4j1_2Jar = project(':logging:log4j1_2')
+		aiLo4j2Jar = project(':logging:log4j2')
+		aiLogbackJar = project(':logging:logback')
 	}
 }
 

--- a/test/smoke/framework/testCases/build.gradle
+++ b/test/smoke/framework/testCases/build.gradle
@@ -5,6 +5,7 @@ repositories {
 }
 
 dependencies {
+	compile 'com.google.guava:guava:20.0'
 	compile aiCoreJar
 }
 

--- a/test/smoke/framework/utils/build.gradle
+++ b/test/smoke/framework/utils/build.gradle
@@ -7,6 +7,7 @@ repositories {
 dependencies {
 	compile 'com.google.code.gson:gson:2.8.2'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
+	compile 'com.google.guava:guava:20.0'
 	compile aiCoreJar
 
 	testCompile 'junit:junit:4.12'

--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -3,12 +3,6 @@ apply plugin: 'base'
 subprojects {
 	apply plugin: 'java'
 
-	ext {
-		aiAgentJar = project(':agent')
-		aiCoreJar = project(':core')
-		aiWebJar =  project(':web')
-	}
-
 	repositories {
 		jcenter()
 		mavenCentral()


### PR DESCRIPTION
Overview of issues:
_variables were defined twice:_ opted to use parent project definitions. this scenario is also dependent on it being defined in one place.
_guava missing from test dependencies:_ Since we re-namespace the guava dependency, it needs to be named here also so these still work when custom jars are used.
