### PR TITLE
fix trailing whitespace

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsHeartbeatProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsHeartbeatProvider.java
@@ -145,7 +145,7 @@ public class WebAppsHeartbeatProvider implements HeartBeatPayloadProviderInterfa
    */
 
   private String getWebsiteHostName() {
-    return environmentMap.get("WEBSITE_HOSTNAME ");
+    return environmentMap.get("WEBSITE_HOSTNAME");
   }
 
   /**


### PR DESCRIPTION
A small fix to remove the trailing white space from the environment variable in HeartBeat
