### PR TITLE
401s are not successful requests

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -125,7 +125,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
 
             ApplicationInsightsHttpResponseWrapper response = ((ApplicationInsightsHttpResponseWrapper)res);
             if (response != null) {
-                telemetry.setSuccess(response.getStatus() < 400 || response.getStatus() == 401 );
+                telemetry.setSuccess(response.getStatus() < 400);
                 telemetry.setResponseCode(Integer.toString(response.getStatus()));
             } else {
                 InternalLogger.INSTANCE.error("Failed to get response status for request ID: %s", telemetry.getId());


### PR DESCRIPTION
401s are always errors w.r.t. the http client. It's expected behavior, but it's not a successful request.

I searched other AppInsights repos and could not find anything resembling this classification.