### PR TITLE
smoketests: added delay after container stops

### DIFF
--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -124,8 +124,6 @@ public abstract class AiSmokeTest {
 	//endregion
 
 	//region: application fields
-
-
 	protected String targetUri;
 	protected String httpMethod;
 	protected boolean expectSomeTelemetry = true;
@@ -134,6 +132,7 @@ public abstract class AiSmokeTest {
 	//region: options
 	public static final int APPLICATION_READY_TIMEOUT_SECONDS = 120;
 	public static final int TELEMETRY_RECEIVE_TIMEOUT_SECONDS = 10;
+	public static final int DELAY_AFTER_CONTAINER_STOP_MILLISECONDS = 1500;
 	//endregion
 
 	private static final Properties testProps = new Properties();
@@ -390,6 +389,7 @@ public abstract class AiSmokeTest {
 		if (!docker.isContainerRunning(currentContainerInfo.getContainerId())) { // for good measure
 			currentContainerInfo = null;
 		}
+		TimeUnit.MILLISECONDS.sleep(DELAY_AFTER_CONTAINER_STOP_MILLISECONDS);
 	}
 
 	//region: test helper methods


### PR DESCRIPTION
I'm seeing issues every once in a while with container communication. I'm hoping docker just needs a cooldown period.