### PR TITLE
scan logs for exceptions as last test on container

### DIFF
--- a/test/smoke/appServers/JBossEAP.6/jbosseap6.linux.partial.dockerfile
+++ b/test/smoke/appServers/JBossEAP.6/jbosseap6.linux.partial.dockerfile
@@ -5,9 +5,7 @@ WORKDIR /root/docker-compile
 
 # update packages and install dependencies: wget
 RUN apt-get update \
-	&& apt-get install -y wget \
-	&& apt-get install -y procps \
-	&& apt-get install -y unzip
+	&& apt-get install -y wget procps unzip zip
 
 # add jboss zip
 ADD ./@ZIP_FILENAME@ ./

--- a/test/smoke/appServers/JBossEAP.6/resources/linux/gatherLogs.sh
+++ b/test/smoke/appServers/JBossEAP.6/resources/linux/gatherLogs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ -z "$JBOSS_HOME" ]; then
+	echo "\$JBOSS_HOME not set" >&2
+	exit 1
+fi
+
+LOG_DIR="$JBOSS_HOME/standalone/log"
+
+LOG_FILES=("$LOG_DIR/server.log")
+OUTPUT_ZIP="appServerLogs.zip"
+
+for file in "${LOG_FILES[@]}"
+do
+    if [ -f "$file" ]; then
+        LOGS_TO_GATHER="$LOGS_TO_GATHER $file"
+    fi
+done
+
+zip ${OUTPUT_ZIP} ${LOGS_TO_GATHER}

--- a/test/smoke/appServers/JBossEAP.7/jbosseap7.linux.partial.dockerfile
+++ b/test/smoke/appServers/JBossEAP.7/jbosseap7.linux.partial.dockerfile
@@ -5,9 +5,7 @@ WORKDIR /root/docker-compile
 
 # update packages and install dependencies: wget
 RUN apt-get update \
-	&& apt-get install -y wget \
-	&& apt-get install -y procps \
-	&& apt-get install -y unzip
+	&& apt-get install -y wget procps unzip zip
 
 # add jboss zip
 ADD ./@ZIP_FILENAME@ ./

--- a/test/smoke/appServers/JBossEAP.7/resources/linux/gatherLogs.sh
+++ b/test/smoke/appServers/JBossEAP.7/resources/linux/gatherLogs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ -z "$JBOSS_HOME" ]; then
+	echo "\$JBOSS_HOME not set" >&2
+	exit 1
+fi
+
+LOG_DIR="$JBOSS_HOME/standalone/log"
+
+LOG_FILES=("$LOG_DIR/server.log")
+OUTPUT_ZIP="appServerLogs.zip"
+
+for file in "${LOG_FILES[@]}"
+do
+    if [ -f "$file" ]; then
+        LOGS_TO_GATHER="$LOGS_TO_GATHER $file"
+    fi
+done
+
+zip ${OUTPUT_ZIP} ${LOGS_TO_GATHER}

--- a/test/smoke/appServers/Jetty.9/jetty9.linux.partial.dockerfile
+++ b/test/smoke/appServers/Jetty.9/jetty9.linux.partial.dockerfile
@@ -16,7 +16,7 @@ RUN wget http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$J
 ENV JETTY_HOME /opt/jetty-distribution-$JETTY_FULL_VERSION
 
 RUN mkdir -p /opt/jetty-base
