### PR TITLE
Added javadoc and rewrote assert in smoketests

### DIFF
--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/DependencyContainer.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/DependencyContainer.java
@@ -1,5 +1,8 @@
 package com.microsoft.applicationinsights.smoketest;
 
+/**
+ * Defines a container to be used as a test dependency.
+ */
 public @interface DependencyContainer {
     /**
      * The identifier of the docker image.

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/UseAgent.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/UseAgent.java
@@ -6,14 +6,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that this test class should use the agent.
+ * Indicates that this test class should use the agent and selects the configuration file for the agent to use.
+ *
+ * <p>The configuration files should be placed in {@code /test/smoke/appServers/global-resources/{mode}_AI-Agent.xml}.</p>
+ *
+ * <p>
+ *     The {mode} prefix differentiates the configurations for various purposes and the mode is selected by the
+ *     {@link #value()} in this annotation. For example, a configuration file named {@code myconfig_AI-Agent.xml}
+ *     can be selected by annotating a class with {@code @UseAgent("myconfig")}.
+ * </p>
+ *
+ * <p>
+ *     When the configuration file is used, the selected configuration file is copied to the agent library's directory
+ *     and renamed to {@code AI-Agent.xml}.
+ * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface UseAgent {
     /**
-     * Sets the agent mode; meaning which config file to use.
-     * @return
+     * Sets the agent mode, i.e. chooses the config file to use.
      */
     String value() default "default";
 }

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/WithDependencyContainers.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/WithDependencyContainers.java
@@ -5,6 +5,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Indicated that the annotated class should also start the listed containers on the same Docker network to be used
+ * as test app dependencies. Dependency contianers are started before the test application in the same order listed
+ * in this annotation.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface WithDependencyContainers {

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -13,8 +13,10 @@ import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
 import com.microsoft.applicationinsights.telemetry.Duration;
 
+
 import org.junit.*;
 
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.List;
@@ -257,7 +259,8 @@ public class CoreAndFilterTests extends AiSmokeTest {
         RequestData rd1 = getTelemetryDataForType(0, "RequestData");
         long actual = rd1.getDuration().getTotalMilliseconds();
         long expected = (new Duration(0, 0, 0, 20, 0).getTotalMilliseconds());
-        assertTrue(actual >= expected);
+        long tolerance = 2 * 1000; // 2 seconds
+        assertThat(actual, both(greaterThanOrEqualTo(expected - tolerance)).and(lessThan(expected + tolerance)));
     }
 
     @Ignore // See github issue #600. This should pass when that is fixed.

--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -28,6 +28,7 @@ subprojects {
 		smokeTestCompile project(':test:smoke:framework:testCore')
 		smokeTestCompile project(':test:smoke:framework:utils')
 		smokeTestCompile 'junit:junit:4.12'
+		smokeTestCompile 'org.hamcrest:hamcrest-library:1.3'
 		
 		testCompile project(':test:smoke:framework:testCore') // not necessary; vs code bug workaround
 		testCompile project(':test:smoke:framework:utils')


### PR DESCRIPTION
Docs for using agent and dependency related annotations.
Using `assertThat` instead of `assertTrue` because the former method gives better output on failure.
