### PR TITLE
Fixed javadocs tags, that caused build errors

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmissionHandler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmissionHandler.java
@@ -3,10 +3,9 @@ package com.microsoft.applicationinsights.internal.channel;
 /**
  * An interface that is used to create a concrete class that is called by the the {@link TransmissionHandlerObserver}
  * <p>
- * This is used to implement classes like {@link ErrorHandler} and {@link PartialSuccessHandler}.
+ * This is used to implement classes like {@link com.microsoft.applicationinsights.internal.channel.common.ErrorHandler}
+ * and {@link com.microsoft.applicationinsights.internal.channel.common.PartialSuccessHandler}.
  * @author jamdavi
- * 
- * 
  */
 public interface TransmissionHandler {
 	/**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmissionHandlerArgs.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmissionHandlerArgs.java
@@ -7,7 +7,7 @@ import com.microsoft.applicationinsights.internal.channel.common.Transmission;
 /**
  * This class is used to store information between the transmission sender and the transmission handlers
  * <p>
- * An example class that uses this are {@link ErrorHandler}
+ * An example class that uses this are {@link com.microsoft.applicationinsights.internal.channel.common.ErrorHandler}
  * @author jamdavi
  *
  */

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmissionHandlerObserver.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmissionHandlerObserver.java
@@ -2,16 +2,17 @@ package com.microsoft.applicationinsights.internal.channel;
 
 
 /**
- * Enables the {@link TransmissionPolicyManager} to handle transmission states.
+ * Enables the {@link com.microsoft.applicationinsights.internal.channel.common.TransmissionPolicyManager} to handle transmission states.
  * <p>
- * This interface extends {@TransmissionHandler} to add the ability to observe when the transmission is completed.
+ * This interface extends {@link TransmissionHandler} to add the ability to observe when the transmission is completed.
  * @author jamdavi
  *
  */
 public interface TransmissionHandlerObserver extends TransmissionHandler {
 	
 	/**
-	 * Used to add a {@link TransmissionHandler} to the collection stored by the {@link TransmissionPolicyManager}
+	 * Used to add a {@link TransmissionHandler} to the collection stored by the 
+     * {@link com.microsoft.applicationinsights.internal.channel.common.TransmissionPolicyManager}.
 	 * @param handler	The handler to add to the collection.
 	 */
 	void addTransmissionHandler(TransmissionHandler handler);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmitterFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/TransmitterFactory.java
@@ -26,7 +26,7 @@ package com.microsoft.applicationinsights.internal.channel;
  */
 public interface TransmitterFactory {
 	/** 
-	 * Creates the {@link TelemetriesTransmitter} for use by the {@link TelemetryChannel}
+	 * Creates the {@link TelemetriesTransmitter} for use by the {@link com.microsoft.applicationinsights.channel.TelemetryChannel}
 	 * @param endpoint HTTP Endpoint to send telemetry to
 	 * @param maxTransmissionStorageCapacity Max amount of disk space in KB for persistent storage to use
 	 * @param throttlingIsEnabled Allow the network telemetry sender to be throttled 
@@ -34,7 +34,7 @@ public interface TransmitterFactory {
 	 */
     TelemetriesTransmitter create(String endpoint, String maxTransmissionStorageCapacity, boolean throttlingIsEnabled);
 	/** 
-	 * Creates the {@link TelemetriesTransmitter} for use by the {@link TelemetryChannel}
+	 * Creates the {@link TelemetriesTransmitter} for use by the {@link com.microsoft.applicationinsights.channel.TelemetryChannel}
 	 * @param endpoint HTTP Endpoint to send telemetry to
 	 * @param maxTransmissionStorageCapacity Max amount of disk space in KB for persistent storage to use
 	 * @param throttlingIsEnabled Allow the network telemetry sender to be throttled 


### PR DESCRIPTION
Fixed javadocs tags, that caused build errors while executing `javadoc` gradle task

**P.S.** do I need issue and CHANGELOG for this tiny fix?