-ENV JETTY_BASE /opt/jetty-base/
+ENV JETTY_BASE /opt/jetty-base
 
 RUN mkdir -p /root/docker-stage
 ADD ./*.sh /root/docker-stage/

--- a/test/smoke/appServers/Jetty.9/jetty9.linux.partial.dockerfile
+++ b/test/smoke/appServers/Jetty.9/jetty9.linux.partial.dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/local/docker-compile
 
 # update packages and install dependencies: wget procps (we need 'ps' for debugging)
 RUN apt-get update \
-	&& apt-get install -y wget procps
+	&& apt-get install -y wget procps zip
 
 ENV JETTY_FULL_VERSION 9.4.9.v20180320
 

--- a/test/smoke/appServers/Jetty.9/resources/linux/gatherLogs.sh
+++ b/test/smoke/appServers/Jetty.9/resources/linux/gatherLogs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ -z "$JETTY_BASE" ]; then
+	echo "\$JETTY_BASE not set" >&2
+	exit 1
+fi
+
+TODAYS_DATE=`date +%Y_%m_%d`
+LOGS_DIR="$JETTY_BASE/logs"
+
+LOG_FILES=("$LOGS_DIR/$TODAYS_DATE.jetty.log")
+OUTPUT_ZIP="appServerLogs.zip"
+
+for file in "${LOG_FILES[@]}"
+do
+    if [ -f "$file" ]; then
+        LOGS_TO_GATHER="$LOGS_TO_GATHER $file"
+    fi
+done
+
+zip ${OUTPUT_ZIP} ${LOGS_TO_GATHER}

--- a/test/smoke/appServers/Tomcat.7/resources/linux/gatherLogs.sh
+++ b/test/smoke/appServers/Tomcat.7/resources/linux/gatherLogs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ -z "$CATALINA_HOME" ]; then
+	echo "\$CATALINA_HOME not set" >&2
+	exit 1
+fi
+
+TODAYS_DATE=`date +%Y-%m-%d`
+CATALINA_LOG_DIR="$CATALINA_HOME/logs"
+
+LOG_FILES=("$CATALINA_LOG_DIR/catalina.$TODAYS_DATE.log" "$CATALINA_LOG_DIR/catalina.out")
+OUTPUT_ZIP="appServerLogs.zip"
+
+for file in "${LOG_FILES[@]}"
+do
+    if [ -f "$file" ]; then
+        LOGS_TO_GATHER="$LOGS_TO_GATHER $file"
+    fi
+done
+
+zip ${OUTPUT_ZIP} ${LOGS_TO_GATHER}

--- a/test/smoke/appServers/Tomcat.7/tomcat7.linux.partial.dockerfile
+++ b/test/smoke/appServers/Tomcat.7/tomcat7.linux.partial.dockerfile
@@ -7,10 +7,7 @@ RUN mkdir /root/docker-stage
 
 # update packages and install dependencies: wget
 RUN apt-get update \
-	&& apt-get install -y wget
-
-RUN apt-get install -y procps
-
+	&& apt-get install -y wget procps zip
 
 ENV TOMCAT_MAJOR_VERSION 7
 ENV TOMCAT_FULL_VERSION 7.0.84

--- a/test/smoke/appServers/Tomcat.8.5/resources/linux/gatherLogs.sh
+++ b/test/smoke/appServers/Tomcat.8.5/resources/linux/gatherLogs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ -z "$CATALINA_HOME" ]; then
+	echo "\$CATALINA_HOME not set" >&2
+	exit 1
+fi
+
+TODAYS_DATE=`date +%Y-%m-%d`
+CATALINA_LOG_DIR="$CATALINA_HOME/logs"
+
+LOG_FILES=("$CATALINA_LOG_DIR/catalina.$TODAYS_DATE.log" "$CATALINA_LOG_DIR/catalina.out")
+OUTPUT_ZIP="appServerLogs.zip"
+
+for file in "${LOG_FILES[@]}"
+do
+    if [ -f "$file" ]; then
+        LOGS_TO_GATHER="$LOGS_TO_GATHER $file"
+    fi
+done
+
+zip ${OUTPUT_ZIP} ${LOGS_TO_GATHER}

--- a/test/smoke/appServers/Tomcat.8.5/tomcat85.linux.partial.dockerfile
+++ b/test/smoke/appServers/Tomcat.8.5/tomcat85.linux.partial.dockerfile
@@ -7,7 +7,7 @@ RUN mkdir /root/docker-stage
 
 # update packages and install dependencies: wget
 RUN apt-get update \
-	&& apt-get install -y wget procps
+	&& apt-get install -y wget procps zip
 
 ENV TOMCAT_MAJOR_VERSION 8
 ENV TOMCAT_FULL_VERSION 8.5.28

--- a/test/smoke/appServers/Tomcat.8/resources/linux/gatherLogs.sh
+++ b/test/smoke/appServers/Tomcat.8/resources/linux/gatherLogs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ -z "$CATALINA_HOME" ]; then
+	echo "\$CATALINA_HOME not set" >&2
+	exit 1
+fi
+
+TODAYS_DATE=`date +%Y-%m-%d`
+CATALINA_LOG_DIR="$CATALINA_HOME/logs"
+
+LOG_FILES=("$CATALINA_LOG_DIR/catalina.$TODAYS_DATE.log" "$CATALINA_LOG_DIR/catalina.out")
+OUTPUT_ZIP="appServerLogs.zip"
+
+for file in "${LOG_FILES[@]}"
+do
+    if [ -f "$file" ]; then
+        LOGS_TO_GATHER="$LOGS_TO_GATHER $file"
+    fi
+done
+
+zip ${OUTPUT_ZIP} ${LOGS_TO_GATHER}

--- a/test/smoke/appServers/Tomcat.8/tomcat8.linux.partial.dockerfile
+++ b/test/smoke/appServers/Tomcat.8/tomcat8.linux.partial.dockerfile
@@ -7,9 +7,7 @@ RUN mkdir /root/docker-stage
 
 # update packages and install dependencies: wget
 RUN apt-get update \
-	&& apt-get install -y wget
-
-RUN apt-get install -y procps
+	&& apt-get install -y wget procps zip
 
 
 ENV TOMCAT_MAJOR_VERSION 8

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -582,9 +582,9 @@ public abstract class AiSmokeTest {
 				{ // <init>
 					errorPatterns.add(Pattern.compile(".*?ERROR\\s+.*Exception.*"));
 
-					stackTracePatterns.add(Pattern.compile("^\\s+at\\s+?(?:[A-Za-z][\\w$]+)(?:\\.(?:[A-Za-z][\\w$]+))*.*"));
+					stackTracePatterns.add(Pattern.compile(".*\\s+at\\s+?(?:[A-Za-z][\\w$]+)(?:\\.(?:[A-Za-z][\\w$]+))*.*"));
 
-					suppressionPatterns.add(Pattern.compile("InstrumentationKeyResolver - failed to resolve instrumentation key:"));
+					suppressionPatterns.add(Pattern.compile("failed to resolve instrumentation key"));
 				}
 
 				@Override
@@ -593,6 +593,7 @@ public abstract class AiSmokeTest {
 					// check if line matches an exception pattern
 					if (anyPatternMatches(line, errorPatterns)) {
 						if (anyPatternMatches(line, suppressionPatterns)) {
+							suppressedCount.incrementAndGet();
 						    lastOneWasSuppressed = true;
 							return true;
 						}

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -550,6 +550,8 @@ public abstract class AiSmokeTest {
 
 	@Test
 	public void zzz_CheckForExceptionsInLogs() throws IOException, InterruptedException {
+	    Assume.assumeTrue("Test class opted to skip log scanner test.", shouldRunTheLogScannerTest());
+
 		Stopwatch sw = Stopwatch.createStarted();
 		System.out.println("\n-=== SCANNING LOGS FOR UNEXPECTED EXCEPTIONS ===-\n");
 		System.out.println("Gathering logs...");
@@ -640,6 +642,13 @@ public abstract class AiSmokeTest {
 		Assert.assertTrue(String.format("%d errors detected", detectedErrors.size()), detectedErrors.isEmpty());
 		System.out.println("No errors detected.");
 	}
+
+    /**
+     * Override this method if the smoketest class should not run the log scanner test.
+     */
+	protected boolean shouldRunTheLogScannerTest() {
+	    return true;
+    }
 
 	@After
 	public void resetMockedIngestion() throws Exception {

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -10,6 +10,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.common.io.CharStreams;
+import com.google.common.io.LineProcessor;
 import com.google.common.io.Resources;
 import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.Domain;
@@ -26,6 +28,7 @@ import com.microsoft.applicationinsights.test.fakeingestion.MockedAppInsightsIng
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
@@ -37,20 +40,29 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.annotation.Nullable;
 import javax.transaction.NotSupportedException;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import static org.junit.Assert.*;
 /**
@@ -532,6 +544,92 @@ public abstract class AiSmokeTest {
 		return map;
 	}
 	//endregion
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Test
+	public void zzz_CheckForExceptionsInLogs() throws IOException, InterruptedException {
+		Stopwatch sw = Stopwatch.createStarted();
+		System.out.println("\n-=== SCANNING LOGS FOR UNEXPECTED EXCEPTIONS ===-\n");
+		System.out.println("Gathering logs...");
+		docker.execOnContainer(currentContainerInfo.getContainerId(), "./gatherLogs.sh");
+		System.out.println("Downloading zip...");
+		File logsZipFile = tempFolder.newFile();
+		docker.copyFromContainer(currentContainerInfo.getContainerId(), "/root/docker-stage/appServerLogs.zip", logsZipFile);
+		ZipFile logsAsZip = new ZipFile(logsZipFile);
+
+		int fileCount = 0;
+		final AtomicInteger linesCount = new AtomicInteger();
+
+		final Enumeration<? extends ZipEntry> entries = logsAsZip.entries();
+		List<String> exceptionTypeToTrace = new ArrayList<>();
+		while (entries.hasMoreElements()) {
+			ZipEntry entry = entries.nextElement();
+			List<String> fileResults = CharStreams.readLines(new BufferedReader(new InputStreamReader(logsAsZip.getInputStream(entry))), new LineProcessor<List<String>>() {
+				final List<String> result = new ArrayList<>();
+
+				final List<Pattern> errorPatterns = new LinkedList<>();
+				final List<Pattern> stackTracePatterns = new LinkedList<>();
+				final List<Pattern> suppressionPatterns = new LinkedList<>();
+
+				boolean lastOneWasSuppressed = false;
+
+				{ // <init>
+					errorPatterns.add(Pattern.compile(".*?ERROR\\s+.*"));
+					errorPatterns.add(Pattern.compile(".*Exception.*"));
+
+					stackTracePatterns.add(Pattern.compile("^\\s+at\\s+?(?:[A-Za-z][\\w$]+)(?:\\.(?:[A-Za-z][\\w$]+))*.*"));
+				}
+
+				@Override
+				public boolean processLine(final String line) throws IOException {
+					linesCount.incrementAndGet();
+					// check if line matches an exception pattern
+					if (anyPatternMatches(line, errorPatterns)) {
+						if (anyPatternMatches(line, suppressionPatterns)) {
+							return true;
+						}
+						result.add(line);
+						return true;
+					}
+
+					if (lastOneWasSuppressed) { // then don't add the stack trace
+						return true;
+					}
+					if (anyPatternMatches(line, stackTracePatterns)) {
+						if (anyPatternMatches(line, suppressionPatterns)) {
+							return true;
+						}
+						String lastResult = result.remove(result.size()-1);
+						result.add(String.format("%s%n%s", lastResult, line));
+					}
+					return true;
+				}
+
+				private boolean anyPatternMatches(final String line, final List<Pattern> patterns) {
+					for (Pattern p : patterns) {
+						Matcher m = p.matcher(line);
+						if (m.matches()) {
+							return true;
+						}
+					}
+					return false;
+				}
+
+				@Override
+				public List<String> getResult() {
+					return result;
+				}
+			});
+			if (!fileResults.isEmpty()) {
+				exceptionTypeToTrace.addAll(fileResults);
+			}
+			fileCount++;
+		}
+		System.out.printf("Scanned %d lines in %d files in %.3fms%n", linesCount.get(), fileCount, sw.elapsed(TimeUnit.NANOSECONDS)/1_000_000.0);
+		Assert.assertTrue(String.format("%d errors detected", exceptionTypeToTrace.size()), exceptionTypeToTrace.isEmpty());
+	}
 
 	@After
 	public void resetMockedIngestion() throws Exception {

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -590,6 +590,9 @@ public abstract class AiSmokeTest {
 				@Override
 				public boolean processLine(final String line) {
 					linesCount.incrementAndGet();
+					if (StringUtils.isBlank(line)) {
+					    return true;
+                    }
 					// check if line matches an exception pattern
 					if (anyPatternMatches(line, errorPatterns)) {
 						if (anyPatternMatches(line, suppressionPatterns)) {
@@ -605,8 +608,13 @@ public abstract class AiSmokeTest {
 					if (lastOneWasSuppressed) { // then don't add the stack trace
 						return true;
 					}
+
 					if (anyPatternMatches(line, stackTracePatterns)) {
-						String lastResult = result.remove(result.size()-1);
+					    int lastIndex = result.size() - 1;
+					    if (lastIndex < 0 || lastIndex >= result.size()) {
+					        return true;
+                        }
+						String lastResult = result.remove(lastIndex);
 						result.add(String.format("%s%n%s", lastResult, line));
 					}
 					return true;

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
@@ -178,7 +178,7 @@ public class AiDockerClient {
 		}
 		Process p = buildProcess(cmdList).start();
 		try {
-			waitAndCheckCodeForProcess(p, 10, TimeUnit.SECONDS, String.format("executing command on container: '%s'", id, Joiner.on(' ').join(cmdList)));
+			waitAndCheckCodeForProcess(p, 10, TimeUnit.SECONDS, String.format("executing command on container: '%s'", Joiner.on(' ').join(cmdList)));
 			flushStdout(p);
 		}
 		catch (Exception e) {

--- a/test/smoke/testApps/SimpleCalculator/src/smokeTest/resources/appServers.txt
+++ b/test/smoke/testApps/SimpleCalculator/src/smokeTest/resources/appServers.txt
@@ -1,1 +1,1 @@
-tomcat7
+tomcat85


### PR DESCRIPTION
This creates a test which runs last (thanks to the test sorter which runs tests in alphabetical order). Since it's in the smoketest superclass, it runs on all current tests. This is before a container is stopped and the next one is selected.

There is only one pattern right now which checks for exceptions and one suppression "rule".

Going forward, we'll need to keep an eye on these results and continue to populate the search rules and suppression rules as needed.