### PR TITLE
IkeyResolver: support system properties and limit retries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Version 2.1.0
 - Introduced Heartbeat feature which sends periodic heartbeats with basic information about application and runtime to Application Insights.
+- Enable support for system properties in the instrumentation key resolving component.
 
 ## Version 2.0.2 
 - Fix incorrect success flag set when capturing HTTP Dependency.


### PR DESCRIPTION
Enable system properties for the HTTP client used in the ikey resolver. Also, limit retries in the resolver to save on performance in case of constant failures.