### PR TITLE
Permit External Instrumentation Key in default config in addition to ApplicationInsights.xml

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
@@ -22,6 +22,7 @@
 package com.microsoft.applicationinsights;
 
 import com.google.common.base.Strings;
+import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
 import com.microsoft.applicationinsights.channel.TelemetryChannel;
 import com.microsoft.applicationinsights.extensibility.ContextInitializer;
 import com.microsoft.applicationinsights.extensibility.TelemetryInitializer;
@@ -34,7 +35,7 @@ import java.util.List;
 
 /**
  * Encapsulates the global telemetry configuration typically loaded from the ApplicationInsights.xml file.
- *
+ * <p>
  * All {@link com.microsoft.applicationinsights.telemetry.TelemetryContext} objects are initialized using the
  * 'Active' (returned by the 'getActive' static method) telemetry configuration provided by this class.
  */
@@ -46,7 +47,7 @@ public final class TelemetryConfiguration {
 
     private String instrumentationKey;
 
-    private final ArrayList<ContextInitializer> contextInitializers = new   ArrayList<ContextInitializer>();
+    private final ArrayList<ContextInitializer> contextInitializers = new ArrayList<ContextInitializer>();
     private final ArrayList<TelemetryInitializer> telemetryInitializers = new ArrayList<TelemetryInitializer>();
     private final ArrayList<TelemetryModule> telemetryModules = new ArrayList<TelemetryModule>();
     private final ArrayList<TelemetryProcessor> telemetryProcessors = new ArrayList<TelemetryProcessor>();
@@ -59,6 +60,7 @@ public final class TelemetryConfiguration {
      * Gets the active {@link com.microsoft.applicationinsights.TelemetryConfiguration} instance loaded from the
      * ApplicationInsights.xml file. If the configuration file does not exist, the active configuration instance is
      * initialized with minimum defaults needed to send telemetry to Application Insights.
+     *
      * @return The 'Active' instance
      */
     public static TelemetryConfiguration getActive() {
@@ -78,16 +80,37 @@ public final class TelemetryConfiguration {
      * Creates a new instance loaded from the ApplicationInsights.xml file.
      * If the configuration file does not exist, the new configuration instance is initialized with minimum defaults
      * needed to send telemetry to Application Insights.
+     *
      * @return Telemetry Configuration instance.
      */
     public static TelemetryConfiguration createDefault() {
+        return createDefaultWithInstrumentationKey(null);
+    }
+
+    /**
+     * Creates a new instance loaded from the ApplicationInsights.xml file.
+     * If the configuration file does not exist, the new configuration instance is initialized with minimum defaults
+     * needed to send telemetry to Application Insights.
+     *
+     * This call permits client to create client with its own i-Key stored, for instance, in some Key-Value storage
+     * in the cloud and let intrinsically created TelemetryClients (such as for JMX metrics) to be aware of the key
+     * even it is not in the ApplicationInsights.xml. This permits convenient work with environment-based configurations.
+     *
+     * @return Telemetry Configuration instance.
+     */
+    public static TelemetryConfiguration createDefaultWithInstrumentationKey(String instrumentationKey) {
         TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration();
+        if (!StringUtils.isNullOrEmpty(instrumentationKey)) {
+            telemetryConfiguration.setInstrumentationKey(instrumentationKey);
+        }
         TelemetryConfigurationFactory.INSTANCE.initialize(telemetryConfiguration);
         return telemetryConfiguration;
     }
 
+
     /**
      * Gets the telemetry channel.
+     *
      * @return An instance of {@link com.microsoft.applicationinsights.channel.TelemetryChannel}
      */
     public TelemetryChannel getChannel() {
@@ -96,6 +119,7 @@ public final class TelemetryConfiguration {
 
     /**
      * Sets the telemetry channel.
+     *
      * @param channel An instance of {@link com.microsoft.applicationinsights.channel.TelemetryChannel}
      */
     public void setChannel(TelemetryChannel channel) {
@@ -104,7 +128,7 @@ public final class TelemetryConfiguration {
 
     /**
      * Gets value indicating whether sending of telemetry to Application Insights is disabled.
-     *
+     * <p>
      * This disable tracking setting value is used by default by all {@link com.microsoft.applicationinsights.TelemetryClient}
      * instances created in the application.
      *
@@ -116,9 +140,10 @@ public final class TelemetryConfiguration {
 
     /**
      * Sets value indicating whether sending of telemetry to Application Insights is disabled.
-     *
+     * <p>
      * This disable tracking setting value is used by default by all {@link com.microsoft.applicationinsights.TelemetryClient}
      * instances created in the application.
+     *
      * @param disable True to disable tracking.
      */
     public void setTrackingIsDisabled(boolean disable) {
@@ -127,12 +152,13 @@ public final class TelemetryConfiguration {
 
     /**
      * Gets the list of {@link ContextInitializer} objects that supply additional information about application.
-     *
+     * <p>
      * Context initializers extend Application Insights telemetry collection by supplying additional information
      * about application environment, such as 'User' information (in TelemetryContext.getUser or Device (in TelemetryContext.getDevice
      * invokes telemetry initializers each time the TelemetryClient's 'track' method is called
-     *
+     * <p>
      * The default list of telemetry initializers is provided by the SDK and can also be set from the ApplicationInsights.xml.
+     *
      * @return Collection of Context Initializers
      */
     public List<ContextInitializer> getContextInitializers() {
@@ -141,9 +167,10 @@ public final class TelemetryConfiguration {
 
     /**
      * Gets the list of modules that automatically generate application telemetry.
-     *
+     * <p>
      * Telemetry modules automatically send telemetry describing the application to Application Insights. For example, a telemetry
      * module can handle application exception events and automatically send
+     *
      * @return List of Telemetry Initializers
      */
     public List<TelemetryInitializer> getTelemetryInitializers() {
@@ -160,10 +187,11 @@ public final class TelemetryConfiguration {
 
     /**
      * Gets or sets the default instrumentation key for the application.
-     *
+     * <p>
      * This instrumentation key value is used by default by all {@link com.microsoft.applicationinsights.TelemetryClient}
      * instances created in the application. This value can be overwritten by setting the Instrumentation Key in
      * {@link com.microsoft.applicationinsights.telemetry.TelemetryContext} class
+     *
      * @return The instrumentation key
      */
     public String getInstrumentationKey() {
@@ -172,10 +200,11 @@ public final class TelemetryConfiguration {
 
     /**
      * Gets or sets the default instrumentation key for the application.
-     *
+     * <p>
      * This instrumentation key value is used by default by all {@link com.microsoft.applicationinsights.TelemetryClient}
      * instances created in the application. This value can be overwritten by setting the Instrumentation Key in
      * {@link com.microsoft.applicationinsights.telemetry.TelemetryContext} class
+     *
      * @param key The instrumentation key
      * @throws IllegalArgumentException when the new value is null or empty
      */

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
@@ -92,7 +92,7 @@ public final class TelemetryConfiguration {
      * If the configuration file does not exist, the new configuration instance is initialized with minimum defaults
      * needed to send telemetry to Application Insights.
      *
-     * This call permits client to create client with its own i-Key stored, for instance, in some Key-Value storage
+     * This call permits to create a client with its own i-Key stored, for instance, in some Key-Value storage
      * in the cloud and let intrinsically created TelemetryClients (such as for JMX metrics) to be aware of the key
      * even it is not in the ApplicationInsights.xml. This permits convenient work with environment-based configurations.
      *


### PR DESCRIPTION
 The code is too much dependent now on having Instrumentation key in the ApplicationInsights.xml. 

This modification permits to create a client with its own i-Key stored, for instance, in some Key-Value storage in the cloud and let intrinsically created TelemetryClients (such as for JMX metrics) to be aware of the key even it is not in the ApplicationInsights.xml. This permits convenient work with environment-based configurations.
