### PR TITLE
Fix Status Code in RequestTelemetry when Servlet Throws Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
-## Version 2.0.1
+## Version 2.0.2
+- Fix #600 where RequestTelemetry has 200 whereas browser shows 500 (when servlet throws)
 - Fix issue when dependency start time wasn't being recorded correctly
 - Fixed #533 HTTP Dependency Telemetry now matches with .NET SDK
 - Introduced public method `httpMethodFinishedWithPath(String identifier, String method, String path, String correlationId, String uri, String target, int result, long delta)`
@@ -12,6 +13,9 @@
 - Fixed PageView telemetry data not being reported. 
 - Fixed Issue #526 (NPE in MapUtil.copy())
 - Fixed Issue #513 (Memory leak in SDKShutdownActivity). This fix upgrades our Servlet version from 2.5 to 3.0. The SDK must now be run on an application server supporting Servlet 3.0.
+
+## Version 2.0.1
+-Fix Inconsistency in artifact names in POM files
 
 ## Version 2.0.0
 - Upgraded logback dependency version to 1.2.3

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testCompile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.1'
     testCompile group: 'org.json', name:'json', version:'20090211'
     testCompile group: 'com.microsoft.azure', name: 'azure-storage', version: '2.1.0'
+    testCompile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 }
 
 shadowJar {

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -39,7 +39,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Date;
 
-//import org.apache.http.HttpStatus;
 
 /**
  * Created by yonisha on 2/2/2015.

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -21,16 +21,9 @@
 
 package com.microsoft.applicationinsights.web.extensibility.modules;
 
-import java.util.Date;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import com.microsoft.applicationinsights.common.CommonUtils;
-//import org.apache.http.HttpStatus;
-import com.microsoft.applicationinsights.web.internal.ApplicationInsightsHttpResponseWrapper;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.common.CommonUtils;
 import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.telemetry.Duration;
@@ -39,6 +32,14 @@ import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
 import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.correlation.InstrumentationKeyResolver;
 import com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
+
+//import org.apache.http.HttpStatus;
 
 /**
  * Created by yonisha on 2/2/2015.
@@ -123,7 +124,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
 
             long endTime = new Date().getTime();
 
-            ApplicationInsightsHttpResponseWrapper response = ((ApplicationInsightsHttpResponseWrapper)res);
+            HttpServletResponse response = (HttpServletResponse)res;
             if (response != null) {
                 telemetry.setSuccess(response.getStatus() < 400 || response.getStatus() == 401 );
                 telemetry.setResponseCode(Integer.toString(response.getStatus()));

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsHttpResponseWrapper.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsHttpResponseWrapper.java
@@ -26,10 +26,12 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.IOException;
 
 /**
+ * @deprecated No longer needed as library has upgraded to Servlet API 3.0.1
  * This class wraps the HTTP servlet response in order to store the response status code.
  * This wrapper is used to support servlet API 2.5, which lacks the api to get response status.
  * Created by yonisha on 5/27/2015.
  */
+@Deprecated
 public class ApplicationInsightsHttpResponseWrapper extends HttpServletResponseWrapper {
 
     private int httpStatusCode = SC_OK;

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsHttpResponseWrapperTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsHttpResponseWrapperTests.java
@@ -23,6 +23,7 @@ package com.microsoft.applicationinsights.web.internal;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletResponse;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Created by yonisha on 5/27/2015.
  */
+@Ignore
 public class ApplicationInsightsHttpResponseWrapperTests {
 
     private HttpServletResponse responseMock = mock(HttpServletResponse.class);

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
@@ -22,19 +22,20 @@
 package com.microsoft.applicationinsights.web.internal;
 
 import com.microsoft.applicationinsights.TelemetryClient;
-import com.microsoft.applicationinsights.internal.reflect.ClassDataUtils;
-import com.microsoft.applicationinsights.internal.reflect.ClassDataVerifier;
+import com.microsoft.applicationinsights.web.utils.ServletUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import com.microsoft.applicationinsights.web.utils.ServletUtils;
 
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
@@ -94,7 +95,7 @@ public class WebRequestTrackingFilterTests {
 
         FilterChain chain = mock(FilterChain.class);
 
-        HttpServletRequest request = ServletUtils.generateDummyServletRequest();
+        ServletRequest request = ServletUtils.generateDummyServletRequest();
 
         // execute
         filter.doFilter(request, ServletUtils.generateDummyServletResponse(), chain);
@@ -164,8 +165,8 @@ public class WebRequestTrackingFilterTests {
         try {
             FilterChain chain = mock(FilterChain.class);
 
-            HttpServletRequest request = ServletUtils.generateDummyServletRequest();
-            HttpServletResponse response = ServletUtils.generateDummyServletResponse();
+            HttpServletRequest request = (HttpServletRequest) ServletUtils.generateDummyServletRequest();
+            HttpServletResponse response = (HttpServletResponse) ServletUtils.generateDummyServletResponse();
             Mockito.doThrow(expectedException).when(chain).doFilter(eq(request), any(ServletResponse.class));
 
             // execute

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
@@ -34,8 +34,6 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
@@ -165,8 +163,8 @@ public class WebRequestTrackingFilterTests {
         try {
             FilterChain chain = mock(FilterChain.class);
 
-            HttpServletRequest request = (HttpServletRequest) ServletUtils.generateDummyServletRequest();
-            HttpServletResponse response = (HttpServletResponse) ServletUtils.generateDummyServletResponse();
+            ServletRequest request =  ServletUtils.generateDummyServletRequest();
+            ServletResponse response = ServletUtils.generateDummyServletResponse();
             Mockito.doThrow(expectedException).when(chain).doFilter(eq(request), any(ServletResponse.class));
 
             // execute

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
@@ -27,6 +27,7 @@ import com.microsoft.applicationinsights.internal.reflect.ClassDataVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.mockito.Mockito;
@@ -93,7 +94,7 @@ public class WebRequestTrackingFilterTests {
 
         FilterChain chain = mock(FilterChain.class);
 
-        ServletRequest request = ServletUtils.generateDummyServletRequest();
+        HttpServletRequest request = ServletUtils.generateDummyServletRequest();
 
         // execute
         filter.doFilter(request, ServletUtils.generateDummyServletResponse(), chain);
@@ -163,8 +164,8 @@ public class WebRequestTrackingFilterTests {
         try {
             FilterChain chain = mock(FilterChain.class);
 
-            ServletRequest request = ServletUtils.generateDummyServletRequest();
-            ServletResponse response = ServletUtils.generateDummyServletResponse();
+            HttpServletRequest request = ServletUtils.generateDummyServletRequest();
+            HttpServletResponse response = ServletUtils.generateDummyServletResponse();
             Mockito.doThrow(expectedException).when(chain).doFilter(eq(request), any(ServletResponse.class));
 
             // execute

--- a/web/src/test/java/com/microsoft/applicationinsights/web/utils/ServletUtils.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/utils/ServletUtils.java
@@ -78,11 +78,11 @@ public class ServletUtils {
         return container;
     }
 
-    public static HttpServletRequest generateDummyServletRequest() {
+    public static ServletRequest generateDummyServletRequest() {
         return mock(HttpServletRequest.class);
     }
 
-    public static HttpServletResponse generateDummyServletResponse() {
+    public static ServletResponse generateDummyServletResponse() {
         return mock(HttpServletResponse.class);
     }
 

--- a/web/src/test/java/com/microsoft/applicationinsights/web/utils/ServletUtils.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/utils/ServletUtils.java
@@ -78,11 +78,11 @@ public class ServletUtils {
         return container;
     }
 
-    public static ServletRequest generateDummyServletRequest() {
+    public static HttpServletRequest generateDummyServletRequest() {
         return mock(HttpServletRequest.class);
     }
 
-    public static ServletResponse generateDummyServletResponse() {
+    public static HttpServletResponse generateDummyServletResponse() {
         return mock(HttpServletResponse.class);
     }
 


### PR DESCRIPTION
This PR fixes the issue where the where the `WebRequestTelemetryFilter` stamps the response code as 200 OK when the Servlet Throws. 

The fix includes explicitly setting the response code as 500 on the `RequestTelemetry` item when filter catches `RunTimeException`, `IOException`or `ServletException`.  This needs to be set explicitly because the response code officially get's set from `org.apache.catalina.core. StandardWrapparValue` class's `invoke()` method in it's catch block. This method is called way later after the FilterChain completes it's execution.

This PR also Deprecates the `ApplicationInsightsHttpResponseWrapper` class and all the places where casting was done to this, as we no longer require this class as of Servlet API 3.0.1 onwards. It already has `getStatus()` method for which this wrapper was designed. 

Fix #600


For significant contributions please make sure you have completed the following items:
- [x] CHANGELOG.md updated
