### PR TITLE
Fix incorrect success flag set while capturing http dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Version 2.0.2 
+- Fix incorrect success flag set when capturing HTTP Dependency.
 - Fix [#577](https://github.com/Microsoft/ApplicationInsights-Java/issues/577), removed HttpFactory class as it was not being used.
 - Fixed issue with sessionId not being set in request telemetry due to date parsing issues.
 - Fix [#616](https://github.com/Microsoft/ApplicationInsights-Java/issues/616), added a way to have real time SDK Logs when logging on File.

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/agent/CoreAgentNotificationsHandler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/agent/CoreAgentNotificationsHandler.java
@@ -173,7 +173,7 @@ final class CoreAgentNotificationsHandler implements AgentNotificationsHandler {
         }
         long deltaInMS = nanoToMilliseconds(delta);
         String name = method + " " + path;
-        RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry(name, uri, new Duration(deltaInMS), true);
+        RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry(name, uri, new Duration(deltaInMS), (result < 400));
         Date dependencyStartTime = new Date(System.currentTimeMillis() - deltaInMS);
         telemetry.setTimestamp(dependencyStartTime);
         telemetry.setId(correlationId);


### PR DESCRIPTION
This PR fixes incorrect success flag set when capturing HTTP Dependencies. The value was hard coded to true instead of checking based on result code.
