### PR TITLE
too many root element annotations. there's only one root element

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/AddTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/AddTypeXmlElement.java
@@ -31,7 +31,6 @@ import java.util.Map;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="Add")
 public class AddTypeXmlElement {
     private String type;
     private ArrayList<ParamXmlElement> paramElements = new ArrayList<ParamXmlElement>();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ChannelXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ChannelXmlElement.java
@@ -25,14 +25,12 @@ import com.google.common.base.Strings;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="Channel")
 public class ChannelXmlElement {
 
     private String endpointAddress;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ContextInitializersXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ContextInitializersXmlElement.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="ContextInitializers")
 public class ContextInitializersXmlElement {
 
     private ArrayList<AddTypeXmlElement> adds;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/FixedSamplerXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/FixedSamplerXmlElement.java
@@ -26,7 +26,6 @@ import javax.xml.bind.annotation.*;
 /**
  * Created by gupele on 11/14/2016.
  */
-@XmlRootElement(name="Fixed")
 public class FixedSamplerXmlElement {
     private String includeTypes;
     private String excludeTypes;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/JmxListXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/JmxListXmlElement.java
@@ -28,7 +28,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="Jmx")
 public class JmxListXmlElement {
     private ArrayList<JmxXmlElement> jmx;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/JmxXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/JmxXmlElement.java
@@ -27,7 +27,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="Add")
 public class JmxXmlElement {
     private String displayName;
     private String objectName;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/JvmXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/JvmXmlElement.java
@@ -27,7 +27,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 8/8/2016.
  */
-@XmlRootElement(name="JvmPC")
 public class JvmXmlElement {
     private String name;
     private boolean enabled = true;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamExcludedTypeXmlElement.java
@@ -7,8 +7,6 @@ import java.util.List;
 /**
  * This is the class for binding the xml array list of {@code <ExcludedTypes>}
  */
-
-@XmlRootElement(name = "ExcludedTypes")
 public class ParamExcludedTypeXmlElement {
 
     public List<String> getExcludedType() {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamIncludedTypeXmlElement.java
@@ -7,8 +7,6 @@ import java.util.List;
 /**
  * This class is used to bind the xml array list of {@code <IncludeTypes>}
  */
-
-@XmlRootElement(name = "IncludedTypes")
 public class ParamIncludedTypeXmlElement {
 
     public List<String> getIncludedType() {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ParamXmlElement.java
@@ -27,7 +27,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by yonisha on 3/16/2015.
  */
-@XmlRootElement(name="Param")
 public class ParamXmlElement {
     private String name;
     private String value;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/PerformanceCounterJvmSectionXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/PerformanceCounterJvmSectionXmlElement.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 /**
  * Created by gupele on 8/8/2016.
  */
-@XmlRootElement(name="Jvm")
 public class PerformanceCounterJvmSectionXmlElement {
     private ArrayList<JvmXmlElement> jvmXmlElements;
     private boolean enabled = true;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/PerformanceCountersXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/PerformanceCountersXmlElement.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="PerformanceCounters")
 public class PerformanceCountersXmlElement {
     private boolean useBuiltIn = true;
     private long collectionFrequencyInSec = 60;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/QuickPulseXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/QuickPulseXmlElement.java
@@ -27,7 +27,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 12/13/2016.
  */
-@XmlRootElement(name="QuickPulse")
 public class QuickPulseXmlElement {
     private boolean enabled = true;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/RemoveTypeXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/RemoveTypeXmlElement.java
@@ -27,7 +27,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 3/16/2015.
  */
-@XmlRootElement(name="Remove")
 public class RemoveTypeXmlElement {
     private String type;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/SDKLoggerXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/SDKLoggerXmlElement.java
@@ -30,7 +30,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="SDKLogger")
 public class SDKLoggerXmlElement {
     private String type = "CONSOLE";
     private String level;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/SamplerXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/SamplerXmlElement.java
@@ -28,7 +28,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 11/2/2016.
  */
-@XmlRootElement(name="Sampling")
 public class SamplerXmlElement {
     private FixedSamplerXmlElement fixedSamplerXmlElement;
     private AdaptiveSamplerXmlElement adaptiveSamplerXmlElement;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryInitializersXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryInitializersXmlElement.java
@@ -28,7 +28,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="TelemetryInitializers")
 public class TelemetryInitializersXmlElement {
 
     private ArrayList<AddTypeXmlElement> adds;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryModulesXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryModulesXmlElement.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 /**
  * Created by gupele on 3/15/2015.
  */
-@XmlRootElement(name="TelemetryModules")
 public class TelemetryModulesXmlElement {
     private ArrayList<AddTypeXmlElement> adds;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorXmlElement.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 /**
  * Created by gupele on 7/26/2016.
  */
-@XmlRootElement(name="Processor")
 public class TelemetryProcessorXmlElement {
     private String type;
     private ArrayList<ParamXmlElement> adds = new ArrayList<ParamXmlElement>();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorsXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorsXmlElement.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 /**
  * Created by gupele on 7/26/2016.
  */
-@XmlRootElement(name="TelemetryProcessors")
 public class TelemetryProcessorsXmlElement {
     private ArrayList<TelemetryProcessorXmlElement> custom = new ArrayList<TelemetryProcessorXmlElement>();
     private ArrayList<TelemetryProcessorXmlElement> builtIn = new ArrayList<TelemetryProcessorXmlElement>();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/WindowsPerformanceCounterXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/WindowsPerformanceCounterXmlElement.java
@@ -27,7 +27,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Created by gupele on 3/30/2015.
  */
-@XmlRootElement(name="Add")
 public class WindowsPerformanceCounterXmlElement {
     private String displayName;
     private String categoryName;


### PR DESCRIPTION
While working on our configuration XMLs' schema documentation, I noticed all of these annotations. This marks the root element of an xml document. We only have one, so I removed all the ones that were wrong.
