### PR TITLE
Minor change to smoke tests to make them a bit more tolerant

### DIFF
--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -13,8 +13,10 @@ import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
 import com.microsoft.applicationinsights.telemetry.Duration;
 
+
 import org.junit.*;
 
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.List;
@@ -257,7 +259,8 @@ public class CoreAndFilterTests extends AiSmokeTest {
         RequestData rd1 = getTelemetryDataForType(0, "RequestData");
         long actual = rd1.getDuration().getTotalMilliseconds();
         long expected = (new Duration(0, 0, 0, 20, 0).getTotalMilliseconds());
-        assertTrue(actual >= expected);
+        long tolerance = 2 * 1000; // 2 seconds
+        assertThat(actual, both(greaterThanOrEqualTo(expected - tolerance)).and(lessThan(expected + tolerance)));
     }
 
     @Ignore // See github issue #600. This should pass when that is fixed.

--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -28,6 +28,7 @@ subprojects {
 		smokeTestCompile project(':test:smoke:framework:testCore')
 		smokeTestCompile project(':test:smoke:framework:utils')
 		smokeTestCompile 'junit:junit:4.12'
+		smokeTestCompile 'org.hamcrest:hamcrest-library:1.3'
 		
 		testCompile project(':test:smoke:framework:testCore') // not necessary; vs code bug workaround
 		testCompile project(':test:smoke:framework:utils')


### PR DESCRIPTION
Used a `Matcher` instead of `assertTrue`, which will give a better error message.

This failed for me locally and took some digging to figure out what went wrong. In the future, if you must use `assertTrue` or `assertFalse`, let's include a message, too.
