### PR TITLE
Minor improvements to smoketests

### DIFF
--- a/test/smoke/appServers/build.gradle
+++ b/test/smoke/appServers/build.gradle
@@ -165,12 +165,15 @@ def getConfigSet(File universeFile, File includesFile, File excludesFile) {
 		logger.info "excludes exist: $excludesFile.absolutePath"
 	}
 	def universalSet = universeFile.text.readLines().toSet()
+	universalSet.removeAll { it.trim().isEmpty() }
 	logger.info "universalSet has ${universalSet.size()} elements: $universalSet"
 	
 	def includeSet = (hasIncludes ? includesFile.text.readLines().toSet() : universalSet)
+	includeSet.removeAll { it.trim().isEmpty() }
 	logger.info "includeSet has ${includeSet.size()} elements: $includeSet"
 	
 	def excludeSet = (hasExcludes ? excludesFile.text.readLines() : []).toSet()
+	excludeSet.removeAll { it.trim().isEmpty() }
 	logger.info "excludeSet has ${excludeSet.size()} elements: $excludeSet"
 
 	// if the excludes file contains entries which do not exist in the master list, warn the user; this is likely a typo

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -15,6 +15,8 @@ import com.microsoft.applicationinsights.internal.schemav2.Domain;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.smoketest.docker.AiDockerClient;
 import com.microsoft.applicationinsights.smoketest.docker.ContainerInfo;
+import com.microsoft.applicationinsights.smoketest.exceptions.SmokeTestException;
+import com.microsoft.applicationinsights.smoketest.exceptions.TimeoutException;
 import com.microsoft.applicationinsights.smoketest.fixtures.AfterWithParams;
 import com.microsoft.applicationinsights.smoketest.fixtures.BeforeWithParams;
 import com.microsoft.applicationinsights.smoketest.fixtures.ParameterizedRunnerWithFixturesFactory;
@@ -433,7 +435,7 @@ public abstract class AiSmokeTest {
 
 	protected static String getProperty(String key) {
 		String rval = testProps.getProperty(key);
-		if (rval == null) throw new RuntimeException(String.format("test property not found '%s'", key));
+		if (rval == null) throw new SmokeTestException(String.format("test property not found '%s'", key));
 		return rval;
 	}
 
@@ -446,7 +448,7 @@ public abstract class AiSmokeTest {
 		Stopwatch watch = Stopwatch.createStarted();
 		do {
 			if (watch.elapsed(timeoutUnit) > timeout) {
-				throw new RuntimeException(String.format("Timeout reached waiting for '%s' to come online", appName));
+				throw new TimeoutException(appName, timeout, timeoutUnit);
 			}
 
 			try {
@@ -483,7 +485,7 @@ public abstract class AiSmokeTest {
 			}
 		} while (!success && triedCount++ < numberOfRetries);
 		if (!success) {
-			throw new RuntimeException(lastThrowable);
+			throw new TimeoutException(appName, timeout*triedCount, timeoutUnit, String.format("Tried %d times to hit %s", triedCount, url), lastThrowable);
 		}
 	}
 

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/JsonHelper.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/JsonHelper.java
@@ -25,6 +25,7 @@ import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.internal.schemav2.SessionStateData;
 import com.microsoft.applicationinsights.telemetry.Duration;
+
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
@@ -78,7 +79,7 @@ public class JsonHelper {
 			} catch (InstantiationException | IllegalAccessException e) {
 				System.err.println("Error deserializing data");
 				e.printStackTrace();
-				throw new RuntimeException(e);
+				throw new JsonParseException(e);
 			}
 		}
 

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/exceptions/SmokeTestException.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/exceptions/SmokeTestException.java
@@ -1,0 +1,23 @@
+package com.microsoft.applicationinsights.smoketest.exceptions;
+
+public class SmokeTestException extends RuntimeException {
+    public SmokeTestException() {
+        super();
+    }
+
+    public SmokeTestException(String message) {
+        super(message);
+    }
+
+    public SmokeTestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SmokeTestException(Throwable cause) {
+        super(cause);
+    }
+
+    protected SmokeTestException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/exceptions/TimeoutException.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/exceptions/TimeoutException.java
@@ -1,0 +1,21 @@
+package com.microsoft.applicationinsights.smoketest.exceptions;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimeoutException extends SmokeTestException {
+    public TimeoutException(String componentName, long timeout, TimeUnit unit) {
+        this(componentName, timeout, unit, "", null);
+    }
+    public TimeoutException(String componentName, long timeout, TimeUnit unit, String message) {
+        this(componentName, timeout, unit, message, null);
+    }
+    public TimeoutException(String componentName, long timeout, TimeUnit unit, Throwable cause) {
+        this(componentName, timeout, unit, "", cause);
+    }
+
+    public TimeoutException(String componentName, long timeout, TimeUnit unit, String message, Throwable cause) {
+        super(String.format("Timeout reached (%d %s) waiting for %s. %s", timeout, unit.toString().toLowerCase(), componentName, message), cause);
+    }
+}


### PR DESCRIPTION
Reduced number of retries so it fails a bit faster when containers do not start.
Fixed NPE when stopping a container after it fails; it doesn't need to stop. it should be skipped.
Added check for success and throw exception.
Added custom exceptions for clarity.