### PR TITLE
added timezone to dateformat for logs

### DIFF
--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/logger/InternalAgentLogger.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/logger/InternalAgentLogger.java
@@ -23,6 +23,7 @@ package com.microsoft.applicationinsights.agent.internal.logger;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
 
@@ -84,6 +85,12 @@ public enum InternalAgentLogger {
                 loggingLevel = LoggingLevel.TRACE;
             } else {
                 loggingLevel = LoggingLevel.valueOf(loggerLevel.toUpperCase());
+            }
+            final String utcId = "UTC";
+            try {
+                dateFormatter.setTimeZone(TimeZone.getTimeZone(utcId));
+            } catch (Exception e) {
+                logAlways(LoggingLevel.WARN, "Failed to find timezone with id='%s'. Using default '%s'", utcId, dateFormatter.getTimeZone().getDisplayName());
             }
         } catch (Exception e) {
             logAlways(LoggingLevel.ERROR, "Failed to parse logging level, using OFF");

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/logger/InternalAgentLogger.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/logger/InternalAgentLogger.java
@@ -53,7 +53,7 @@ public enum InternalAgentLogger {
 
     private boolean initialized = false;
 
-    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSS");
+    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSSZ");
     private LoggingLevel loggingLevel = LoggingLevel.OFF;
 
     public boolean isTraceEnabled() {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
@@ -22,7 +22,6 @@
 package com.microsoft.applicationinsights.internal.logger;
 
 import java.text.SimpleDateFormat;
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
@@ -22,8 +22,10 @@
 package com.microsoft.applicationinsights.internal.logger;
 
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Map;
+import java.util.TimeZone;
 
 import com.google.common.base.Strings;
 
@@ -41,7 +43,7 @@ public enum InternalLogger {
     INSTANCE;
 
     private final static String LOGGER_LEVEL = "Level";
-    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSSZ");
+    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSS");
 
     public enum LoggingLevel {
         ALL(Integer.MIN_VALUE),
@@ -100,6 +102,13 @@ public enum InternalLogger {
                         // Failed
                         onInitializationError(String.format("Error: Illegal value '%s' for the SDK internal logger. Logging level is therefore set to 'OFF'", loggerLevel));
                     }
+                }
+
+                final String utcId = "UTC";
+                try {
+                    dateFormatter.setTimeZone(TimeZone.getTimeZone(utcId));
+                } catch (Exception e) {
+                    new ConsoleLoggerOutput().log(String.format("Failed to find timezone with id='%s'. Using default '%s'", utcId, dateFormatter.getTimeZone().getDisplayName()));
                 }
             } finally {
                 initialized = true;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
@@ -42,7 +42,7 @@ public enum InternalLogger {
     INSTANCE;
 
     private final static String LOGGER_LEVEL = "Level";
-    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSS");
+    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSSZ");
 
     public enum LoggingLevel {
         ALL(Integer.MIN_VALUE),

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/logger/InternalLogger.java
@@ -41,7 +41,7 @@ public enum InternalLogger {
     INSTANCE;
 
     private final static String LOGGER_LEVEL = "Level";
-    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSS");
+    private final static SimpleDateFormat dateFormatter = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSSZ");
 
     public enum LoggingLevel {
         ALL(Integer.MIN_VALUE),


### PR DESCRIPTION
to make debugging customer issues easier when point-in-time matters; i.e. to correlate customer log events with events in the application insights services.

TODO:
- [ ] check smoketest logs for timezone and any errors finding timezone by id.