### PR TITLE
Updated trackMetric to conform to bond spec

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -270,17 +270,6 @@ public class TelemetryClient {
 
     /**
      * Sends a numeric metric to Application Insights. Appears in customMetrics in Analytics, and under Custom Metrics in Metric Explorer.
-     * @param name The name of the metric. Max length 150.
-     * @param value The value of the metric.
-     * @param properties Named string values you can use to search and classify trace messages.
-     * @throws IllegalArgumentException if name is null or empty.
-     */
-    public void trackMetric(String name, double value, Map<String, String> properties) {
-        trackMetric(name, value, null, null, null, null, properties);
-    }
-
-    /**
-     * Sends a numeric metric to Application Insights. Appears in customMetrics in Analytics, and under Custom Metrics in Metric Explorer.
      * @param telemetry The {@link com.microsoft.applicationinsights.telemetry.Telemetry} instance.
      */
     public void trackMetric(MetricTelemetry telemetry) {

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -39,6 +39,7 @@ import com.microsoft.applicationinsights.internal.util.MapUtil;
 import com.microsoft.applicationinsights.channel.TelemetryChannel;
 
 import com.google.common.base.Strings;
+import com.sun.istack.internal.Nullable;
 
 // Created by gupele
 /**
@@ -217,43 +218,66 @@ public class TelemetryClient {
     /**
      * Sends a numeric metric to Application Insights. Appears in customMetrics in Analytics, and under Custom Metrics in Metric Explorer.
      * @param name The name of the metric. Max length 150.
-     * @param value The value of the metric. Average if based on more than one sample count. Should be greater than 0.
+     * @param value The value of the metric. Sum if based on more than one sample count.
      * @param sampleCount The sample count.
      * @param min The minimum value of the sample.
      * @param max The maximum value of the sample.
      * @param properties Named string values you can use to search and classify trace messages.
+     * @throws IllegalArgumentException if name is null or empty.
+     * @deprecated Use {@link #trackMetric(String, double, Integer, Double, Double, Double, Map)}
      */
+    @Deprecated
     public void trackMetric(String name, double value, int sampleCount, double min, double max, Map<String, String> properties) {
+        this.trackMetric(name, value, sampleCount, min, max, null, properties);
+    }
+
+    /**
+     * Sends a numeric metric to Application Insights. Appears in customMetrics in Analytics, and under Custom Metrics in Metric Explorer.
+     *
+     * @param name The name of the metric. Max length 150.
+     * @param value The value of the metric. Sum if it represents an aggregation.
+     * @param sampleCount The sample count.
+     * @param min The minimum value of the sample.
+     * @param max The maximum value of the sample.
+     * @param stdDev The standard deviation of the sample.
+     * @param properties Named string values you can use to search and classify trace messages.
+     * @throws IllegalArgumentException if name is null or empty
+     */
+    public void trackMetric(String name, double value, @Nullable Integer sampleCount, @Nullable Double min, @Nullable Double max, @Nullable Double stdDev, @Nullable Map<String, String> properties) {
         if (isDisabled()) {
             return;
         }
 
-        if (Strings.isNullOrEmpty(name)) {
-            name = "";
-        }
-
         MetricTelemetry mt = new MetricTelemetry(name, value);
         mt.setCount(sampleCount);
-        if (sampleCount > 1) {
-            mt.setMin(min);
-            mt.setMax(max);
-            mt.setStandardDeviation(0.0);
-        }
-
+        mt.setMin(min);
+        mt.setMax(max);
+        mt.setStandardDeviation(stdDev);
         if (properties != null && properties.size() > 0) {
-            MapUtil.copy(properties, mt.getContext().getProperties());
+            MapUtil.copy(properties, mt.getProperties());
         }
-
         this.track(mt);
     }
 
     /**
      * Sends a numeric metric to Application Insights. Appears in customMetrics in Analytics, and under Custom Metrics in Metric Explorer.
      * @param name The name of the metric. Max length 150.
-     * @param value The value of the metric. Should be greater than 0.
+     * @param value The value of the metric.
+     * @throws IllegalArgumentException if name is null or empty.
      */
     public void trackMetric(String name, double value) {
-        trackMetric(name, value, 1, value, value, null);
+        trackMetric(name, value, null, null, null, null, null);
+    }
+
+    /**
+     * Sends a numeric metric to Application Insights. Appears in customMetrics in Analytics, and under Custom Metrics in Metric Explorer.
+     * @param name The name of the metric. Max length 150.
+     * @param value The value of the metric.
+     * @param properties Named string values you can use to search and classify trace messages.
+     * @throws IllegalArgumentException if name is null or empty.
+     */
+    public void trackMetric(String name, double value, @Nullable Map<String, String> properties) {
+        trackMetric(name, value, null, null, null, null, properties);
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -237,6 +237,7 @@ public class TelemetryClient {
         if (sampleCount > 1) {
             mt.setMin(min);
             mt.setMax(max);
+            mt.setStandardDeviation(0.0);
         }
 
         if (properties != null && properties.size() > 0) {

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -39,7 +39,6 @@ import com.microsoft.applicationinsights.internal.util.MapUtil;
 import com.microsoft.applicationinsights.channel.TelemetryChannel;
 
 import com.google.common.base.Strings;
-import com.sun.istack.internal.Nullable;
 
 // Created by gupele
 /**
@@ -243,7 +242,7 @@ public class TelemetryClient {
      * @param properties Named string values you can use to search and classify trace messages.
      * @throws IllegalArgumentException if name is null or empty
      */
-    public void trackMetric(String name, double value, @Nullable Integer sampleCount, @Nullable Double min, @Nullable Double max, @Nullable Double stdDev, @Nullable Map<String, String> properties) {
+    public void trackMetric(String name, double value, Integer sampleCount, Double min, Double max, Double stdDev, Map<String, String> properties) {
         if (isDisabled()) {
             return;
         }
@@ -276,7 +275,7 @@ public class TelemetryClient {
      * @param properties Named string values you can use to search and classify trace messages.
      * @throws IllegalArgumentException if name is null or empty.
      */
-    public void trackMetric(String name, double value, @Nullable Map<String, String> properties) {
+    public void trackMetric(String name, double value, Map<String, String> properties) {
         trackMetric(name, value, null, null, null, null, properties);
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/MapUtil.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/MapUtil.java
@@ -35,14 +35,20 @@ import com.google.common.base.Strings;
  */
 public class MapUtil
 {
+    /**
+     * Copies entries from the source map to the target map, overwrites any values in target.
+     * Filters out null values if target is a {@link ConcurrentHashMap}.
+     * @param source the source map. Cannot be null.
+     * @param target the target map. Cannot be null.
+     * @param <Value> The type of the values in both maps
+     * @throws IllegalArgumentException if either {@code source} or {@code target} are null.
+     */
     public static <Value> void copy(Map<String, Value> source, Map<String, Value> target) {
         if (source == null) {
-            Preconditions.checkArgument(source != null, "source must not be null");
-            return;
+            throw new IllegalArgumentException("source must not be null");
         }
         if (target == null) {
-            Preconditions.checkArgument(target != null, "target must not be null");
-            return;
+            throw new IllegalArgumentException("target must not be null");
         }
         for (Map.Entry<String,Value> entry : source.entrySet()) {
             String key = entry.getKey();

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/MetricTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/MetricTelemetry.java
@@ -26,9 +26,16 @@ import com.microsoft.applicationinsights.internal.schemav2.DataPoint;
 import com.microsoft.applicationinsights.internal.schemav2.DataPointType;
 import com.microsoft.applicationinsights.internal.schemav2.MetricData;
 import com.microsoft.applicationinsights.internal.util.Sanitizer;
+import com.sun.istack.internal.Nullable;
 
 /**
  * Telemetry type used to track metrics sent to Azure Application Insights.
+ * <p>
+ * This represents a Measurement, if only Name and Value are set.
+ * If Count, Min, Max or Standard Deviation are set, this represents an Aggregation;
+ * a sampled set of points summarized by these statistic fields.
+ * In an Aggregation metric, the value, i.e. {@link #getValue()}, represents the sum of sampled data points.
+ * </p>
  */
 public final class MetricTelemetry extends BaseTelemetry<MetricData> {
     private final MetricData data;
@@ -60,6 +67,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Initializes the instance with a name and value
      * @param name The name of the metric. Length 1-150 characters.
      * @param value The value of the metric.
+     * @throws IllegalArgumentException if name is null or empty
      */
     public MetricTelemetry(String name, double value) {
         this();
@@ -68,10 +76,11 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
     }
 
     /**
-     * indicate that this metric is a custom performance counter and should be sent to the performance counters table
+     * Indicate that this metric is a custom performance counter and should be sent to the performance counters table.
+     * This sets 'CustomPerfCounter'='true' key/value pair in this metric's properties.
      */
     public void markAsCustomPerfCounter(){
-        data.getProperties().putIfAbsent("CustomPerfCounter", "true");
+        data.getProperties().put("CustomPerfCounter", "true");
     }
 
     /**
@@ -85,6 +94,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
     /**
      * Sets the name of the metric. Length 1-150 characters.
      * @param name The name of the metric.
+     * @throws IllegalArgumentException if the name is null or empty.
      */
     public void setName(String name) {
         if (Strings.isNullOrEmpty(name)) {
@@ -95,7 +105,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
     }
 
     /**
-     * Gets The value of the metric.
+     * Gets The value of the metric. Represents the sum of data points if this metric is an Aggregation
      * @return The value of the metric.
      */
     public double getValue() {
@@ -119,10 +129,10 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
     }
 
     /**
-     * Sets the number of samples for this metric. 
+     * Sets the number of samples for this metric.
      * @param count Number of samples greater than or equal to 1
      */
-    public void setCount(Integer count) {
+    public void setCount(@Nullable Integer count) {
         metric.setCount(count); updateKind();
     }
 
@@ -138,7 +148,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Sets the min value of this metric across samples.
      * @param value The min value.
      */
-    public void setMin(Double value) {
+    public void setMin(@Nullable Double value) {
         metric.setMin(value); updateKind();
     }
 
@@ -154,7 +164,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Sets the max value of this metric across samples.
      * @param value The max value.
      */
-    public void setMax(Double value) {
+    public void setMax(@Nullable Double value) {
         metric.setMax(value); updateKind();
     }
 
@@ -170,7 +180,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Sets the standard deviation of this metric across samples.
      * @param value The max value.
      */
-    public void setStandardDeviation(Double value) {
+    public void setStandardDeviation(@Nullable Double value) {
         metric.setStdDev(value); updateKind();
     }
 
@@ -186,16 +196,12 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
     }
 
     private void updateKind() {
+        // if any stats are set, assume it's an aggregation.
         boolean isAggregation =
             (metric.getCount() != null) ||
             (metric.getMin() != null) ||
             (metric.getMax() != null) ||
             (metric.getStdDev() != null);
-
-        if ((metric.getCount() != null) && metric.getCount() == 1) {
-            // Singular data point. This is not an aggregation.
-            isAggregation = false;
-        }
 
         metric.setKind(isAggregation ? DataPointType.Aggregation : DataPointType.Measurement);
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/MetricTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/MetricTelemetry.java
@@ -26,7 +26,6 @@ import com.microsoft.applicationinsights.internal.schemav2.DataPoint;
 import com.microsoft.applicationinsights.internal.schemav2.DataPointType;
 import com.microsoft.applicationinsights.internal.schemav2.MetricData;
 import com.microsoft.applicationinsights.internal.util.Sanitizer;
-import com.sun.istack.internal.Nullable;
 
 /**
  * Telemetry type used to track metrics sent to Azure Application Insights.
@@ -132,7 +131,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Sets the number of samples for this metric.
      * @param count Number of samples greater than or equal to 1
      */
-    public void setCount(@Nullable Integer count) {
+    public void setCount(Integer count) {
         metric.setCount(count); updateKind();
     }
 
@@ -148,7 +147,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Sets the min value of this metric across samples.
      * @param value The min value.
      */
-    public void setMin(@Nullable Double value) {
+    public void setMin(Double value) {
         metric.setMin(value); updateKind();
     }
 
@@ -164,7 +163,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Sets the max value of this metric across samples.
      * @param value The max value.
      */
-    public void setMax(@Nullable Double value) {
+    public void setMax(Double value) {
         metric.setMax(value); updateKind();
     }
 
@@ -180,7 +179,7 @@ public final class MetricTelemetry extends BaseTelemetry<MetricData> {
      * Sets the standard deviation of this metric across samples.
      * @param value The max value.
      */
-    public void setStandardDeviation(@Nullable Double value) {
+    public void setStandardDeviation(Double value) {
         metric.setStdDev(value); updateKind();
     }
 

--- a/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientTests.java
@@ -321,31 +321,6 @@ public final class TelemetryClientTests {
     }
 
     @Test
-    public void testTrackMetricWithNameValueProperties() {
-        final String name = "Metric";
-        final double value = 1.11;
-        final Map<String, String> props = new HashMap<String, String>(){{
-            put("key1", "val1");
-            put("key2", "val2");
-        }};
-        client.trackMetric(name, value, props);
-
-        MetricTelemetry mt = (MetricTelemetry) verifyAndGetLastEventSent();
-        assertEquals("getName", name, mt.getName());
-        assertEquals("getValue", value, mt.getValue(), Math.ulp(value));
-
-        assertNull("getCount should be null", mt.getCount());
-        assertNull("getMin should be null", mt.getMin());
-        assertNull("getMax should be null", mt.getMax());
-        assertNull("getStandardDeviation should be null", mt.getStandardDeviation());
-        assertNotNull("getProperties should be non-null", mt.getProperties());
-        for (String key : props.keySet()) {
-            assertTrue("metric properties contains key", mt.getProperties().containsKey(key));
-            assertEquals("metric properties key/value pair did not match", props.get(key), mt.getProperties().get(key));
-        }
-    }
-
-    @Test
     public void testTrackMetricWithAllValues() {
         Map<String, String> props = new HashMap<String, String>() {{
             put("key1", "value1");

--- a/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientTests.java
@@ -47,6 +47,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
@@ -304,9 +305,96 @@ public final class TelemetryClientTests {
 
     @Test
     public void testTrackMetricWithNameAndValue() {
-        client.trackMetric("Metric", 1);
+        final String name = "Metric";
+        final double value = 1.11;
+        client.trackMetric(name, value);
 
-        verifyAndGetLastEventSent();
+        MetricTelemetry mt = (MetricTelemetry) verifyAndGetLastEventSent();
+        assertEquals("getName", name, mt.getName());
+        assertEquals("getValue", value, mt.getValue(), Math.ulp(value));
+
+        assertNull("getCount should be null", mt.getCount());
+        assertNull("getMin should be null", mt.getMin());
+        assertNull("getMax should be null", mt.getMax());
+        assertNull("getStandardDeviation should be null", mt.getStandardDeviation());
+        assertTrue("properties should be empty", mt.getProperties().isEmpty());
+    }
+
+    @Test
+    public void testTrackMetricWithNameValueProperties() {
+        final String name = "Metric";
+        final double value = 1.11;
+        final Map<String, String> props = new HashMap<String, String>(){{
+            put("key1", "val1");
+            put("key2", "val2");
+        }};
+        client.trackMetric(name, value, props);
+
+        MetricTelemetry mt = (MetricTelemetry) verifyAndGetLastEventSent();
+        assertEquals("getName", name, mt.getName());
+        assertEquals("getValue", value, mt.getValue(), Math.ulp(value));
+
+        assertNull("getCount should be null", mt.getCount());
+        assertNull("getMin should be null", mt.getMin());
+        assertNull("getMax should be null", mt.getMax());
+        assertNull("getStandardDeviation should be null", mt.getStandardDeviation());
+        assertNotNull("getProperties should be non-null", mt.getProperties());
+        for (String key : props.keySet()) {
+            assertTrue("metric properties contains key", mt.getProperties().containsKey(key));
+            assertEquals("metric properties key/value pair did not match", props.get(key), mt.getProperties().get(key));
+        }
+    }
+
+    @Test
+    public void testTrackMetricWithAllValues() {
+        Map<String, String> props = new HashMap<String, String>() {{
+            put("key1", "value1");
+            put("key2", "value2");
+        }};
+
+        final String name = "MyMetric";
+        final double value = 1.01;
+        final Integer sampleCount = 2;
+        final Double min = 0.01;
+        final Double max = 1.0;
+        final Double stdDev = 0.636396;
+
+        client.trackMetric(name, value, sampleCount, min, max, stdDev, props);
+        MetricTelemetry mt = (MetricTelemetry) verifyAndGetLastEventSent();
+
+        assertEquals("getName", name, mt.getName());
+        assertEquals("getValue", value, mt.getValue(), Math.ulp(value));
+        assertEquals("getMin", min, mt.getMin());
+        assertEquals("getMax", max, mt.getMax());
+        assertEquals("getStandardDeviation", stdDev, mt.getStandardDeviation());
+        assertNotNull("getProperties should be non-null", mt.getProperties());
+        for (String key : props.keySet()) {
+            assertTrue("metric properties contains key", mt.getProperties().containsKey(key));
+            assertEquals("metric properties key/value pair did not match", props.get(key), mt.getProperties().get(key));
+        }
+    }
+
+    @Test
+    public void testTrackMetricAggregateWithSomeNulls() {
+        Map<String, String> propsIsNull = null;
+
+        final String name = "MyMetricHasNulls";
+        final double value = 1.02;
+        final Integer sampleCount = 3;
+        final Double minIsNull = null;
+        final Double max = 0.99;
+        final Double stdDevIsNull = null;
+
+        client.trackMetric(name, value, sampleCount, minIsNull, max, stdDevIsNull, propsIsNull);
+        MetricTelemetry mt = (MetricTelemetry) verifyAndGetLastEventSent();
+
+        assertEquals("getName", name, mt.getName());
+        assertEquals("getValue", value, mt.getValue(), Math.ulp(value));
+        assertNull("getMin should be null", mt.getMin());
+        assertEquals("getMax", max, mt.getMax());
+        assertNull("getStandardDeviation should be null", mt.getStandardDeviation());
+        assertNotNull("getProperties should be null", mt.getProperties());
+        assertEquals("properties size", 0, mt.getProperties().size());
     }
 
     @Test
@@ -362,7 +450,7 @@ public final class TelemetryClientTests {
     }
 
     @Test
-    @Ignore("Not supported yet.")
+    @Ignore("Not supported yet.") //FIXME yes, it is
     public void testTrackRemoteDependency(){ }
 
     @Test

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -179,11 +179,11 @@ public class CoreAndFilterTests extends AiSmokeTest {
 		assertEquals(DataPointType.Measurement, dp.getKind());
 		assertEquals(expectedValue, dp.getValue(), epsilon);
 		assertEquals("TimeToRespond", dp.getName());
-		assertEquals(Integer.valueOf(1),  dp.getCount());
 
-		assertNull(dp.getMin());
-		assertNull(dp.getMax());
-		assertNull(dp.getStdDev());
+		assertNull("getCount was non-null", dp.getCount());
+		assertNull("getMin was non-null", dp.getMin());
+		assertNull("getMax was non-null", dp.getMax());
+		assertNull("getStdDev was non-null", dp.getStdDev());
 	}
 	
 	@Test


### PR DESCRIPTION
Original description
---
The stddev should be non-null in aggregate metrics. Maybe it should be -1 since that's an invalid value for Standard Deviation.

See [MetricTelemetry.updateKind](https://github.com/Microsoft/ApplicationInsights-Java/blob/0e2fe37143ad78b600d52189bc1994ccf70ac99c/core/src/main/java/com/microsoft/applicationinsights/telemetry/MetricTelemetry.java#L188). If stddev isn't set (or any of the statistic fields), then the metric won't be marked as kind=Aggregate. Perhaps this logic is flawed since it also excludes the possibility of an aggregation on a data set with size=1.

---
According to the bond spec, stddev can be null; as well as the other statistic fields. Updated TelemetryClient and MetricTelemetry to reflect the [bond spec](https://github.com/Microsoft/ApplicationInsights-Home/tree/master/EndpointSpecs/Schemas/Bond) (this PR is just about Metric).
