### PR TITLE
removed usage of -1 as a default value for some measurements

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractUnixPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractUnixPerformanceCounter.java
@@ -45,11 +45,11 @@ abstract class AbstractUnixPerformanceCounter extends AbstractPerformanceCounter
         this.path = path;
         processFile = new File(path);
         if (!processFile.canRead()) {
-            logError("Can not read");
+            logPerfCounterErrorError("Can not read");
         }
     }
 
-    protected void logError(String format, Object... args) {
+    protected void logPerfCounterErrorError(String format, Object... args) {
         format = "Performance Counter " + getId() + ": Error in file '" + path + "': " + format;
         InternalLogger.INSTANCE.error(format, args);
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/Constants.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/Constants.java
@@ -51,8 +51,6 @@ public final class Constants {
 
     public final static String PROCESS_CATEGORY = "Process";
 
-    public final static double DEFAULT_DOUBLE_VALUE = -1.0;
-
     private Constants() {
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/CpuPerformanceCounterCalculator.java
@@ -47,8 +47,8 @@ public final class CpuPerformanceCounterCalculator {
 
     }
 
-    public double getProcessCpuUsage() {
-        double processCpuUsage;
+    public Double getProcessCpuUsage() {
+        Double processCpuUsage = null;
         try {
             RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
 
@@ -58,14 +58,12 @@ public final class CpuPerformanceCounterCalculator {
             if (prevUpTime > 0L && upTime > prevUpTime) {
                 long elapsedCpu = processCpuTime - prevProcessCpuTime;
                 long elapsedTime = upTime - prevUpTime;
-                processCpuUsage = Math.min(99F, elapsedCpu / (elapsedTime * 10000F * numberOfCpus));
-            } else {
-                processCpuUsage = Constants.DEFAULT_DOUBLE_VALUE;
+                processCpuUsage = Math.min(99.999, elapsedCpu / (elapsedTime * 10_000.0 * numberOfCpus)); // if this looks weird, here's another way to write it: (elapsedCpu / 1000000.0) / elapsedTime / numberOfCpus * 100.0
             }
             prevUpTime = upTime;
             prevProcessCpuTime = processCpuTime;
         } catch (Exception e) {
-            processCpuUsage = Constants.DEFAULT_DOUBLE_VALUE;
+            processCpuUsage = null;
             InternalLogger.INSTANCE.error("Error in getProcessCPUUsage");
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxPerformanceCounter.java
@@ -59,7 +59,10 @@ public final class JmxPerformanceCounter implements PerformanceCounter {
         Preconditions.checkArgument(!objectToAttributes.isEmpty(), "objectToAttributes should be not be empty");
 
         id = categoryName + "." + counterName;
-        telemetry = new PerformanceCounterTelemetry(categoryName, counterName, SystemInformation.INSTANCE.getProcessId(), Constants.DEFAULT_DOUBLE_VALUE);
+        telemetry = new PerformanceCounterTelemetry();
+        telemetry.setCategoryName(categoryName);
+        telemetry.setCounterName(counterName);
+        telemetry.setInstanceName(SystemInformation.INSTANCE.getProcessId());
         this.objectToAttributes = objectToAttributes;
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessCpuPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessCpuPerformanceCounter.java
@@ -67,7 +67,10 @@ final class ProcessCpuPerformanceCounter extends AbstractPerformanceCounter {
         if (cpuPerformanceCounterCalculator == null) {
             return;
         }
-        double processCpuUsage = cpuPerformanceCounterCalculator.getProcessCpuUsage();
+        Double processCpuUsage = cpuPerformanceCounterCalculator.getProcessCpuUsage();
+        if (processCpuUsage == null) {
+            return;
+        }
 
         InternalLogger.INSTANCE.trace("Performance Counter: %s %s: %s", getProcessCategoryName(), Constants.CPU_PC_COUNTER_NAME, processCpuUsage);
         Telemetry telemetry = new PerformanceCounterTelemetry(

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
@@ -99,14 +99,14 @@ final class UnixTotalCpuPerformanceCounter extends AbstractUnixPerformanceCounte
             bufferedReader = new BufferedReader(new FileReader(getProcessFile()));
             line = bufferedReader.readLine();
         } catch (Exception e) {
-            logError("Error while parsing file: '%s'", e.toString());
+            logPerfCounterErrorError("Error while parsing file: '%s'", e.toString());
             InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
         } finally {
             if (bufferedReader != null ) {
                 try {
                     bufferedReader.close();
                 } catch (Exception e) {
-                    logError("Error while closing file : '%s'", e.toString());
+                    logPerfCounterErrorError("Error while closing file : '%s'", e.toString());
                     InternalLogger.INSTANCE.trace("Stack trace generated is %s", ExceptionUtils.getStackTrace(e));
                 }
             }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
@@ -42,7 +42,7 @@ public final class WindowsPerformanceCounterAsMetric extends AbstractWindowsPerf
     private static final String ID = Constants.PERFORMANCE_COUNTER_PREFIX + "WindowsPerformanceCounterAsMetric";
 
     private final HashMap<String, String> keyToDisplayName = new HashMap<String, String>();
-    private final MetricTelemetry telemetry = new MetricTelemetry("placeholder", Constants.DEFAULT_DOUBLE_VALUE);
+    private final MetricTelemetry telemetry = new MetricTelemetry();
 
     /**
      * Registers the argument's data into performance counters.

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocatorTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/ConfigurationFileLocatorTest.java
@@ -21,7 +21,7 @@
 
 package com.microsoft.applicationinsights.internal.config;
 
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,6 +38,11 @@ import static org.junit.Assert.*;
 public final class ConfigurationFileLocatorTest {
     private final static String MOCK_CONF_FILE = "MockApplicationInsights.xml";
     private final static String EXISTING_CONF_TEST_FILE = "ApplicationInsights.xml";
+
+    @Before
+    public void clearProp() {
+        System.clearProperty(ConfigurationFileLocator.CONFIG_DIR_PROPERTY);
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testCtorWithNull() {

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -348,7 +348,7 @@ public abstract class AiSmokeTest {
 		System.out.println("Container started: "+containerId);
 
 		final int appServerDelayAfterStart_seconds = 5;
-		System.out.println("Waiting %d seconds for app server to startup...");
+		System.out.printf("Waiting %d seconds for app server to startup...%n", appServerDelayAfterStart_seconds);
 		TimeUnit.SECONDS.sleep(appServerDelayAfterStart_seconds);
 
 		currentContainerInfo = new ContainerInfo(containerId, currentImageName);

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.io.Resources;
+import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.Domain;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.smoketest.docker.AiDockerClient;
@@ -128,6 +129,7 @@ public abstract class AiSmokeTest {
 
 	protected String targetUri;
 	protected String httpMethod;
+	protected long targetUriDelayMs;
 	protected boolean expectSomeTelemetry = true;
 	//endregion
 
@@ -154,13 +156,14 @@ public abstract class AiSmokeTest {
 			if (targetUri == null) {
 				thiz.targetUri = null;
 				thiz.httpMethod = null;
+				thiz.targetUriDelayMs = 0L;
 			} else {
 				thiz.targetUri = targetUri.value();
 				if (!thiz.targetUri.startsWith("/")) {
 					thiz.targetUri = "/"+thiz.targetUri;
 				}
-
 				thiz.httpMethod = targetUri.method().toUpperCase();
+				thiz.targetUriDelayMs = targetUri.delay();
 			}
 
 			ExpectSomeTelemetry expectSomeTelemetry = description.getAnnotation(ExpectSomeTelemetry.class);
@@ -272,7 +275,11 @@ public abstract class AiSmokeTest {
 			System.out.println("targetUri==null: automated testapp request disabled");
 			return;
 		}
-
+		if (targetUriDelayMs > 0) {
+			System.out.printf("Waiting %.3fs before calling uri...%n", targetUriDelayMs/1000.0);
+			System.out.flush();
+			TimeUnit.MILLISECONDS.sleep(targetUriDelayMs);
+		}
 		System.out.println("Calling "+targetUri+" ...");
 		String url = getBaseUrl()+targetUri;
 		final String content;
@@ -288,7 +295,7 @@ public abstract class AiSmokeTest {
 		assertNotNull(String.format("Null response from targetUri: '%s'. %s", targetUri, expectationMessage), content);
 		assertTrue(String.format("Empty response from targetUri: '%s'. %s", targetUri, expectationMessage), content.length() > 0);
 
-		System.out.printf("Waiting %ds for telemetry...", TELEMETRY_RECEIVE_TIMEOUT_SECONDS);
+		System.out.printf("Waiting %ds for telemetry...%n", TELEMETRY_RECEIVE_TIMEOUT_SECONDS);
 		TimeUnit.SECONDS.sleep(TELEMETRY_RECEIVE_TIMEOUT_SECONDS);
 		System.out.println("Finished waiting for telemetry.\nStarting validation...");
 
@@ -399,6 +406,10 @@ public abstract class AiSmokeTest {
 		String rval = testProps.getProperty(key);
 		if (rval == null) throw new RuntimeException(String.format("test property not found '%s'", key));
 		return rval;
+	}
+
+	protected static <T extends Domain> T getBaseData(Envelope envelope) {
+		return ((Data<T>)envelope.getData()).getBaseData();
 	}
 
 	protected static void waitForUrl(String url, long timeout, TimeUnit timeoutUnit, String appName) throws InterruptedException {

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/TargetUri.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/TargetUri.java
@@ -10,4 +10,9 @@ import java.lang.annotation.Target;
 public @interface TargetUri {
     String value();
     String method() default "GET";
+
+    /**
+     * The delay in milliseconds to wait before calling the target uri.
+     */
+    long delay() default 0L;
 }

--- a/test/smoke/testApps/AutoPerfCounters/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/PerfCountersDataTest.java
+++ b/test/smoke/testApps/AutoPerfCounters/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/PerfCountersDataTest.java
@@ -1,29 +1,100 @@
 package com.microsoft.applicationinsights.smoketest;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.microsoft.applicationinsights.internal.schemav2.Base;
-import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.DataPoint;
 import com.microsoft.applicationinsights.internal.schemav2.DataPointType;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.MetricData;
 import com.microsoft.applicationinsights.internal.schemav2.PerformanceCounterData;
-
 import org.junit.*;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
+@SuppressWarnings("deprecation")
 public class PerfCountersDataTest extends AiSmokeTest {
+    @Test
+    @TargetUri(value = "index.jsp", delay = 5000)
+    public void testPerformanceCounterData() throws Exception {
+        System.out.println("Waiting for performance data...");
+        long start = System.currentTimeMillis();
+
+        // we should get these envelopes:
+        //      MetricData, metrics.name="Suspected Deadlocked Threads"
+        //      PerformanceCounterData, categoryName=Memory, counterName=Available Bytes
+        //      MetricData, metrics.name="Heap Memory Used (MB)"
+        //      PerformanceCounterData, category=Process, counter="IO Data Bytes/sec"
+        //      PerformanceCounterData, category=Processor, counter="% Processor Time", instance="_Total"
+        //      PerformanceCounterData, category=Process, counter=Private Bytes
+        //      PerformanceCounterData, Process, "% Processor Time"
+
+        Envelope availableMem = mockedIngestion.waitForItem(getPerfCounterPredicate("Memory", "Available Bytes"), 150, TimeUnit.SECONDS);
+        Envelope totalCpu = mockedIngestion.waitForItem(getPerfCounterPredicate("Processor", "% Processor Time", "_Total"), 150, TimeUnit.SECONDS);
+
+        Envelope processIo = mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "IO Data Bytes/sec"), 150, TimeUnit.SECONDS);
+        Envelope processMemUsed = mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "Private Bytes"), 150, TimeUnit.SECONDS);
+        Envelope processCpu = mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "% Processor Time"), 150, TimeUnit.SECONDS);
+        System.out.println("PerformanceCounterData are good: " + (System.currentTimeMillis() - start));
+
+        PerformanceCounterData pdMem = getBaseData(availableMem);
+        assertPerfCounter(pdMem);
+        assertNull(pdMem.getInstanceName());
+
+        PerformanceCounterData pdCpu = getBaseData(totalCpu);
+        assertPerfCounter(pdCpu);
+        assertEquals("_Total", pdCpu.getInstanceName());
+
+        assertPerfCounter(getBaseData(processIo));
+        assertPerfCounter(getBaseData(processMemUsed));
+        assertPerfCounter(getBaseData(processCpu));
+        assertSameInstanceName(processIo, processMemUsed, processCpu);
+
+
+        start = System.currentTimeMillis();
+        System.out.println("Waiting for metric data...");
+        Envelope deadlocks = mockedIngestion.waitForItem(getPerfMetricPredicate("Suspected Deadlocked Threads"), 150, TimeUnit.SECONDS);
+        Envelope heapUsed = mockedIngestion.waitForItem(getPerfMetricPredicate("Heap Memory Used (MB)"), 150, TimeUnit.SECONDS);
+        System.out.println("MetricData are good: " + (System.currentTimeMillis() - start));
+
+        MetricData mdDeadlocks = getBaseData(deadlocks);
+        assertPerfMetric(mdDeadlocks);
+        assertEquals(0.0, mdDeadlocks.getMetrics().get(0).getValue(), Math.ulp(0.0));
+
+        MetricData mdHeapUsed = getBaseData(heapUsed);
+        assertPerfMetric(mdHeapUsed);
+        assertTrue(mdHeapUsed.getMetrics().get(0).getValue() > 0.0);
+    }
+
+    private void assertSameInstanceName(Envelope... envelopes) {
+        Preconditions.checkArgument(envelopes.length > 0);
+        PerformanceCounterData firstOne = getBaseData(envelopes[0]);
+        String instanceName = firstOne.getInstanceName();
+        assertNotNull(instanceName);
+        if (envelopes.length == 1) {
+            return;
+        }
+        for (int i = 1; i < envelopes.length; i++) {
+            PerformanceCounterData pcd = getBaseData(envelopes[i]);
+            assertEquals(instanceName, pcd.getInstanceName());
+        }
+    }
+
+    private void assertPerfCounter(PerformanceCounterData perfCounter) {
+        assertTrue(perfCounter.getValue() > 0.0);
+    }
+
+    private void assertPerfMetric(MetricData perfMetric) {
+        assertEquals("true", perfMetric.getProperties().get("CustomPerfCounter"));
+        List<DataPoint> metrics = perfMetric.getMetrics();
+        assertEquals(1, metrics.size());
+        DataPoint dp = metrics.get(0);
+        assertEquals(DataPointType.Measurement, dp.getKind());
+    }
 
     private static Predicate<Envelope> getPerfCounterPredicate(String category, String counter) {
         return getPerfCounterPredicate(category, counter, null);
@@ -39,153 +110,25 @@ public class PerfCountersDataTest extends AiSmokeTest {
                 if (!data.getBaseType().equals("PerformanceCounterData")) {
                     return false;
                 }
-                PerformanceCounterData pcd = ((Data<PerformanceCounterData>)data).getBaseData();
+                PerformanceCounterData pcd = getBaseData(input);
                 return category.equals(pcd.getCategoryName()) && counter.equals(pcd.getCounterName())
                         && (instance == null || instance.equals(pcd.getInstanceName()));
             }
         };
     }
 
-    @Test
-    public void testPerformanceCounterData() throws Exception {
-        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
-        ScheduledFuture<?> x = executor.schedule(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    HttpHelper.get(getBaseUrl() + "/index.jsp");
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }, 5, TimeUnit.SECONDS); // this just calls the uri after 5 seconds.
-
-        System.out.println("Waiting for performance data...");
-        long start = System.currentTimeMillis();
-
-        // we should get these envelopes:
-        //      MetricData, metrics.name="Suspected Deadlocked Threads"
-        //      PerformanceCounterData, categoryName=Memory, counterName=Available Bytes
-        //      MetricData, metrics.name="Heap Memory Used (MB)"
-        //      PerformanceCounterData, category=Process, counter="IO Data Bytes/sec"
-        //      PerformanceCounterData, category=Processor, counter="% Processor Time", instance="_Total"
-        //      PerformanceCounterData, category=Process, counter=Private Bytes
-        //      PerformanceCounterData, Process, "% Processor Time"
-
-        List<Envelope> performanceItems = new ArrayList<>();
-        performanceItems.add(mockedIngestion.waitForItem(getPerfCounterPredicate("Memory", "Available Bytes"), 150, TimeUnit.SECONDS));
-        performanceItems.add(mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "IO Data Bytes/sec"), 150, TimeUnit.SECONDS));
-        performanceItems.add(mockedIngestion.waitForItem(getPerfCounterPredicate("Processor", "% Processor Time", "_Total"), 150, TimeUnit.SECONDS));
-        performanceItems.add(mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "Private Bytes"), 150, TimeUnit.SECONDS));
-        performanceItems.add(mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "% Processor Time"), 150, TimeUnit.SECONDS));
-
-        assertEquals(5, performanceItems.size());
-        for (Envelope item : performanceItems) {
-            assertEquals("PerformanceCounterData", item.getData().getBaseType());
-        }
-        System.out.println("PerformanceCounterData are good: " + (System.currentTimeMillis() - start));
-
-        System.out.println("Waiting for metric data...");
-        List<Envelope> metricItems = mockedIngestion.waitForItems(new Predicate<Envelope>() {
+    private static Predicate<Envelope> getPerfMetricPredicate(String name) {
+        Preconditions.checkNotNull(name, "name");
+        return new Predicate<Envelope>() {
             @Override
             public boolean apply(@Nullable Envelope input) {
-                if (input == null) {
+                if(!input.getData().getBaseType().equals("MetricData")) {
                     return false;
                 }
-                boolean rval = "MetricData".equals(input.getData().getBaseType());
-                return rval;
+                MetricData md = getBaseData(input);
+                return name.equals(md.getMetrics().get(0).getName());
             }
-        }, 4, 10, TimeUnit.SECONDS);
-        assertEquals(4, metricItems.size());
-        for (Envelope item : metricItems) {
-            assertEquals("MetricData", item.getData().getBaseType());
-        }
-        System.out.println("MetricData are good: " + (System.currentTimeMillis() - start));
-
-        System.out.println("Waiting for requests...");
-        start = System.currentTimeMillis();
-        Envelope requestItem = mockedIngestion.waitForItem(new Predicate<Envelope>() {
-            @Override
-            public boolean apply(@Nullable Envelope input) {
-                if (input == null)
-                    return false;
-                return "RequestData".equals(input.getData().getBaseType());
-            }
-        }, 10, TimeUnit.SECONDS); // this one just returns a single envelope.
-        // at this point, the item has already arrived and this just returns immediately
-        assertNotNull(requestItem);
-        System.out.println("Requests are good: " + (System.currentTimeMillis() - start));
-
-        int heapMemoryUsed = 0;
-        int suspected = 0;
-        for (int i = metricItems.size(); i > 2; i = i - 1) {
-            DataPoint dp1 = getMetricDataDetails(i - 1);
-            switch (dp1.getName()) {
-            case "Suspected Deadlocked Threads":
-                assertEquals(DataPointType.Measurement, dp1.getKind());
-                assertTrue(dp1.getValue() == 0);
-                suspected++;
-                break;
-            case "Heap Memory Used (MB)":
-                assertEquals(DataPointType.Measurement, dp1.getKind());
-                assertTrue(dp1.getValue() > 0);
-                heapMemoryUsed++;
-                break;
-            default:
-                break;
-            }
-        }
-        assertEquals(1, heapMemoryUsed);
-        assertEquals(1, suspected);
-
-        int processor = 0, processPrivate = 0, processIO = 0, processTime = 0, memory = 0;
-        for (Envelope env : performanceItems) {
-            PerformanceCounterData perfd1 = ((Data<PerformanceCounterData>)env.getData()).getBaseData();
-            assertTrue(perfd1.getValue() > -1);
-            switch (perfd1.getCategoryName()) {
-            case "Processor":
-                assertEquals("% Processor Time", perfd1.getCounterName());
-                assertEquals("_Total", perfd1.getInstanceName());
-                processor++;
-                break;
-            case "Memory":
-                assertEquals("Available Bytes", perfd1.getCounterName());
-                assertTrue(perfd1.getValue() != 0);
-                memory++;
-            case "Process":
-                assertTrue(perfd1.getValue() != 0);
-                switch (perfd1.getCounterName()) {
-                case "Private Bytes":
-                    processPrivate++;
-                    break;
-                case "IO Data Bytes/sec":
-                    processIO++;
-                    break;
-                case "% Processor Time":
-                    processTime++;
-                    break;
-                default:
-                    break;
-                }
-            default:
-                break;
-            }
-        }
-
-        assertEquals(1, processor);
-        assertEquals(1, processPrivate);
-        assertEquals(1, processIO);
-        assertEquals(1, processTime);
-        assertEquals(1, memory);
-    }
-
-    private DataPoint getMetricDataDetails(int index) {
-        MetricData md = getTelemetryDataForType(index, "MetricData");
-        assertEquals("true", md.getProperties().get("CustomPerfCounter"));
-        List<DataPoint> metrics = md.getMetrics();
-        assertEquals(1, metrics.size());
-        DataPoint dp = metrics.get(0);
-        return dp;
+        };
     }
 
 }


### PR DESCRIPTION
This just causes confusion when seen in the cloud. Now, if we can't measure something, we won't report it as some garbage value.

Fix #647 .
