### PR TITLE
added waitForItems methods so to not rely on guessing the right time

### DIFF
--- a/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
+++ b/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
@@ -1,5 +1,21 @@
 package com.microsoft.applicationinsights.test.fakeingestion;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.*;
+import java.util.zip.GZIPInputStream;
+import javax.annotation.concurrent.GuardedBy;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ListMultimap;
@@ -8,19 +24,6 @@ import com.google.common.io.CharStreams;
 import com.google.gson.JsonSyntaxException;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.smoketest.JsonHelper;
-
-import javax.annotation.concurrent.GuardedBy;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.zip.GZIPInputStream;
 
 public class MockedAppInsightsIngestionServlet extends HttpServlet {
     public static final long serialVersionUID = -1;
@@ -141,7 +144,7 @@ public class MockedAppInsightsIngestionServlet extends HttpServlet {
                             targetCollection.add(val);
                         }
                     }
-                    TimeUnit.MILLISECONDS.sleep(150);
+                    TimeUnit.MILLISECONDS.sleep(75);
                 }
                 return targetCollection;
             }

--- a/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
+++ b/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
@@ -1,5 +1,20 @@
 package com.microsoft.applicationinsights.test.fakeingestion;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.io.CharStreams;
+import com.google.gson.JsonSyntaxException;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.smoketest.JsonHelper;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
@@ -9,21 +24,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.zip.GZIPInputStream;
-import javax.annotation.concurrent.GuardedBy;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.MultimapBuilder;
-import com.google.common.io.CharStreams;
-import com.google.gson.JsonSyntaxException;
-import com.microsoft.applicationinsights.internal.schemav2.Envelope;
-import com.microsoft.applicationinsights.smoketest.JsonHelper;
 
 public class MockedAppInsightsIngestionServlet extends HttpServlet {
     public static final long serialVersionUID = -1;

--- a/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
+++ b/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
@@ -22,7 +22,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.zip.GZIPInputStream;
 
 public class MockedAppInsightsIngestionServlet extends HttpServlet {

--- a/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
+++ b/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
@@ -1,11 +1,5 @@
 package com.microsoft.applicationinsights.test.fakeingestion;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.microsoft.applicationinsights.internal.schemav2.Data;
@@ -14,6 +8,12 @@ import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class MockedAppInsightsIngestionServer implements AutoCloseable {
 	public static final int DEFAULT_PORT = 60606;

--- a/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
+++ b/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
@@ -11,7 +11,6 @@ import com.google.common.base.Predicate;
 import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.Domain;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
-
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;

--- a/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
+++ b/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
@@ -2,6 +2,9 @@ package com.microsoft.applicationinsights.test.fakeingestion;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -87,6 +90,32 @@ public class MockedAppInsightsIngestionServer implements AutoCloseable {
 	public <T extends Domain> T getBaseDataForType(int index, String type) {
 		Data<T> data = (Data<T>) getItemsByType(type).get(index).getData();
 		return data.getBaseData();
+	}
+
+	/**
+	 * Waits the given amount of time for this mocked server to recieve one telemetry item matching the given predicate.
+	 *
+	 * @see #waitForItems(Predicate, int, int, TimeUnit)
+	 */
+	public Envelope waitForItem(Predicate<Envelope> condition, int timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+		return waitForItems(condition, 1, timeout, timeUnit).get(0);
+	}
+
+
+	/**
+	 * Waits the given amount of time for this mocked server to receive a certain number of items which match the given predicate.
+	 *
+	 * @param condition condition describing what items to wait for.
+	 * @param numItems number of matching items to wait for.
+	 * @param timeout amount of time to wait
+	 * @param timeUnit the unit of time to wait
+	 * @return The items the given condition. This will be at least {@code numItems}, but could be more.
+	 * @throws InterruptedException if the thread is interrupted while waiting
+	 * @throws ExecutionException if an exception is thrown while waiting
+	 * @throws TimeoutException if the timeout is reached
+	 */
+	public List<Envelope> waitForItems(Predicate<Envelope> condition, int numItems, int timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+		return this.servlet.waitForItems(condition, numItems, timeout, timeUnit);
 	}
 
 	@Override


### PR DESCRIPTION
This expands the smoke tests, adding a method which waits for a number of telemetry items matching a particular condition.

This is intended for testing perf counters.