### PR TITLE
Change JmxMetricPerformanceCounter

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxMetricPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxMetricPerformanceCounter.java
@@ -34,16 +34,17 @@ import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
  * Created by gupele on 3/15/2015.
  */
 public final class JmxMetricPerformanceCounter extends AbstractJmxPerformanceCounter {
-    private final MetricTelemetry telemetry = new MetricTelemetry();
 
     public JmxMetricPerformanceCounter(String id, String objectName, Collection<JmxAttributeData> attributes) {
         super(id, objectName, attributes);
-        telemetry.markAsCustomPerfCounter();
     }
 
     @Override
     protected void send(TelemetryClient telemetryClient, String displayName, double value) {
         InternalLogger.INSTANCE.trace("Metric JMX: %s, %s", displayName, value);
+	
+	MetricTelemetry telemetry = new MetricTelemetry();
+	telemetry.markAsCustomPerfCounter();
         telemetry.setName(displayName);
         telemetry.setValue(value);
         telemetry.getProperties().put("CustomPerfCounter", "true");


### PR DESCRIPTION
This change allow **JmxMetricPerformanceCounter** to send a new instance of MetricTelemetry instead of reuse it.

Fix #609

For significant contributions please make sure you have completed the following items:
- [ ] CHANGELOG.md updated
