### PR TITLE
Optimizations for Filter/TelemetryClient startup

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/annotation/AnnotationPackageScanner.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/annotation/AnnotationPackageScanner.java
@@ -33,13 +33,14 @@ import java.util.List;
  * Created by gupele on 3/15/2015.
  */
 public final class AnnotationPackageScanner {
+    private AnnotationPackageScanner(){}
     /**
      * The method will scan packages searching for classes that have the needed annotations.
      * @param annotationsToSearch The annotations we need.
      * @param packageToScan The packages to scan from, note that all sub packages will be scanned too.
      * @return A list of class names that are under the package we asked and that carry the needed annotations
      */
-    public List<String> scanForClassAnnotations(final Class<? extends Annotation>[] annotationsToSearch, String packageToScan) {
+    public static List<String> scanForClassAnnotations(final Class<? extends Annotation>[] annotationsToSearch, String packageToScan) {
         final ArrayList<String> performanceModuleNames = new ArrayList<String>();
         AnnotationDetector.TypeReporter reporter = new AnnotationDetector.TypeReporter() {
             @Override

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmitterImpl.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmitterImpl.java
@@ -22,7 +22,8 @@
 package com.microsoft.applicationinsights.internal.channel.common;
 
 import java.util.Collection;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -120,7 +121,7 @@ public final class TransmitterImpl implements TelemetriesTransmitter {
 
     private final TelemetrySerializer serializer;
 
-    private final ScheduledThreadPoolExecutor threadPool;
+    private final ScheduledExecutorService threadPool;
 
     private final TransmissionsLoader transmissionsLoader;
 
@@ -138,8 +139,7 @@ public final class TransmitterImpl implements TelemetriesTransmitter {
 
         semaphore = new Semaphore(MAX_PENDING_SCHEDULE_REQUESTS);
 
-        threadPool = new ScheduledThreadPoolExecutor(2);
-        threadPool.setThreadFactory(ThreadPoolUtils.createDaemonThreadFactory(TransmitterImpl.class, instanceId));
+        threadPool = Executors.newScheduledThreadPool(2, ThreadPoolUtils.createDaemonThreadFactory(TransmitterImpl.class, instanceId));
 
         this.transmissionsLoader = transmissionsLoader;
         this.transmissionsLoader.load(false);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -70,14 +70,14 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
         this.excludedTypes = new HashSet<Class>();
         try {
             this.allowedTypes = new HashMap<String, Class>() {{
-                put(dependencyTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry"));
-                put(eventTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.EventTelemetry"));
-                put(exceptionTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.ExceptionTelemetry"));
-                put(pageViewTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.PageViewTelemetry"));
-                put(requestTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.RequestTelemetry"));
-                put(traceTelemetryName, Class.forName("com.microsoft.applicationinsights.telemetry.TraceTelemetry"));
+                put(dependencyTelemetryName, com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry.class);
+                put(eventTelemetryName, com.microsoft.applicationinsights.telemetry.EventTelemetry.class);
+                put(exceptionTelemetryName, com.microsoft.applicationinsights.telemetry.ExceptionTelemetry.class);
+                put(pageViewTelemetryName, com.microsoft.applicationinsights.telemetry.PageViewTelemetry.class);
+                put(requestTelemetryName, com.microsoft.applicationinsights.telemetry.RequestTelemetry.class);
+                put(traceTelemetryName, com.microsoft.applicationinsights.telemetry.TraceTelemetry.class);
             }};
-        } catch (ClassNotFoundException e) {
+        } catch (Exception e) {
             InternalLogger.INSTANCE.trace("Unable to locate telemetry classes. stack trace is %s", ExceptionUtils.getStackTrace(e));
         }
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ReflectionUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ReflectionUtils.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +39,37 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  * Created by gupele on 8/7/2016.
  */
 public final class ReflectionUtils {
+
+    private static final Map<String, Class<?>> builtInMap = new HashMap<>();
+
+    static {
+        addClass(com.microsoft.applicationinsights.channel.concrete.inprocess.InProcessTelemetryChannel.class);
+        addClass(com.microsoft.applicationinsights.internal.channel.stdout.StdOutChannel.class);
+
+        addClass(com.microsoft.applicationinsights.internal.heartbeat.HeartBeatModule.class);
+        addClass(com.microsoft.applicationinsights.internal.perfcounter.JvmPerformanceCountersModule.class);
+        addClass(com.microsoft.applicationinsights.internal.perfcounter.ProcessPerformanceCountersModule.class);
+
+        addClass(com.microsoft.applicationinsights.extensibility.initializer.SdkVersionContextInitializer.class);
+        addClass(com.microsoft.applicationinsights.extensibility.initializer.DeviceInfoContextInitializer.class);
+
+        addClass(com.microsoft.applicationinsights.extensibility.initializer.TimestampPropertyInitializer.class);
+        addClass(com.microsoft.applicationinsights.extensibility.initializer.SequencePropertyInitializer.class);
+        addClass(com.microsoft.applicationinsights.extensibility.initializer.docker.DockerContextInitializer.class);
+
+        addClass(com.microsoft.applicationinsights.internal.processor.MetricTelemetryFilter.class);
+        addClass(com.microsoft.applicationinsights.internal.processor.RequestTelemetryFilter.class);
+        addClass(com.microsoft.applicationinsights.internal.channel.samplingV2.FixedRateSamplingTelemetryProcessor.class);
+        addClass(com.microsoft.applicationinsights.internal.processor.SyntheticSourceFilter.class);
+        addClass(com.microsoft.applicationinsights.internal.processor.PageViewTelemetryFilter.class);
+        addClass(com.microsoft.applicationinsights.internal.processor.TelemetryEventFilter.class);
+        addClass(com.microsoft.applicationinsights.internal.processor.TraceTelemetryFilter.class);
+    }
+
+    static void addClass(Class<?> clazz) {
+        builtInMap.put(clazz.getCanonicalName(), clazz);
+    }
+
     /**
      * Creates an instance from its name. We suppress Java compiler warnings for Generic casting
      *
@@ -56,9 +88,14 @@ public final class ReflectionUtils {
                 return null;
             }
 
-            Class<?> clazz = Class.forName(className).asSubclass(interfaceClass);
+            Class<?> clazz = builtInMap.get(className);
+            if (clazz == null) {
+                InternalLogger.INSTANCE.trace(" :( class lookup failed: %s", className);
+                clazz = Class.forName(className).asSubclass(interfaceClass);
+            } else {
+                clazz = clazz.asSubclass(interfaceClass);
+            }
             T instance = (T)clazz.newInstance();
-
             return instance;
         } catch (ClassCastException e) {
             InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
@@ -97,7 +134,12 @@ public final class ReflectionUtils {
                 return null;
             }
 
-            Class<?> clazz = Class.forName(className).asSubclass(interfaceClass);
+            Class<?> clazz = builtInMap.get(className);
+            if (clazz == null) {
+                clazz = Class.forName(className).asSubclass(interfaceClass);
+            } else {
+                clazz = clazz.asSubclass(interfaceClass);
+            }
             Constructor<?> clazzConstructor = clazz.getConstructor(argumentClass);
             T instance = (T)clazzConstructor.newInstance(argument);
             return instance;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/ReflectionUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/ReflectionUtils.java
@@ -90,21 +90,12 @@ public final class ReflectionUtils {
 
             Class<?> clazz = builtInMap.get(className);
             if (clazz == null) {
-                InternalLogger.INSTANCE.trace(" :( class lookup failed: %s", className);
                 clazz = Class.forName(className).asSubclass(interfaceClass);
             } else {
                 clazz = clazz.asSubclass(interfaceClass);
             }
             T instance = (T)clazz.newInstance();
             return instance;
-        } catch (ClassCastException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
-        } catch (ClassNotFoundException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
-        } catch (InstantiationException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
-        } catch (IllegalAccessException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
         } catch (Exception e) {
             InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
         }
@@ -143,14 +134,6 @@ public final class ReflectionUtils {
             Constructor<?> clazzConstructor = clazz.getConstructor(argumentClass);
             T instance = (T)clazzConstructor.newInstance(argument);
             return instance;
-        } catch (ClassCastException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
-        } catch (ClassNotFoundException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
-        } catch (InstantiationException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
-        } catch (IllegalAccessException e) {
-            InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
         } catch (Exception e) {
             InternalLogger.INSTANCE.error("Failed to create %s, Exception : %s", className, ExceptionUtils.getStackTrace(e));
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -68,7 +68,17 @@ public enum TelemetryConfigurationFactory {
     private final static String CONFIG_FILE_NAME = "ApplicationInsights.xml";
     private final static String DEFAULT_PERFORMANCE_MODULES_PACKAGE = "com.microsoft.applicationinsights";
     private final static String BUILT_IN_NAME = "BuiltIn";
+
+    /**
+     * This enables scanning for classes annotated with {@link BuiltInProcessor}.
+     * If set "true" (case insensitive) scanning will be enabled. Otherwise (by default), it will be disabled.
+     */
     public static final String BUILTIN_PROCESSORS_SCANNING_ENABLED_PROPERTY = "applicationinsights.processors.builtin.scanning.enabled";
+
+    /**
+     * This enables scanning for classes annotated with {@link PerformanceModule}.
+     * If set "true" (case insensitive) scanning will be enabled. Otherwise (by default), it will be disabled.
+     */
     public static final String PERFORMANCE_MODULES_SCANNING_ENABLED_PROPERTY = "applicationinsights.modules.performance.scanning.enabled";
 
     private String performanceCountersSection = DEFAULT_PERFORMANCE_MODULES_PACKAGE;

--- a/web/src/main/java/com/microsoft/applicationinsights/internal/config/WebReflectionUtils.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/internal/config/WebReflectionUtils.java
@@ -1,0 +1,21 @@
+package com.microsoft.applicationinsights.internal.config;
+
+import static com.microsoft.applicationinsights.internal.config.ReflectionUtils.addClass;
+
+public class WebReflectionUtils {
+    public static void initialize() {
+        addClass(com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule.class);
+        addClass(com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule.class);
+        addClass(com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule.class);
+        addClass(com.microsoft.applicationinsights.web.internal.perfcounter.WebPerformanceCounterModule.class);
+
+        addClass(com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationIdTelemetryInitializer.class);
+        addClass(com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationNameTelemetryInitializer.class);
+        addClass(com.microsoft.applicationinsights.web.extensibility.initializers.WebSessionTelemetryInitializer.class);
+        addClass(com.microsoft.applicationinsights.web.extensibility.initializers.WebUserAgentTelemetryInitializer.class);
+        addClass(com.microsoft.applicationinsights.web.extensibility.initializers.WebUserTelemetryInitializer.class);
+        addClass(com.microsoft.applicationinsights.web.extensibility.initializers.WebSyntheticRequestTelemetryInitializer.class);
+
+        TelemetryConfigurationFactory.addDefaultPerfModuleClassName(com.microsoft.applicationinsights.web.internal.perfcounter.WebPerformanceCounterModule.class.getCanonicalName());
+    }
+}

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -27,7 +27,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.microsoft.applicationinsights.common.CommonUtils;
-//import org.apache.http.HttpStatus;
 import com.microsoft.applicationinsights.web.internal.ApplicationInsightsHttpResponseWrapper;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
@@ -37,7 +36,6 @@ import com.microsoft.applicationinsights.telemetry.Duration;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
 import com.microsoft.applicationinsights.web.internal.ThreadContext;
-import com.microsoft.applicationinsights.web.internal.correlation.InstrumentationKeyResolver;
 import com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils;
 
 /**
@@ -151,13 +149,6 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
     public void initialize(TelemetryConfiguration configuration) {
         try {
             telemetryClient = new TelemetryClient(configuration);
-            
-            //kick-off resolving ikey to appId
-            String ikey = configuration.getInstrumentationKey();
-            if (ikey != null && ikey.length() > 0) {
-            	InstrumentationKeyResolver.INSTANCE.resolveInstrumentationKey(ikey);
-            }
-
             isInitialized = true;
         } catch (Exception e) {
             InternalLogger.INSTANCE.error("Failed to initialize telemetry module %s. Exception: %s.", this.getClass().getSimpleName(), e.toString());

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsServletContextListener.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/ApplicationInsightsServletContextListener.java
@@ -6,7 +6,6 @@ import javax.servlet.annotation.WebListener;
 
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.shutdown.SDKShutdownActivity;
-import com.microsoft.applicationinsights.internal.shutdown.Stoppable;
 
 @WebListener
 public class ApplicationInsightsServletContextListener implements ServletContextListener {
@@ -17,7 +16,7 @@ public class ApplicationInsightsServletContextListener implements ServletContext
 
 	@Override
 	public void contextDestroyed(ServletContextEvent sce) {
-		InternalLogger.INSTANCE.trace("Shutting down threads");
+		InternalLogger.INSTANCE.info("Shutting down thread pools");
 		SDKShutdownActivity.INSTANCE.stopAll();
 	}
 	


### PR DESCRIPTION
This limits the use of reflection during initialization.
This also makes a few other expensive initialization asynchronous.