### PR TITLE
Adding test case for PageView

### DIFF
--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -189,7 +189,9 @@ tasks.withType(Test) {
             events  TestLogEvent.FAILED,
                     TestLogEvent.PASSED,
                     TestLogEvent.SKIPPED,
-                    TestLogEvent.STANDARD_ERROR
+                    TestLogEvent.STANDARD_ERROR,
+                    TestLogEvent.STARTED,
+                    TestLogEvent.STANDARD_OUT
 
             exceptionFormat TestExceptionFormat.FULL
             showExceptions true
@@ -199,8 +201,6 @@ tasks.withType(Test) {
 
         debug {
             events = info.events
-            events << TestLogEvent.STARTED
-            events << TestLogEvent.STANDARD_OUT
             
             exceptionFormat = info.exceptionFormat
             showExceptions = info.showExceptions

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -189,9 +189,7 @@ tasks.withType(Test) {
             events  TestLogEvent.FAILED,
                     TestLogEvent.PASSED,
                     TestLogEvent.SKIPPED,
-                    TestLogEvent.STANDARD_ERROR,
-                    TestLogEvent.STARTED,
-                    TestLogEvent.STANDARD_OUT
+                    TestLogEvent.STANDARD_ERROR
 
             exceptionFormat TestExceptionFormat.FULL
             showExceptions true
@@ -201,6 +199,8 @@ tasks.withType(Test) {
 
         debug {
             events = info.events
+            events << TestLogEvent.STARTED
+            events << TestLogEvent.STANDARD_OUT
             
             exceptionFormat = info.exceptionFormat
             showExceptions = info.showExceptions

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/JsonHelper.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/JsonHelper.java
@@ -19,6 +19,7 @@ import com.microsoft.applicationinsights.internal.schemav2.EventData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
 import com.microsoft.applicationinsights.internal.schemav2.MetricData;
+import com.microsoft.applicationinsights.internal.schemav2.PageViewData;
 import com.microsoft.applicationinsights.internal.schemav2.PerformanceCounterData;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
@@ -51,7 +52,8 @@ public class JsonHelper {
 				MetricData.class,
 				RemoteDependencyData.class,
 				PerformanceCounterData.class,
-				SessionStateData.class
+				SessionStateData.class,
+				PageViewData.class
 			};
 
 			for (Class<? extends Domain> clazz : classes) {

--- a/test/smoke/testApps/CoreAndFilter/src/main/java/com/microsoft/ajl/simplecalc/SimpleTrackPageViewServlet.java
+++ b/test/smoke/testApps/CoreAndFilter/src/main/java/com/microsoft/ajl/simplecalc/SimpleTrackPageViewServlet.java
@@ -1,0 +1,37 @@
+package com.microsoft.ajl.simplecalc;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.PageViewTelemetry;
+
+/**
+ * Servlet implementation class SimpleTrackTraceServlet
+ */
+@WebServlet(description = "calls trackPageView twice; once vanilla, once with properties", urlPatterns = { "/trackPageView" })
+public class SimpleTrackPageViewServlet extends HttpServlet {
+    private static final long serialVersionUID = -633683109556605395L;
+    private TelemetryClient client = new TelemetryClient();
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        client.trackPageView("test-page");
+        
+        PageViewTelemetry pvt = new PageViewTelemetry("test-page-2");
+        pvt.getProperties().put("key", "value");
+        pvt.setDuration(123456);
+        client.trackPageView(pvt);
+
+        ServletFuncs.geRrenderHtml(request, response);
+    }
+}

--- a/test/smoke/testApps/CoreAndFilter/src/main/webapp/doPageView.jsp
+++ b/test/smoke/testApps/CoreAndFilter/src/main/webapp/doPageView.jsp
@@ -1,0 +1,17 @@
+<%@page import="com.microsoft.applicationinsights.TelemetryClient"%>
+
+<%@page pageEncoding="UTF-8" contentType="text/html;charset=UTF-8"%>
+
+<!DOCTYPE html>
+<html>
+<head>
+<title>Simple Telemetry</title>
+</head>
+<body>
+	<h1>trackPageView Test</h1>
+	<%
+		TelemetryClient tc = new TelemetryClient();
+		tc.trackPageView("doPageView");
+	%>
+</body>
+</html>

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -7,6 +7,7 @@ import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
 import com.microsoft.applicationinsights.internal.schemav2.MetricData;
+import com.microsoft.applicationinsights.internal.schemav2.PageViewData;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
@@ -193,5 +194,32 @@ public class CoreAndFilterTests extends AiSmokeTest {
 		assertEquals(expectedMessage3, d3.getMessage());
 		assertEquals(SeverityLevel.Information, d3.getSeverityLevel());
 		assertEquals(expectedValue, d3.getProperties().get("key"));
-	}
+    }
+    
+    @Test
+    @TargetUri("/trackPageView")
+    public void testTrackPageView() {
+        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        assertEquals(2, mockedIngestion.getCountForType("PageViewData"));
+        
+        PageViewData pv1 = getTelemetryDataForType(0, "PageViewData");
+        assertEquals("test-page", pv1.getName());
+        assertEquals(new Duration(0), pv1.getDuration());
+
+        PageViewData pv2 = getTelemetryDataForType(1, "PageViewData");
+        assertEquals("test-page-2", pv2.getName());
+        assertEquals(new Duration(123456), pv2.getDuration());
+        assertEquals("value", pv2.getProperties().get("key"));
+    }
+
+    @Test
+    @TargetUri("/doPageView.jsp")
+    public void testTrackPageView_JSP() {
+        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        assertEquals(1, mockedIngestion.getCountForType("PageViewData"));
+        
+        PageViewData pv1 = getTelemetryDataForType(0, "PageViewData");
+        assertEquals("doPageView", pv1.getName());
+        assertEquals(new Duration(0), pv1.getDuration());
+    }
 }

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/resources/appServers.txt
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/resources/appServers.txt
@@ -1,3 +1,4 @@
 jbosseap7
 tomcat7
 tomcat8
+tomcat85

--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -75,7 +75,7 @@ subprojects {
 		reports.html.destination = file("${reporting.baseDir}/${name}")
 
 		testLogging {
-			events 'FAILED', 'PASSED', 'SKIPPED', 'STANDARD_OUT', 'STANDARD_ERROR'
+			events 'FAILED', 'PASSED', 'SKIPPED', 'STANDARD_OUT', 'STANDARD_ERROR', 'STARTED'
 			exceptionFormat 'FULL'
 			showExceptions true
 			showCauses true


### PR DESCRIPTION
In addition to the test:

* This also includes adding tomcat 8.5 to test envs (missing from previous PR)
* Included `STARTED` event in smoketests so it's clear when the test method has started in the logs
* Fixed deserialization code in smoke tests to support PageViewData