### PR TITLE
HeartBeat Feature Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# Version 2.1.0
+- Introduced Heartbeat support to monitor application health periodically.
+
 ## Version 2.0.2 
 - Fix incorrect success flag set when capturing HTTP Dependency.
 - Fix [#577](https://github.com/Microsoft/ApplicationInsights-Java/issues/577), removed HttpFactory class as it was not being used.

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -22,7 +22,6 @@
 package com.microsoft.applicationinsights.internal.config;
 
 import com.microsoft.applicationinsights.internal.heartbeat.HeartBeatModule;
-import com.microsoft.applicationinsights.telemetry.Telemetry;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.List;
@@ -178,7 +177,7 @@ public enum TelemetryConfigurationFactory {
         }
 
         //if heartbeat module is not loaded, load heartbeat module
-        if (!heartBeatModuleAdded(modules)) {
+        if (!isHeartBeatModuleAdded(modules)) {
             addHeartBeatModule(configuration);
         }
 
@@ -512,12 +511,21 @@ public enum TelemetryConfigurationFactory {
         }
     }
 
+    /**
+     * Adds heartbeat module with default configuration
+     * @param configuration TelemetryConfiguration Instance
+     */
     private void addHeartBeatModule(TelemetryConfiguration configuration) {
         HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
         configuration.getTelemetryModules().add(module);
     }
 
-    private boolean heartBeatModuleAdded(List<TelemetryModule> module) {
+    /**
+     * Checks if heartbeat module is present
+     * @param module List of modules in current TelemetryConfiguration Instance
+     * @return true if heartbeat module is present
+     */
+    private boolean isHeartBeatModuleAdded(List<TelemetryModule> module) {
         for (TelemetryModule mod : module) {
             if (mod instanceof HeartBeatModule) return true;
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/BaseDefaultHeartbeatPropertyProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/BaseDefaultHeartbeatPropertyProvider.java
@@ -10,12 +10,34 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+/**
+ * <h1>Base Heartbeat Property Provider</h1>
+ *
+ * <p>
+ *   This class is a concrete implementation of {@link com.microsoft.applicationinsights.internal.heartbeat.HeartBeatDefaultPayloadProviderInterface}
+ *   It enables setting SDK Metadata to heartbeat payload.
+ * </p>
+ *
+ * @author Dhaval Doshi
+ * @since 03-30-2018
+ */
 public class BaseDefaultHeartbeatPropertyProvider implements HeartBeatDefaultPayloadProviderInterface {
 
+  /**
+   * Collection holding default properties for this default provider.
+   */
   private final Set<String> defaultFields;
 
-  private UUID uniqueProcessId;
+  /**
+   * Random GUID that would help in analysis when app has stopped and restarted. Each restart will
+   * have a new GUID. If the application is unstable and goes through frequent restarts this will help
+   * us identify instability in the analytics backend.
+   */
+  private static UUID uniqueProcessId;
 
+  /**
+   * Name of this provider.
+   */
   private final String name = "Base";
 
   public BaseDefaultHeartbeatPropertyProvider() {
@@ -29,10 +51,16 @@ public class BaseDefaultHeartbeatPropertyProvider implements HeartBeatDefaultPay
   }
 
   @Override
+  public boolean isKeyWord(String keyword) {
+    return defaultFields.contains(keyword);
+  }
+
+  @Override
   public Callable<Boolean> setDefaultPayload(final List<String> disableFields,
       final HeartBeatProviderInterface provider) {
     return new Callable<Boolean>() {
 
+      // using volatile here to avoid caching in threads.
       volatile boolean hasSetValues = false;
       volatile Set<String> enabledProperties = MiscUtils.except(defaultFields, disableFields);
       @Override
@@ -57,6 +85,7 @@ public class BaseDefaultHeartbeatPropertyProvider implements HeartBeatDefaultPay
                 hasSetValues = true;
                 break;
               default:
+                //We won't accept unknown properties in default providers.
                 InternalLogger.INSTANCE.trace("Encountered unknown default property");
                 break;
             }
@@ -71,6 +100,10 @@ public class BaseDefaultHeartbeatPropertyProvider implements HeartBeatDefaultPay
     };
   }
 
+  /**
+   * This method initializes the collection with Default Properties of this provider.
+   * @param defaultFields collection to hold default properties.
+   */
   private void initializeDefaultFields(Set<String> defaultFields) {
 
     if (defaultFields == null) {
@@ -82,10 +115,19 @@ public class BaseDefaultHeartbeatPropertyProvider implements HeartBeatDefaultPay
     defaultFields.add("processSessionId");
   }
 
+  /**
+   * Gets the JDK version being used by the application
+   * @return String representing JDK Version
+   */
   private String getJdkVersion() {
     return System.getProperty("java.version");
   }
 
+  /**
+   * Returns the Application Insights SDK version user is using to instrument his application
+   * @return returns string prefixed with "java" representing the Application Insights Java
+   * SDK version.
+   */
   private String getSdkVersion() {
 
     String sdkVersion = "java";
@@ -99,13 +141,20 @@ public class BaseDefaultHeartbeatPropertyProvider implements HeartBeatDefaultPay
     return sdkVersion + ":unknown-version";
   }
 
-
+  /**
+   * Gets the OS version on which application is running.
+   * @return String representing OS version
+   */
   private String getOsType() {
     return System.getProperty("os.name");
   }
 
+  /**
+   * Returns the Unique GUID for the application's current session.
+   * @return String representing GUID for each running session
+   */
   private String getProcessSessionId() {
-    if (this.uniqueProcessId == null) {
+    if (uniqueProcessId == null) {
       uniqueProcessId = UUID.randomUUID();
     }
     return uniqueProcessId.toString();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/BaseDefaultHeartbeatPropertyProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/BaseDefaultHeartbeatPropertyProvider.java
@@ -1,0 +1,153 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+public class BaseDefaultHeartbeatPropertyProvider implements HeartBeatDefaultPayloadProviderInterface {
+
+  private final List<String> defaultFields;
+
+  private UUID uniqueProcessId;
+
+  private final String name = "Base";
+
+  public BaseDefaultHeartbeatPropertyProvider() {
+    defaultFields = new ArrayList<>();
+    initializeDefaultFields(defaultFields);
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
+  }
+
+  @Override
+  public boolean isKeyword(String keyword) {
+    return containsIgnoreCase(keyword, defaultFields);
+  }
+
+  @Override
+  public Callable<Boolean> setDefaultPayload(final List<String> disableFields,
+      final HeartBeatProviderInterface provider) {
+    return new Callable<Boolean>() {
+
+      volatile boolean hasSetValues = false;
+      volatile List<String> enabledProperties = except(defaultFields, disableFields);
+      @Override
+      public Boolean call() {
+        for (String fieldName : enabledProperties) {
+          try {
+            switch (fieldName) {
+              case "jdkVersion":
+                provider.addHeartBeatProperty(fieldName, getJdkVersion(), true);
+                hasSetValues = true;
+                break;
+              case "sdk-version":
+                provider.addHeartBeatProperty(fieldName, getSdkVersion(), true);
+                hasSetValues = true;
+                break;
+              case "osType":
+                provider.addHeartBeatProperty(fieldName, getOsType(), true);
+                hasSetValues = true;
+                break;
+              case "processSessionId":
+                provider.addHeartBeatProperty(fieldName, getProcessSessionId(), true);
+                hasSetValues = true;
+                break;
+            }
+          }
+          catch (Exception e) {
+           InternalLogger.INSTANCE.warn("Failed to obtain heartbeat property, stack trace"
+               + "is: %s", ExceptionUtils.getStackTrace(e));
+          }
+        }
+        return hasSetValues;
+      }
+
+      private List<String> except(List<String> list1, List<String> list2) {
+        try {
+          if (list1 == null || list2 == null) throw new IllegalArgumentException("Input is null");
+          List<String> union = new ArrayList<>(list1);
+          union.addAll(list2);
+          List<String> intersection = new ArrayList<>(list1);
+          intersection.retainAll(list2);
+          union.removeAll(intersection);
+          return union;
+        }
+        catch (Exception e) {
+          InternalLogger.INSTANCE.warn("stack trace is %s", ExceptionUtils.getStackTrace(e));
+        }
+        finally{
+          if (list1 != null) return list1;
+          return list2;
+        }
+      }
+    };
+  }
+
+  private void initializeDefaultFields(List<String> defaultFields) {
+
+    if (defaultFields == null) {
+      defaultFields = new ArrayList<>();
+    }
+    defaultFields.add("jdkVersion");
+    defaultFields.add("sdk-version");
+    defaultFields.add("osType");
+    defaultFields.add("processSessionId");
+  }
+
+  private boolean containsIgnoreCase(String keyword, List<String> inputList) {
+    try {
+      if (keyword == null) throw new IllegalArgumentException("Keyword to compare is null");
+      if (inputList == null) throw new IllegalArgumentException("List to compare is null");
+      for (String key : inputList) {
+        if (key.equalsIgnoreCase(keyword)) return true;
+      }
+      return false;
+    }
+    catch (Exception e) {
+      InternalLogger.INSTANCE.warn("exception while comparision, stack trace is %s",
+          ExceptionUtils.getStackTrace(e));
+    }
+    finally{
+      //return true so we don't add property when comparison exception
+      return true;
+    }
+
+  }
+
+  private String getJdkVersion() {
+    return System.getProperty("java.version");
+  }
+
+  private String getSdkVersion() {
+
+    String sdkVersion = "java";
+
+    Properties sdkVersionProps = PropertyHelper.getSdkVersionProperties();
+    if (sdkVersionProps != null) {
+      String version = sdkVersionProps.getProperty("version");
+      sdkVersion = String.format("java:%s", version);
+      return sdkVersion;
+    }
+    return sdkVersion + ":unknown-version";
+  }
+
+
+  private String getOsType() {
+    return System.getProperty("os.name");
+  }
+
+  private String getProcessSessionId() {
+    if (this.uniqueProcessId == null) {
+      uniqueProcessId = UUID.randomUUID();
+    }
+    return uniqueProcessId.toString();
+  }
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatDefaultPayloadProviderInterface.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatDefaultPayloadProviderInterface.java
@@ -1,0 +1,14 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public interface HeartBeatDefaultPayloadProviderInterface {
+
+  String getName();
+
+  boolean isKeyword(String keyword);
+
+  Callable<Boolean> setDefaultPayload(List<String> disableFields, HeartBeatProviderInterface provider);
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatDefaultPayloadProviderInterface.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatDefaultPayloadProviderInterface.java
@@ -3,10 +3,41 @@ package com.microsoft.applicationinsights.internal.heartbeat;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+/**
+ * <h1>Interface for setting default properties</h1>
+ *
+ * <p>
+ *   This interface is used to set the default payload of a provider and defines implementation for
+ *   some helper methods to assist it.
+ *
+ *   The default concrete implementations are {@link com.microsoft.applicationinsights.internal.heartbeat.BaseDefaultHeartbeatPropertyProvider}
+ *   and {@link com.microsoft.applicationinsights.internal.heartbeat.WebAppsDefaultHeartbeatProvider}
+ * </p>
+ *
+ * @author Dhaval Doshi
+ * @since 03-30-2018
+ */
 public interface HeartBeatDefaultPayloadProviderInterface {
 
+  /**
+   * Returns the name of the heartbeat provider.
+   * @return Name of the heartbeat provider
+   */
   String getName();
 
+  /**
+   * Tells if the input string is a reserved property.
+   * @param keyword string to test
+   * @return true if input string is reserved keyword
+   */
+  boolean isKeyWord(String keyword);
+
+  /**
+   * Returns a callable which can be executed to set the payload based on the parameters.
+   * @param disableFields List of Properties to be excluded from payload
+   * @param provider The current heartbeat provider
+   * @return Callable which can be executed to add the payload
+   */
   Callable<Boolean> setDefaultPayload(List<String> disableFields, HeartBeatProviderInterface provider);
 
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatDefaultPayloadProviderInterface.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatDefaultPayloadProviderInterface.java
@@ -7,8 +7,6 @@ public interface HeartBeatDefaultPayloadProviderInterface {
 
   String getName();
 
-  boolean isKeyword(String keyword);
-
   Callable<Boolean> setDefaultPayload(List<String> disableFields, HeartBeatProviderInterface provider);
 
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
@@ -1,0 +1,100 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.extensibility.TelemetryModule;
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class HeartBeatModule implements TelemetryModule {
+
+  private final HeartBeatProviderInterface heartBeatProviderInterface;
+
+  public HeartBeatModule(Map<String, String> properties) {
+
+    if (properties != null) {
+      for (Map.Entry<String, String> entry : properties.entrySet()) {
+        switch (entry.getKey()) {
+          case "HeartBeatInterval":
+            try {
+              setHeartBeatInterval(Long.valueOf(entry.getValue()));
+            } catch (Exception e) {
+              //add log
+            }
+          case "isHeartBeatEnabled":
+            try {
+              setHeartBeatEnabled(Boolean.parseBoolean(entry.getValue()));
+            }
+            catch (Exception e) {
+              //log
+            }
+          case "ExcludedHeartBeatPropertiesProvider":
+            try {
+              List<String> excludedHeartBeatPropertiesProviderList = parseStringToList(entry.getValue());
+              setExcludedHeartBeatPropertiesProvider(excludedHeartBeatPropertiesProviderList);
+            }
+            catch (Exception e) {
+              //log
+            }
+          case "ExcludedHeartBeatProperties":
+            try {
+              List<String> excludedHeartBeatPropertiesList = parseStringToList(entry.getValue());
+              setExcludedHeartBeatProperties(excludedHeartBeatPropertiesList);
+            }
+            catch (Exception e) {
+              //log
+            }
+        }
+      }
+    }
+
+    heartBeatProviderInterface = new HeartBeatProvider();
+  }
+
+  public long getHeartBeatInterval() {
+    return this.heartBeatProviderInterface.getHeartBeatInterval();
+  }
+
+  public void setHeartBeatInterval(long heartBeatInterval) {
+    this.heartBeatProviderInterface.setHeartBeatInterval(heartBeatInterval);
+  }
+
+  public List<String> getExcludedHeartBeatProperties() {
+    return heartBeatProviderInterface.getExcludedHeartBeatProperties();
+  }
+
+  public void setExcludedHeartBeatProperties(List<String> excludedHeartBeatProperties) {
+    this.heartBeatProviderInterface.setExcludedHeartBeatProperties(excludedHeartBeatProperties);
+  }
+
+  public List<String> getExcludedHeartBeatPropertiesProvider() {
+    return heartBeatProviderInterface.getExcludedHeartBeatPropertyProviders();
+  }
+
+  public void setExcludedHeartBeatPropertiesProvider(
+      List<String> excludedHeartBeatPropertiesProvider) {
+      this.heartBeatProviderInterface.setExcludedHeartBeatPropertyProviders(excludedHeartBeatPropertiesProvider);
+  }
+
+  public boolean isHeartBeatEnabled() {
+    return this.heartBeatProviderInterface.isHeartBeatEnabled();
+  }
+
+  public void setHeartBeatEnabled(boolean heartBeatEnabled) {
+    this.heartBeatProviderInterface.setHeartBeatEnabled(heartBeatEnabled);
+  }
+
+  @Override
+  public void initialize(TelemetryConfiguration configuration) {
+    InternalLogger.INSTANCE.info("heartbeat is enabled");
+  }
+
+  private List<String> parseStringToList(String value) {
+    if (value == null || value.length() == 0) return new ArrayList<>();
+    List<String> valueList = Arrays.asList(value.split(";"));
+    return valueList;
+  }
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
@@ -110,7 +110,7 @@ public class HeartBeatModule implements TelemetryModule {
       isEnabled = true;
     }
     finally{
-      lock.lock();
+      lock.unlock();
     }
 
   }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
@@ -16,7 +16,7 @@ public class HeartBeatModule implements TelemetryModule {
 
   private Lock lock = new ReentrantLock();
 
-  private boolean isEnabled = false;
+  private static boolean isEnabled = false;
 
   public HeartBeatModule(Map<String, String> properties) {
 
@@ -117,8 +117,7 @@ public class HeartBeatModule implements TelemetryModule {
 
   private List<String> parseStringToList(String value) {
     if (value == null || value.length() == 0) return new ArrayList<>();
-    List<String> valueList = Arrays.asList(value.split(";"));
-    return valueList;
+    return Arrays.asList(value.split(";"));
   }
 
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatPropertyPayload.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatPropertyPayload.java
@@ -1,0 +1,5 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+public class HeartBeatPropertyPayload {
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatPropertyPayload.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatPropertyPayload.java
@@ -1,25 +1,59 @@
 package com.microsoft.applicationinsights.internal.heartbeat;
 
+/**
+ * <p>
+ *  Defines the Payload class to store and send heartbeat properties and allowing to keep track of updates
+ *  to them.
+ *  </p>
+ *
+ *  @author Dhaval Doshi
+ *  @since 03-30-2018
+ */
 public class HeartBeatPropertyPayload {
 
+  /**
+   * Value of payload on initialization. Ready for transmission.
+   */
   private String payloadValue = "";
 
-  private boolean isHealthy = true;
+  /**
+   * Is this healthy property or not.
+   */
+  private boolean isHealthy = false;
 
+  /**
+   * Property is updated or not.
+   */
   private boolean isUpdated = true;
 
-  public String getPayloadValue() {
+  /**
+   * Returns the payload value
+   * @return String value of payload property
+   */
+  String getPayloadValue() {
     return payloadValue;
   }
 
-  public boolean isUpdated() {
+  /**
+   * Returns true if the property value is updated
+   * @return true if value is updated
+   */
+  boolean isUpdated() {
     return isUpdated;
   }
 
+  /**
+   * Set update flag to indicate the change of value
+   * @param updated the boolean value to indicate update
+   */
   public void setUpdated(boolean updated) {
     isUpdated = updated;
   }
 
+  /**
+   * This is used to set the payload
+   * @param payloadValue value of the property
+   */
   public void setPayloadValue(String payloadValue) {
     if (payloadValue != null && !this.payloadValue.equals(payloadValue)) {
       this.payloadValue = payloadValue;
@@ -28,10 +62,18 @@ public class HeartBeatPropertyPayload {
 
   }
 
+  /**
+   * Gets the value of payload is healthy
+   * @return returns true of payload value is healthy.
+   */
   public boolean isHealthy() {
     return isHealthy;
   }
 
+  /**
+   * Sets the health of the payload.
+   * @param healthy boolean value representing the health.
+   */
   public void setHealthy(boolean healthy) {
     this.isUpdated = this.isHealthy != healthy;
     this.isHealthy = healthy;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatPropertyPayload.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatPropertyPayload.java
@@ -2,4 +2,38 @@ package com.microsoft.applicationinsights.internal.heartbeat;
 
 public class HeartBeatPropertyPayload {
 
+  private String payloadValue = "";
+
+  private boolean isHealthy = true;
+
+  private boolean isUpdated = true;
+
+  public String getPayloadValue() {
+    return payloadValue;
+  }
+
+  public boolean isUpdated() {
+    return isUpdated;
+  }
+
+  public void setUpdated(boolean updated) {
+    isUpdated = updated;
+  }
+
+  public void setPayloadValue(String payloadValue) {
+    if (payloadValue != null && !this.payloadValue.equals(payloadValue)) {
+      this.payloadValue = payloadValue;
+      isUpdated = true;
+    }
+
+  }
+
+  public boolean isHealthy() {
+    return isHealthy;
+  }
+
+  public void setHealthy(boolean healthy) {
+    this.isUpdated = this.isHealthy != healthy;
+    this.isHealthy = healthy;
+  }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProvider.java
@@ -1,0 +1,107 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class HeartBeatProvider implements HeartBeatProviderInterface {
+
+  private final String HEARTBEAT_SYNTHETIC_METRIC_NAME = "HeartbeatState";
+
+  private List<String> disableDefaultProperties = new ArrayList<>();
+
+  private List<String> disabledHeartBeatPropertiesProviders =new ArrayList<>();
+
+  private long heartbeatsSent;
+
+  private ConcurrentMap<String, HeartBeatPropertyPayload> heartbeatProperties;
+
+  private long interval;
+
+  private TelemetryClient telemetryClient;
+
+  private volatile boolean isEnabled;
+
+  public HeartBeatProvider() {
+    this.interval = HeartBeatProviderInterface.DEFAULT_HEARTBEAT_INTERVAL;
+    this.heartbeatProperties = new ConcurrentHashMap<>();
+    this.isEnabled = true;
+  }
+
+  @Override
+  public String getInstrumentationKey() {
+    return null;
+  }
+
+  @Override
+  public void setInstrumentationKey(String key) {
+
+  }
+
+  @Override
+  public void initialize(TelemetryConfiguration configuration) {
+
+  }
+
+  @Override
+  public boolean addHeartBeatProperty(String propertyName, String propertyValue,
+      boolean isHealthy) {
+    return false;
+  }
+
+  @Override
+  public boolean setHeartBeatPropertyName(String propertyName, String propertyValue,
+      boolean isHealthy) {
+    return false;
+  }
+
+  @Override
+  public boolean isHeartBeatEnabled() {
+    return false;
+  }
+
+  @Override
+  public void setHeartBeatEnabled(boolean isEnabled) {
+
+  }
+
+  @Override
+  public List<String> getExcludedHeartBeatPropertyProviders() {
+    return null;
+  }
+
+  @Override
+  public void setExcludedHeartBeatPropertyProviders(
+      List<String> excludedHeartBeatPropertyProviders) {
+
+  }
+
+  @Override
+  public long getHeartBeatInterval() {
+    return this.interval;
+  }
+
+  @Override
+  public void setHeartBeatInterval(long timeUnit) {
+    // user set time unit in seconds
+    if (timeUnit <= HeartBeatProviderInterface.MINIMUM_HEARTBEAT_INTERVAL) {
+      this.interval = HeartBeatProviderInterface.MINIMUM_HEARTBEAT_INTERVAL;
+    }
+    else {
+      this.interval = timeUnit;
+    }
+  }
+
+  @Override
+  public List<String> getExcludedHeartBeatProperties() {
+    return null;
+  }
+
+  @Override
+  public void setExcludedHeartBeatProperties(List<String> excludedHeartBeatProperties) {
+
+  }
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderInterface.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderInterface.java
@@ -4,36 +4,115 @@ import com.microsoft.applicationinsights.TelemetryConfiguration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * <h1>Interface for HeartBeat Properties</h1>
+ *
+ * <p>
+ * This interface defines an implementation for configuring the properties of Application Insights
+ * SDK. It allows users to set and get the configuration properties of HeartBeat module. A user can
+ * create or bring his own custom implementation of Heartbeat module if wished provided that he abides
+ * to the contracts set by this Interface.
+ *
+ * Default concrete Implementation {@link com.microsoft.applicationinsights.internal.heartbeat.HeartBeatProvider}
+ * </p>
+ *
+ * @author Dhaval Doshi
+ * @since 03-30-2018
+ */
 public interface HeartBeatProviderInterface {
 
+  /**
+   * Default interval in seconds to transmit heartbeat pulse.
+   */
   long DEFAULT_HEARTBEAT_INTERVAL = TimeUnit.MINUTES.toSeconds(15);
 
+  /**
+   * Minimum interval which can be configured by user to transmit heartbeat pulse.
+   */
   long MINIMUM_HEARTBEAT_INTERVAL = TimeUnit.SECONDS.toSeconds(30);
 
+  /**
+   * Gets the instrumentation key used by telemetry client sending heartbeat.
+   * @return InstrumentationKey
+   */
   String getInstrumentationKey();
 
+  /**
+   * Sets the instrumentation key
+   * @param key Key to be set
+   */
   void setInstrumentationKey(String key);
 
+  /**
+   * This method initializes the concrete module.
+   * @param configuration TelemetryConfiguration
+   */
   void initialize(TelemetryConfiguration configuration);
 
+  /**
+   * Adds the heartbeat property to the heartbeat payload.
+   * @param propertyName Name of the property to be added in Heartbeat payload
+   * @param propertyValue Value of the property to be added in Heartbeat payload
+   * @param isHealthy indicates if heartbeat is healthy
+   * @return true if property is added successfully
+   */
   boolean addHeartBeatProperty(String propertyName, String propertyValue, boolean isHealthy);
 
+  /**
+   * Sets the value of already existing heartbeat property in the payload.
+   * @param propertyName Name of the property to be added in Heartbeat payload
+   * @param propertyValue Value of the property to be added in Heartbeat payload
+   * @param isHealthy indicates if heartbeat is healthy
+   * @return true if property is added successfully
+   */
   boolean setHeartBeatProperty(String propertyName, String propertyValue, boolean isHealthy);
 
+  /**
+   * Returns if heartbeat is enabled or not.
+   * @return true if heartbeat is enabled
+   */
   boolean isHeartBeatEnabled();
 
+  /**
+   * Enables or disables heartbeat module.
+   * @param isEnabled state of the heartbeat (enabled/disabled)
+   */
   void setHeartBeatEnabled(boolean isEnabled);
 
+  /**
+   * This returns the list of Excluded Heart Beat Providers
+   * @return list of excluded heartbeat providers
+   */
   List<String> getExcludedHeartBeatPropertyProviders();
 
+  /**
+   * Sets the list of excluded heartbeat providers.
+   * @param excludedHeartBeatPropertyProviders List of heartbeat providers to be excluded
+   */
   void setExcludedHeartBeatPropertyProviders(List<String> excludedHeartBeatPropertyProviders);
 
+  /**
+   * Gets the currently set heartbeat interval.
+   * @return returns the time interval of heartbeat
+   */
   long getHeartBeatInterval();
 
+  /**
+   * Sets the time interval of heartbeat in seconds.
+   * @param timeUnit Heartbeat interval in seconds
+   */
   void setHeartBeatInterval(long timeUnit);
 
+  /**
+   * Returns the list of excluded heartbeat properties.
+   * @return List of excluded heartbeat properties
+   */
   List<String> getExcludedHeartBeatProperties();
 
+  /**
+   * Sets the list of properties to be excluded from heartbeat payload.
+   * @param excludedHeartBeatProperties  List of properties to be excluded
+   */
   void setExcludedHeartBeatProperties(List<String> excludedHeartBeatProperties);
 
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderInterface.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderInterface.java
@@ -18,7 +18,7 @@ public interface HeartBeatProviderInterface {
 
   boolean addHeartBeatProperty(String propertyName, String propertyValue, boolean isHealthy);
 
-  boolean setHeartBeatPropertyName(String propertyName, String propertyValue, boolean isHealthy);
+  boolean setHeartBeatProperty(String propertyName, String propertyValue, boolean isHealthy);
 
   boolean isHeartBeatEnabled();
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderInterface.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderInterface.java
@@ -1,0 +1,39 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public interface HeartBeatProviderInterface {
+
+  long DEFAULT_HEARTBEAT_INTERVAL = TimeUnit.MINUTES.toSeconds(15);
+
+  long MINIMUM_HEARTBEAT_INTERVAL = TimeUnit.SECONDS.toSeconds(30);
+
+  String getInstrumentationKey();
+
+  void setInstrumentationKey(String key);
+
+  void initialize(TelemetryConfiguration configuration);
+
+  boolean addHeartBeatProperty(String propertyName, String propertyValue, boolean isHealthy);
+
+  boolean setHeartBeatPropertyName(String propertyName, String propertyValue, boolean isHealthy);
+
+  boolean isHeartBeatEnabled();
+
+  void setHeartBeatEnabled(boolean isEnabled);
+
+  List<String> getExcludedHeartBeatPropertyProviders();
+
+  void setExcludedHeartBeatPropertyProviders(List<String> excludedHeartBeatPropertyProviders);
+
+  long getHeartBeatInterval();
+
+  void setHeartBeatInterval(long timeUnit);
+
+  List<String> getExcludedHeartBeatProperties();
+
+  void setExcludedHeartBeatProperties(List<String> excludedHeartBeatProperties);
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatDefaultPayload.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatDefaultPayload.java
@@ -1,0 +1,47 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public class HeartbeatDefaultPayload {
+
+  private static final List<HeartBeatDefaultPayloadProviderInterface> defaultPayloadProviders =
+      new ArrayList<>();
+
+  static {
+    defaultPayloadProviders.add(new BaseDefaultHeartbeatPropertyProvider());
+  }
+
+  public static boolean isDefaultKeyword(String keyword) {
+    for (HeartBeatDefaultPayloadProviderInterface payloadProvider : defaultPayloadProviders) {
+      if (payloadProvider.isKeyword(keyword)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static Callable<Boolean> populateDefaultPayload(final List<String> disabledFields, final List<String>
+      disabledProviders, final HeartBeatProviderInterface provider) {
+    return new Callable<Boolean>() {
+
+      volatile boolean populatedFields = false;
+      @Override
+      public Boolean call() throws Exception {
+        for (HeartBeatDefaultPayloadProviderInterface payloadProvider : defaultPayloadProviders) {
+          if (disabledProviders != null && disabledProviders.contains(payloadProvider.getName())) {
+
+            // skip any azure specific modules here
+            continue;
+          }
+
+          boolean fieldsAreSet = payloadProvider.setDefaultPayload(disabledFields, provider).call();
+          populatedFields = populatedFields || fieldsAreSet;
+        }
+        return populatedFields;
+      }
+    };
+  }
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatDefaultPayload.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatDefaultPayload.java
@@ -14,6 +14,15 @@ public class HeartbeatDefaultPayload {
     defaultPayloadProviders.add(new WebAppsDefaultHeartbeatProvider());
   }
 
+  public static boolean isDefaultKeyWord(String keyword) {
+    for (HeartBeatDefaultPayloadProviderInterface payloadProvider : defaultPayloadProviders) {
+      if (payloadProvider.isKeyWord(keyword)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static Callable<Boolean> populateDefaultPayload(final List<String> disabledFields, final List<String>
       disabledProviders, final HeartBeatProviderInterface provider) {
     return new Callable<Boolean>() {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatDefaultPayload.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatDefaultPayload.java
@@ -11,15 +11,7 @@ public class HeartbeatDefaultPayload {
 
   static {
     defaultPayloadProviders.add(new BaseDefaultHeartbeatPropertyProvider());
-  }
-
-  public static boolean isDefaultKeyword(String keyword) {
-    for (HeartBeatDefaultPayloadProviderInterface payloadProvider : defaultPayloadProviders) {
-      if (payloadProvider.isKeyword(keyword)) {
-        return true;
-      }
-    }
-    return false;
+    defaultPayloadProviders.add(new WebAppsDefaultHeartbeatProvider());
   }
 
   public static Callable<Boolean> populateDefaultPayload(final List<String> disabledFields, final List<String>

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/MiscUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/MiscUtils.java
@@ -1,0 +1,51 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+class MiscUtils {
+
+  static Set<String> except(Set<String> set, List<String> list2) {
+    try {
+      if (set == null || list2 == null) throw new IllegalArgumentException("Input is null");
+      Set<String> result = new HashSet<>();
+      for (String s : list2) {
+        if (!set.contains(s)) {
+          result.add(s);
+        }
+      }
+      return result;
+    }
+    catch (Exception e) {
+      InternalLogger.INSTANCE.warn("stack trace is %s", ExceptionUtils.getStackTrace(e));
+    }
+    finally{
+      return set;
+    }
+
+  }
+
+  static boolean containsIgnoreCase(String keyword, Set<String> inputList) {
+    try {
+      if (keyword == null) throw new IllegalArgumentException("Keyword to compare is null");
+      if (inputList == null) throw new IllegalArgumentException("List to compare is null");
+      for (String key : inputList) {
+        if (key.equalsIgnoreCase(keyword)) return true;
+      }
+      return false;
+    }
+    catch (Exception e) {
+      InternalLogger.INSTANCE.warn("exception while comparision, stack trace is %s",
+          ExceptionUtils.getStackTrace(e));
+    }
+    finally{
+      //return true so we don't add property when comparison exception
+      return true;
+    }
+
+  }
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/MiscUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/MiscUtils.java
@@ -6,8 +6,20 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+/**
+ * This class contains some misc. functions used in heartbeat module.
+ *
+ * @author Dhaval Doshi
+ * @since 03-30-2018
+ */
 class MiscUtils {
 
+  /**
+   * Returns a list which contains Items present in list2 but not in the set.
+   * @param set
+   * @param list2
+   * @return
+   */
   static Set<String> except(Set<String> set, List<String> list2) {
     try {
       if (set == null || list2 == null) throw new IllegalArgumentException("Input is null");
@@ -28,6 +40,12 @@ class MiscUtils {
 
   }
 
+  /**
+   * This method returns true if keyword is present in the input list ignoring the case
+   * @param keyword to compare
+   * @param inputList list of string containing reserved keywords
+   * @return true if input word is present in the list ignoring the case.
+   */
   static boolean containsIgnoreCase(String keyword, Set<String> inputList) {
     try {
       if (keyword == null) throw new IllegalArgumentException("Keyword to compare is null");

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsDefaultHeartbeatProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsDefaultHeartbeatProvider.java
@@ -8,14 +8,36 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
+/**
+ * <h1>WebApp Heartbeat Property Provider</h1>
+ * <p>
+ *   This class is a concrete implementation of {@link com.microsoft.applicationinsights.internal.heartbeat.HeartBeatDefaultPayloadProviderInterface}
+ *   It enables setting Web-apps Metadata to heartbeat payload.
+ * </p>
+ *
+ * @author Dhaval Doshi
+ * @since 03-30-2018
+ */
 public class WebAppsDefaultHeartbeatProvider implements HeartBeatDefaultPayloadProviderInterface {
 
+  /**
+   * Name of the provider
+   */
   private final String name = "webapps";
 
+  /**
+   * Collection holding default properties for this default provider.
+   */
   private final Set<String> defaultFields;
 
+  /**
+   * Map for storing environment variables
+   */
   private final Map<String, String> environmentMap;
 
+  /**
+   * Constructor that initializes fields and load environment variables
+   */
   public WebAppsDefaultHeartbeatProvider() {
     defaultFields = new HashSet<>();
     environmentMap = System.getenv();
@@ -25,6 +47,11 @@ public class WebAppsDefaultHeartbeatProvider implements HeartBeatDefaultPayloadP
   @Override
   public String getName() {
     return this.name;
+  }
+
+  @Override
+  public boolean isKeyWord(String keyword) {
+    return defaultFields.contains(keyword);
   }
 
   @Override
@@ -71,6 +98,10 @@ public class WebAppsDefaultHeartbeatProvider implements HeartBeatDefaultPayloadP
     };
   }
 
+  /**
+   * Populates the default Fields with the properties
+   * @param defaultFields
+   */
   private void initializeDefaultFields(Set<String> defaultFields) {
     if (defaultFields == null) {
       defaultFields = new HashSet<>();
@@ -81,6 +112,10 @@ public class WebAppsDefaultHeartbeatProvider implements HeartBeatDefaultPayloadP
 
   }
 
+  /**
+   * Returns the name of the website by reading environment variable
+   * @return website name
+   */
   private String getWebsiteSiteName() {
     if (environmentMap.containsKey("WEBSITE_SITE_NAME")) {
       return environmentMap.get("WEBSITE_SITE_NAME");
@@ -88,6 +123,10 @@ public class WebAppsDefaultHeartbeatProvider implements HeartBeatDefaultPayloadP
     return null;
   }
 
+  /**
+   * Returns the website home stamp name by reading environment variable
+   * @return website stamp host name
+   */
   private String getWebsiteHostName() {
     if (environmentMap.containsKey("WEBSITE_HOME_STAMPNAME")) {
       return environmentMap.get("WEBSITE_HOME_STAMPNAME");

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsDefaultHeartbeatProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsDefaultHeartbeatProvider.java
@@ -1,0 +1,97 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+public class WebAppsDefaultHeartbeatProvider implements HeartBeatDefaultPayloadProviderInterface {
+
+  private final String name = "webapps";
+
+  private final Set<String> defaultFields;
+
+  private final Map<String, String> environmentMap;
+
+  public WebAppsDefaultHeartbeatProvider() {
+    defaultFields = new HashSet<>();
+    environmentMap = System.getenv();
+    initializeDefaultFields(defaultFields);
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
+  }
+
+  @Override
+  public Callable<Boolean> setDefaultPayload(final List<String> disableFields,
+      final HeartBeatProviderInterface provider) {
+    return new Callable<Boolean>() {
+      volatile boolean hasSetValues = false;
+      volatile Set<String> enabledProperties = MiscUtils.except(defaultFields, disableFields);
+      @Override
+      public Boolean call() {
+        for (String fieldName : enabledProperties) {
+          try {
+            switch (fieldName) {
+              case "website_site_name":
+                String webSiteName = getWebsiteSiteName();
+                if (webSiteName == null) {
+                  InternalLogger.INSTANCE.trace("Web site name not available, probably not a web app");
+                  break;
+                }
+                provider.addHeartBeatProperty(fieldName, webSiteName, true);
+                hasSetValues = true;
+                break;
+              case "website_home_name":
+                String webSiteHostName = getWebsiteHostName();
+                if (webSiteHostName == null) {
+                  InternalLogger.INSTANCE.trace("web site host name not available, probably not a web app");
+                  break;
+                }
+                provider.addHeartBeatProperty(fieldName, webSiteHostName, true);
+                hasSetValues = true;
+                break;
+              default:
+                InternalLogger.INSTANCE.trace("Unknown web apps property encountered");
+                break;
+            }
+          }
+          catch (Exception e) {
+            InternalLogger.INSTANCE.warn("Failed to obtain heartbeat property, stack trace"
+                + "is: %s", ExceptionUtils.getStackTrace(e));
+          }
+        }
+        return hasSetValues;
+      }
+    };
+  }
+
+  private void initializeDefaultFields(Set<String> defaultFields) {
+    if (defaultFields == null) {
+      defaultFields = new HashSet<>();
+    }
+
+    defaultFields.add("website_site_name");
+    defaultFields.add("website_home_name");
+
+  }
+
+  private String getWebsiteSiteName() {
+    if (environmentMap.containsKey("WEBSITE_SITE_NAME")) {
+      return environmentMap.get("WEBSITE_SITE_NAME");
+    }
+    return null;
+  }
+
+  private String getWebsiteHostName() {
+    if (environmentMap.containsKey("WEBSITE_HOME_STAMPNAME")) {
+      return environmentMap.get("WEBSITE_HOME_STAMPNAME");
+    }
+    return null;
+  }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactoryTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactoryTest.java
@@ -481,10 +481,11 @@ public final class TelemetryConfigurationFactoryTest {
 
         initializeWithFactory(mockParser, mockConfiguration);
 
-        assertEquals(mockConfiguration.getTelemetryModules().size(), 1);
-        assertTrue(mockConfiguration.getTelemetryModules().get(0) instanceof MockPerformanceModule);
-        assertTrue(((MockPerformanceModule)mockConfiguration.getTelemetryModules().get(0)).initializeWasCalled);
-        assertTrue(((MockPerformanceModule)mockConfiguration.getTelemetryModules().get(0)).addConfigurationDataWasCalled);
+        //heartbeat is added as default
+        assertEquals(mockConfiguration.getTelemetryModules().size(), 2);
+        assertTrue(mockConfiguration.getTelemetryModules().get(1) instanceof MockPerformanceModule);
+        assertTrue(((MockPerformanceModule)mockConfiguration.getTelemetryModules().get(1)).initializeWasCalled);
+        assertTrue(((MockPerformanceModule)mockConfiguration.getTelemetryModules().get(1)).addConfigurationDataWasCalled);
     }
 
 

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderMock.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProviderMock.java
@@ -1,0 +1,114 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class HeartBeatProviderMock implements HeartBeatProviderInterface {
+
+  private ConcurrentMap<String, HeartBeatPropertyPayload> heartbeatProperties;
+
+  private List<String> disableDefaultProperties = new ArrayList<>();
+
+  private List<String> disabledHeartBeatPropertiesProviders = new ArrayList<>();
+
+  private String instrumentationKey;
+
+  private volatile boolean isEnabled;
+
+  private long interval;
+
+  public HeartBeatProviderMock() {
+    this.heartbeatProperties = new ConcurrentHashMap<>();
+    this.instrumentationKey = UUID.randomUUID().toString();
+    this.isEnabled = true;
+    this.interval = 31;
+  }
+
+  public ConcurrentMap<String, HeartBeatPropertyPayload> getHeartBeatProperties() {
+    return this.heartbeatProperties;
+
+  }
+  @Override
+  public String getInstrumentationKey() {
+    return this.instrumentationKey;
+  }
+
+  @Override
+  public void setInstrumentationKey(String key) {
+
+  }
+
+  @Override
+  public void initialize(TelemetryConfiguration configuration) {
+
+  }
+
+  @Override
+  public boolean addHeartBeatProperty(String propertyName, String propertyValue,
+      boolean isHealthy) {
+    HeartBeatPropertyPayload payload = new HeartBeatPropertyPayload();
+    payload.setHealthy(isHealthy);
+    payload.setPayloadValue(propertyValue);
+    heartbeatProperties.put(propertyName, payload);
+    return true;
+  }
+
+  @Override
+  public boolean setHeartBeatProperty(String propertyName, String propertyValue,
+      boolean isHealthy) {
+    if (heartbeatProperties.containsKey(propertyName)) {
+      HeartBeatPropertyPayload payload = new HeartBeatPropertyPayload();
+      payload.setHealthy(isHealthy);
+      payload.setPayloadValue(propertyValue);
+      heartbeatProperties.put(propertyName, payload);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isHeartBeatEnabled() {
+    return this.isEnabled;
+  }
+
+  @Override
+  public void setHeartBeatEnabled(boolean isEnabled) {
+
+  }
+
+  @Override
+  public List<String> getExcludedHeartBeatPropertyProviders() {
+    return this.disabledHeartBeatPropertiesProviders;
+  }
+
+  @Override
+  public void setExcludedHeartBeatPropertyProviders(
+      List<String> excludedHeartBeatPropertyProviders) {
+
+  }
+
+  @Override
+  public long getHeartBeatInterval() {
+    return this.interval;
+  }
+
+  @Override
+  public void setHeartBeatInterval(long timeUnit) {
+
+  }
+
+  @Override
+  public List<String> getExcludedHeartBeatProperties() {
+    return this.disableDefaultProperties;
+  }
+
+  @Override
+  public void setExcludedHeartBeatProperties(List<String> excludedHeartBeatProperties) {
+
+  }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
@@ -82,7 +82,7 @@ public class HeartbeatTests {
 
     boolean origIsEnabled = true;
     String origExcludedHbProvider = "FakeProvider";
-    long orignalInterval = 0;
+    long originalInterval = 0;
     long setInterval = 30;
 
     for (TelemetryModule module : TelemetryConfiguration.getActive().getTelemetryModules()) {
@@ -92,7 +92,7 @@ public class HeartbeatTests {
 
         Assert.assertFalse(((HeartBeatModule)module).getExcludedHeartBeatProperties().contains(origExcludedHbProvider));
         ((HeartBeatModule)module).setExcludedHeartBeatPropertiesProvider(Arrays.asList(origExcludedHbProvider));
-        orignalInterval = ((HeartBeatModule)module).getHeartBeatInterval();
+        originalInterval = ((HeartBeatModule)module).getHeartBeatInterval();
         ((HeartBeatModule)module).setExcludedHeartBeatProperties(Arrays.asList("test01"));
         ((HeartBeatModule)module).setHeartBeatInterval(setInterval);
       }
@@ -104,7 +104,7 @@ public class HeartbeatTests {
         Assert.assertNotEquals(((HeartBeatModule)module).isHeartBeatEnabled(), origIsEnabled);
         Assert.assertTrue(((HeartBeatModule)module).getExcludedHeartBeatPropertiesProvider().contains(origExcludedHbProvider));
         Assert.assertTrue(((HeartBeatModule)module).getExcludedHeartBeatProperties().contains("test01"));
-        Assert.assertNotEquals(((HeartBeatModule)module).getHeartBeatInterval(), orignalInterval);
+        Assert.assertNotEquals(((HeartBeatModule)module).getHeartBeatInterval(), originalInterval);
         Assert.assertEquals(((HeartBeatModule)module).getHeartBeatInterval(), setInterval);
       }
     }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
@@ -33,17 +33,13 @@ public class HeartbeatTests {
   }
 
   @Test
-  public void initializeHeartBeatDefaultsAreSetCorrectly() {
+  public void initializeHeartBeatDefaultsAreSetCorrectly() throws Exception {
     HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
     module.initialize(null);
-    try {
-      Thread.sleep(100);
-    }
-    catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    Thread.sleep(100);
     Assert.assertTrue(module.getExcludedHeartBeatProperties() == null ||
-      module.getExcludedHeartBeatProperties().size() == 0);
+    module.getExcludedHeartBeatProperties().size() == 0);
     Assert.assertEquals(module.getHeartBeatInterval(), HeartBeatProviderInterface.DEFAULT_HEARTBEAT_INTERVAL);
   }
 
@@ -69,19 +65,15 @@ public class HeartbeatTests {
   }
 
   @Test
-  public void canExtendHeartBeatPayload()  {
+  public void canExtendHeartBeatPayload() throws Exception {
     HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
     module.initialize(new TelemetryConfiguration());
-    try {
-      Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
-      field.setAccessible(true);
-      HeartBeatProviderInterface hbi = (HeartBeatProviderInterface)field.get(module);
-      Assert.assertTrue(hbi.addHeartBeatProperty("test01",
-          "This is value", true));
 
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+    Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
+    field.setAccessible(true);
+    HeartBeatProviderInterface hbi = (HeartBeatProviderInterface)field.get(module);
+    Assert.assertTrue(hbi.addHeartBeatProperty("test01",
+        "This is value", true));
   }
 
   @Test
@@ -138,7 +130,7 @@ public class HeartbeatTests {
   }
 
   @Test
-  public void canDisableHeartBeatPriorToInitialize() {
+  public void canDisableHeartBeatPriorToInitialize() throws Exception {
     Map<String, String> dummyPropertyMap = new HashMap<>();
     dummyPropertyMap.put("isHeartBeatEnabled", "false");
     HeartBeatModule module = new HeartBeatModule(dummyPropertyMap);
@@ -147,132 +139,108 @@ public class HeartbeatTests {
     module.initialize(configuration);
     Assert.assertFalse(module.isHeartBeatEnabled());
 
-    try {
-      Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
-      field.setAccessible(true);
-      HeartBeatProviderInterface hbi = (HeartBeatProviderInterface) field.get(module);
-      Assert.assertFalse(hbi.isHeartBeatEnabled());
-    }
-    catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
+    field.setAccessible(true);
+    HeartBeatProviderInterface hbi = (HeartBeatProviderInterface) field.get(module);
+    Assert.assertFalse(hbi.isHeartBeatEnabled());
   }
 
   @Test
-  public void canDisableHeartBeatPropertyProviderPriorToInitialize() {
+  public void canDisableHeartBeatPropertyProviderPriorToInitialize() throws  Exception {
     HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
     module.setExcludedHeartBeatPropertiesProvider(Arrays.asList("Base", "webapps"));
 
 
-    try {
-      Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
-      field.setAccessible(true);
-      HeartBeatProviderInterface hbi = (HeartBeatProviderInterface) field.get(module);
-      Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("Base"));
-      Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("webapps"));
-      module.initialize(new TelemetryConfiguration());
+    Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
+    field.setAccessible(true);
+    HeartBeatProviderInterface hbi = (HeartBeatProviderInterface) field.get(module);
+    Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("Base"));
+    Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("webapps"));
+    module.initialize(new TelemetryConfiguration());
 
-      Thread.sleep(100);
-      Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("Base"));
-      Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("webapps"));
-    }
-    catch (Exception e) {
-      e.printStackTrace();
-    }
+    Thread.sleep(100);
+    Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("Base"));
+    Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("webapps"));
   }
 
   @Test
-  public void defaultHeartbeatPropertyProviderSendsNoFieldWhenDisabled() {
+  public void defaultHeartbeatPropertyProviderSendsNoFieldWhenDisabled() throws Exception {
     HeartBeatProviderMock mockProvider = new HeartBeatProviderMock();
     List<String> disabledProviders = new ArrayList<>();
     disabledProviders.add("Base");
     disabledProviders.add("webapps");
     Callable<Boolean> callable = HeartbeatDefaultPayload.populateDefaultPayload(new ArrayList<String>(),
         disabledProviders, mockProvider);
-    try {
-      callable.call();
-      Assert.assertEquals(0, mockProvider.getHeartBeatProperties().size());
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    callable.call();
+    Assert.assertEquals(0, mockProvider.getHeartBeatProperties().size());
   }
 
   @Test
-  public void heartBeatPayloadContainsDataByDefault() {
+  public void heartBeatPayloadContainsDataByDefault() throws Exception {
     HeartBeatProvider provider = new HeartBeatProvider();
     provider.initialize(null);
-    try {
-      Thread.sleep(100);
-      Method m = provider.getClass().getDeclaredMethod("gatherData");
-      m.setAccessible(true);
-      Telemetry t = (Telemetry)m.invoke(provider);
-      Assert.assertNotNull(t);
-      // for callable to complete adding
-      Thread.sleep(100);
-      Assert.assertTrue(t.getProperties().size() > 0);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    Thread.sleep(100);
+    Method m = provider.getClass().getDeclaredMethod("gatherData");
+    m.setAccessible(true);
+    Telemetry t = (Telemetry)m.invoke(provider);
+    Assert.assertNotNull(t);
+    // for callable to complete adding
+    Thread.sleep(100);
+    Assert.assertTrue(t.getProperties().size() > 0);
+
   }
 
   @Test
-  public void heartBeatPayloadContainsSpecificProperties() {
+  public void heartBeatPayloadContainsSpecificProperties() throws Exception {
     HeartBeatProvider provider = new HeartBeatProvider();
     Assert.assertTrue(provider.addHeartBeatProperty("test", "testVal", true));
-    try {
-      Method m = provider.getClass().getDeclaredMethod("gatherData");
-      m.setAccessible(true);
-      Telemetry t = (Telemetry)m.invoke(provider);
-      Assert.assertEquals("testVal", t.getProperties().get("test"));
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    Method m = provider.getClass().getDeclaredMethod("gatherData");
+    m.setAccessible(true);
+    Telemetry t = (Telemetry)m.invoke(provider);
+    Assert.assertEquals("testVal", t.getProperties().get("test"));
+
   }
 
   @Test
-  public void heartbeatMetricIsNonZeroWhenFailureConditionPresent() {
+  public void heartbeatMetricIsNonZeroWhenFailureConditionPresent() throws Exception {
     HeartBeatProvider provider = new HeartBeatProvider();
     Assert.assertTrue(provider.addHeartBeatProperty("test", "testVal", false));
-    try {
-      Method m = provider.getClass().getDeclaredMethod("gatherData");
-      m.setAccessible(true);
-      Telemetry t = (Telemetry)m.invoke(provider);
-      Assert.assertEquals(1, ((MetricTelemetry)t).getValue(), 0.0);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    Method m = provider.getClass().getDeclaredMethod("gatherData");
+    m.setAccessible(true);
+    Telemetry t = (Telemetry)m.invoke(provider);
+    Assert.assertEquals(1, ((MetricTelemetry)t).getValue(), 0.0);
+
   }
 
   @Test
-  public void heartbeatMetricCountsForAllFailures() {
+  public void heartbeatMetricCountsForAllFailures() throws Exception {
     HeartBeatProvider provider = new HeartBeatProvider();
     Assert.assertTrue(provider.addHeartBeatProperty("test", "testVal", false));
     Assert.assertTrue(provider.addHeartBeatProperty("test1", "testVal1", false));
-    try {
-      Method m = provider.getClass().getDeclaredMethod("gatherData");
-      m.setAccessible(true);
-      Telemetry t = (Telemetry)m.invoke(provider);
-      Assert.assertEquals(2, ((MetricTelemetry)t).getValue(), 0.0);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    Method m = provider.getClass().getDeclaredMethod("gatherData");
+    m.setAccessible(true);
+    Telemetry t = (Telemetry)m.invoke(provider);
+    Assert.assertEquals(2, ((MetricTelemetry)t).getValue(), 0.0);
   }
 
   @Test
-  public void sentHeartbeatContainsExpectedDefaultFields() {
+  public void sentHeartbeatContainsExpectedDefaultFields() throws Exception {
     HeartBeatProviderMock mock = new HeartBeatProviderMock();
     BaseDefaultHeartbeatPropertyProvider defaultProvider = new BaseDefaultHeartbeatPropertyProvider();
-    try {
-      HeartbeatDefaultPayload.populateDefaultPayload(new ArrayList<String>(), new ArrayList<String>(),
-          mock).call();
-      Field field = defaultProvider.getClass().getDeclaredField("defaultFields");
-      field.setAccessible(true);
-      Set<String> defaultFields = (Set<String>)field.get(defaultProvider);
-      for (String fieldName : defaultFields) {
-        Assert.assertTrue(mock.getHeartBeatProperties().containsKey(fieldName));
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
+
+    HeartbeatDefaultPayload.populateDefaultPayload(new ArrayList<String>(), new ArrayList<String>(),
+        mock).call();
+    Field field = defaultProvider.getClass().getDeclaredField("defaultFields");
+    field.setAccessible(true);
+    Set<String> defaultFields = (Set<String>)field.get(defaultProvider);
+    for (String fieldName : defaultFields) {
+      Assert.assertTrue(mock.getHeartBeatProperties().containsKey(fieldName));
     }
   }
 
@@ -294,61 +262,47 @@ public class HeartbeatTests {
   }
 
   @Test
-  public void cannotSetValueOfDefaultPayloadProperties() {
+  public void cannotSetValueOfDefaultPayloadProperties() throws Exception {
     HeartBeatProvider provider = new HeartBeatProvider();
     provider.initialize(null);
     BaseDefaultHeartbeatPropertyProvider defaultBase = new BaseDefaultHeartbeatPropertyProvider();
-    try {
-      //for callable to complete
-      Thread.sleep(100);
-      Field field = defaultBase.getClass().getDeclaredField("defaultFields");
-      field.setAccessible(true);
-      Set<String> defaultFields = (Set<String>)field.get(defaultBase);
-      for (String key : defaultFields) {
-        Assert.assertFalse(provider.setHeartBeatProperty(key, "test", true));
-      }
 
-    }
-    catch (Exception e) {
-      e.printStackTrace();
+    //for callable to complete
+    Thread.sleep(100);
+    Field field = defaultBase.getClass().getDeclaredField("defaultFields");
+    field.setAccessible(true);
+    Set<String> defaultFields = (Set<String>)field.get(defaultBase);
+    for (String key : defaultFields) {
+      Assert.assertFalse(provider.setHeartBeatProperty(key, "test", true));
     }
   }
 
   @Test
-  public void cannotAddUnknownDefaultProperty() {
+  public void cannotAddUnknownDefaultProperty() throws Exception {
     BaseDefaultHeartbeatPropertyProvider base = new BaseDefaultHeartbeatPropertyProvider();
     String testKey = "testKey";
-    try {
-      Field field = base.getClass().getDeclaredField("defaultFields");
-      field.setAccessible(true);
-      Set<String> defaultFields = (Set<String>)field.get(base);
-      defaultFields.add(testKey);
-      HeartBeatProvider provider = new HeartBeatProvider();
-      base.setDefaultPayload(new ArrayList<String>(), provider).call();
-      Method m = provider.getClass().getDeclaredMethod("gatherData");
-      m.setAccessible(true);
-      Telemetry t = (Telemetry)m.invoke(provider);
-      Assert.assertFalse(t.getProperties().containsKey("testKey"));
-    }
-    catch (Exception e) {
-      e.printStackTrace();
-    }
+
+    Field field = base.getClass().getDeclaredField("defaultFields");
+    field.setAccessible(true);
+    Set<String> defaultFields = (Set<String>)field.get(base);
+    defaultFields.add(testKey);
+    HeartBeatProvider provider = new HeartBeatProvider();
+    base.setDefaultPayload(new ArrayList<String>(), provider).call();
+    Method m = provider.getClass().getDeclaredMethod("gatherData");
+    m.setAccessible(true);
+    Telemetry t = (Telemetry)m.invoke(provider);
+    Assert.assertFalse(t.getProperties().containsKey("testKey"));
   }
 
   @Test
-  public void configurationParsingWorksAsExpectedWhenMultipleParamsArePassed() {
+  public void configurationParsingWorksAsExpectedWhenMultipleParamsArePassed()
+      throws InterruptedException {
     Map<String, String> dummyPropertiesMap = new HashMap<>();
     dummyPropertiesMap.put("ExcludedHeartBeatPropertiesProvider", "Base;webapps");
     HeartBeatModule module = new HeartBeatModule(dummyPropertiesMap);
     module.initialize(null);
-
-    try {
-      Thread.sleep(100);
-      Assert.assertTrue(module.getExcludedHeartBeatPropertiesProvider().contains("Base"));
-      Assert.assertTrue(module.getExcludedHeartBeatPropertiesProvider().contains("webapps"));
-    }
-    catch (Exception e) {
-      e.printStackTrace();
-    }
+    Thread.sleep(100);
+    Assert.assertTrue(module.getExcludedHeartBeatPropertiesProvider().contains("Base"));
+    Assert.assertTrue(module.getExcludedHeartBeatPropertiesProvider().contains("webapps"));
   }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
@@ -109,4 +109,51 @@ public class HeartbeatTests {
       }
     }
   }
+
+  @Test
+  public void heartBeatIsEnabledByDefault() {
+
+  }
+
+  @Test
+  public void canDisableHeartBeatPriorToInitialize() {
+    Map<String, String> dummyPropertyMap = new HashMap<>();
+    dummyPropertyMap.put("isHeartBeatEnabled", "false");
+    HeartBeatModule module = new HeartBeatModule(dummyPropertyMap);
+    TelemetryConfiguration configuration = new TelemetryConfiguration();
+    configuration.getTelemetryModules().add(module);
+    module.initialize(configuration);
+    Assert.assertFalse(module.isHeartBeatEnabled());
+
+    try {
+      Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
+      field.setAccessible(true);
+      HeartBeatProviderInterface hbi = (HeartBeatProviderInterface) field.get(module);
+      Assert.assertFalse(hbi.isHeartBeatEnabled());
+    }
+    catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void canDisableHeartBeatPropertyProviderPriorToInitialize() {
+    HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
+    module.setExcludedHeartBeatPropertiesProvider(Arrays.asList("Base"));
+
+    try {
+      Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
+      field.setAccessible(true);
+      HeartBeatProviderInterface hbi = (HeartBeatProviderInterface) field.get(module);
+      Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("Base"));
+
+      module.initialize(new TelemetryConfiguration());
+
+      Assert.assertTrue(hbi.getExcludedHeartBeatPropertyProviders().contains("Base"));
+    }
+    catch (Exception e) {
+      e.printStackTrace();
+    }
+
+  }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/heartbeat/HeartbeatTests.java
@@ -1,0 +1,112 @@
+package com.microsoft.applicationinsights.internal.heartbeat;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.extensibility.TelemetryModule;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HeartbeatTests {
+
+  @Test
+  public void initializeHeartBeatModuleDoesNotThrow() {
+    HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
+    module.initialize(null);
+  }
+
+  @Test
+  public void initializeHeartBeatTwiceDoesNotFail() {
+    HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
+    module.initialize(null);
+    module.initialize(null);
+  }
+
+  @Test
+  public void initializeHeartBeatDefaultsAreSetCorrectly() {
+    HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
+    module.initialize(null);
+    Assert.assertTrue(module.getExcludedHeartBeatProperties() == null ||
+      module.getExcludedHeartBeatProperties().size() == 0);
+    Assert.assertEquals(module.getHeartBeatInterval(), HeartBeatProviderInterface.DEFAULT_HEARTBEAT_INTERVAL);
+  }
+
+  @Test
+  public void initializeHeartBeatWithNonDefaultIntervalSetsCorrectly() {
+    Map<String, String> dummyPropertiesMap = new HashMap<>();
+    long heartBeatInterval = 45;
+    dummyPropertiesMap.put("HeartBeatInterval", String.valueOf(heartBeatInterval));
+    HeartBeatModule module = new HeartBeatModule(dummyPropertiesMap);
+    module.initialize(null);
+    Assert.assertEquals(heartBeatInterval, module.getHeartBeatInterval());
+
+  }
+
+  @Test
+  public void initializeHeatBeatWithValueLessThanMinimumSetsToMinimum() {
+    Map<String, String> dummyPropertiesMap = new HashMap<>();
+    long heartBeatInterval = 0;
+    dummyPropertiesMap.put("HeartBeatInterval", String.valueOf(heartBeatInterval));
+    HeartBeatModule module = new HeartBeatModule(dummyPropertiesMap);
+    module.initialize(null);
+    Assert.assertNotEquals(heartBeatInterval, module.getHeartBeatInterval());
+    Assert.assertEquals(HeartBeatProviderInterface.MINIMUM_HEARTBEAT_INTERVAL, module.getHeartBeatInterval());
+  }
+
+  @Test
+  public void canExtendHeartBeatPayload()  {
+    HeartBeatModule module = new HeartBeatModule(new HashMap<String, String>());
+    module.initialize(new TelemetryConfiguration());
+    try {
+      Field field = module.getClass().getDeclaredField("heartBeatProviderInterface");
+      field.setAccessible(true);
+      HeartBeatProviderInterface hbi = (HeartBeatProviderInterface)field.get(module);
+      Assert.assertTrue(hbi.addHeartBeatProperty("test01",
+          "This is value", true));
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void initializationOfTelemetryClientDoesNotResetHeartbeat() {
+    HeartBeatModule hbm = new HeartBeatModule(new HashMap<String, String>());
+    TelemetryConfiguration configuration= new TelemetryConfiguration();
+    configuration.getTelemetryModules().add(hbm);
+    hbm.initialize(configuration);
+    TelemetryClient client = new TelemetryClient(configuration);
+
+    boolean origIsEnabled = true;
+    String origExcludedHbProvider = "FakeProvider";
+    long orignalInterval = 0;
+    long setInterval = 30;
+
+    for (TelemetryModule module : configuration.getTelemetryModules()) {
+      if (module instanceof HeartBeatModule) {
+        origIsEnabled = ((HeartBeatModule) module).isHeartBeatEnabled();
+        ((HeartBeatModule) module).setHeartBeatEnabled(!origIsEnabled);
+
+        Assert.assertFalse(hbm.getExcludedHeartBeatProperties().contains(origExcludedHbProvider));
+        hbm.setExcludedHeartBeatPropertiesProvider(Arrays.asList(origExcludedHbProvider));
+        orignalInterval = hbm.getHeartBeatInterval();
+        hbm.setExcludedHeartBeatProperties(Arrays.asList("test01"));
+        hbm.setHeartBeatInterval(setInterval);
+      }
+    }
+
+    TelemetryClient client2 = new TelemetryClient(configuration);
+    for (TelemetryModule module :configuration.getTelemetryModules()) {
+      if (module instanceof HeartBeatModule) {
+        Assert.assertNotEquals(hbm.isHeartBeatEnabled(), origIsEnabled);
+        Assert.assertTrue(hbm.getExcludedHeartBeatPropertiesProvider().contains(origExcludedHbProvider));
+        Assert.assertTrue(hbm.getExcludedHeartBeatProperties().contains("test01"));
+        Assert.assertNotEquals(hbm.getHeartBeatInterval(), orignalInterval);
+        Assert.assertEquals(hbm.getHeartBeatInterval(), setInterval);
+      }
+    }
+  }
+}


### PR DESCRIPTION
We would like to introduce HeartBeat feature. 

## What is Heartbeat?
Heartbeat in computer science is a periodic signal generated by software or hardware to indicate the normal operation or perform some synchronization. (https://en.wikipedia.org/wiki/Heartbeat_(computing))

### HeartBeat in Application Insights
HeartBeat in Application Insights would send out some minimal amount of information on a scheduled interval to assist in high level monitoring of application health and would provide some meta data like OS type, Java version, Application Insights SDK version, Website Name and Host (If running on Azure WebApps) and is extensible to add more information should your application have heartbeat specific requirements. 

### HeartBeat Default Payload
Default Heartbeat payload will contain following information : 
HeartBeat would be MetricTelemetry Item, a successful healthy heartbeat would have Metric Value = 0
It would contain following custom Dimensions - 
OS Name - Indicates the name of operating system on which application is running
Java Version - Indicates the JDK version which is used by the application.
SDK Version - Indicates the version of ApplicationInsights Java SDK being used
processSessionId - a random guid which represents each running session of application

If Application is running on Azure WebApps it would also have following information -
Website Name - Name of the website 
Host Stamp Name - Name of the host

### Core Components
`HeartBeatProviderInterface` - Defines the implementation of concrete HeartBeat Provider. Should a user want to create a custom heartbeat provider they should implement the contract of this interface.

`HearBeatProvider` - Default Concrete Implementation of HeartBeatProviderInterface for transmitting HeartBeat Metric

`HeartBeatDefaultPayloadProviderInterface` - Interface which defines HeartBeatPayloadProvider and mechanism to add heartbeat property via separate callable. If a user would like to add custom properties which belong to specific group, implementing this interface is recommended.

`BaseDefaultHeartbeatPropertyProvider` - Concrete implementation of HeartBeatDefaultPayloadProviderInterface for default properties like SDK version, OS name, Java Version and processSessionId

`WebAppsDefaultHeartbeatProvider` - Concrete implementation of HeartBeatDefaultPayloadProviderInterface for default azure webapps properties.

`HeartBeatModule` - Concrete Implementation of TelemetryModule interface which composes HeartBeatProvider class to transmit heartbeat periodically. This module is registered by default even with bare minimum telemetry configuration.

`HeartBeatPropertyPayload` - A container for holding heartbeat property value and meta data about if it has updated and health.

### Can you turn of HeartBeat ?
Yes, heartbeat can be turned off but it is highly not recommended to do this as it provides vital overview of your application health periodically.

### What is the default interval at which heatbeat is sent?
The, default interval at which heartbeat will be sent is 15 minutes.

### What is the minimum interval which can be configured to send heartbeat?
The, minimum interval which can be configured is 5 seconds.

### Can we override default heartbeat properties?
No, you cannot override default heartbeat properties. The are default and vital.

### Can you exclude default heartbeat providers?
Yes, you can but it is not recommended


For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
