### PR TITLE
updating agent detection in filter

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/common/CommonUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/common/CommonUtils.java
@@ -22,30 +22,44 @@
 package com.microsoft.applicationinsights.common;
 
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-
-/**
- * Created by oriy on 11/2/2016.
- */
+/** Created by oriy on 11/2/2016. */
 public class CommonUtils {
-    public static boolean isNullOrEmpty(String string) {
-        return string == null || string.length() == 0;
+  public static boolean isNullOrEmpty(String string) {
+    return string == null || string.length() == 0;
+  }
+
+  public static String getHostName() {
+    try {
+      InetAddress addr;
+      addr = InetAddress.getLocalHost();
+      return addr.getCanonicalHostName();
+    } catch (UnknownHostException ex) {
+      // optional parameter. do nothing if unresolvable
+      InternalLogger.INSTANCE.trace(
+          "Unresolvable host error. Stack trace generated is %s", ExceptionUtils.getStackTrace(ex));
+      return null;
     }
-    public static String getHostName(){
-        try
-        {
-            InetAddress addr;
-            addr = InetAddress.getLocalHost();
-            return addr.getCanonicalHostName();
-        }
-        catch (UnknownHostException ex) {
-            // optional parameter. do nothing if unresolvable
-            InternalLogger.INSTANCE.trace("Unresolvable host error. Stack trace generated is %s", ExceptionUtils.getStackTrace(ex));
-            return null;
-        }
+  }
+
+  /**
+   * This method is used to test if the given class is loaded in the specified ClassLoader
+   * @param classSignature Fully Qualified signature of class
+   * @param classLoader ClassLoader under consideration
+   * @return true if class is loaded otherwise false
+   */
+  public static boolean isClassPresentOnClassPath(String classSignature, ClassLoader classLoader) {
+
+    try {
+      Class.forName(classSignature, false, classLoader);
+      return true;
+    } catch (ClassNotFoundException e) {
+      InternalLogger.INSTANCE.info(
+          "Specified class %s is not present on the classpath", classSignature);
+      return false;
     }
+  }
 }


### PR DESCRIPTION
This PR helps in detecting Agent Jar in a better way inside WebRequestTrackingFilter. Instead of calling the Instance of AgentConnector and failing with an exception when Jar is not present this, explicitly tries to see if the AgentNotificationsHandler is present on the classPath. This prevents from throwing unnecessary exception. 

Copying my comment from #646 


I wanted to point out the following: By reverting the changes of how agent is detected to the original implementation, the user will see this misleading exception message when the Agent Jar is not present.

AI: ERROR 04-05-2018 09:08:53.150, 31(localhost-startStop-1): Could not find Agent: 'java.lang.NoClassDefFoundError: com/microsoft/applicationinsights/agent/internal/coresync/AgentNotificationsHandler
at java.lang.ClassLoader.defineClass1(Native Method)
at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
at java.security.AccessController.doPrivileged(Native Method)
at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:338)
at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
at com.microsoft.applicationinsights.internal.agent.AgentConnector.register(AgentConnector.java:79)
at com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter.registerWebApp(WebRequestTrackingFilter.java:287)
at com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter.initialize(WebRequestTrackingFilter.java:263)
at com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter.init(WebRequestTrackingFilter.java:145)
at org.apache.catalina.core.ApplicationFilterConfig.initFilter(ApplicationFilterConfig.java:285)
at org.apache.catalina.core.ApplicationFilterConfig.(ApplicationFilterConfig.java:112)
at org.apache.catalina.core.StandardContext.filterStart(StandardContext.java:4590)
at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5233)
at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1419)
at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1409)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: com.microsoft.applicationinsights.agent.internal.coresync.AgentNotificationsHandler
at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:338)
at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
... 27 more

IMO, this is very confusing and I can remember couple of tickets when users pointed out to this weired behavior.

My suggestion : We can take two approaches -

1. Either avoid dumping stackTrace for this scenario. (Caution: We will also miss any other exceptions 
    which might come up here).
2.  Change the way how agent is detected. I will submit another PR as requested.

This PR implements the second option, because effectively when a runtime exception is thrown compiler has to jump instructions which makes the program terribly slow. You can look at more details on this thread (https://stackoverflow.com/questions/299068/how-slow-are-java-exceptions)
Further, users expect exceptions when a bad behavior happens in the program, not for what is expected to be usual behavior. This is also considered seriously bad practice. I would strongly urge to have a better way for detecting agent. I propose one in another PR, if there is a better alternative I am happy to evaluate it.


