### PR TITLE
added timeout option to @TargetUri

### DIFF
--- a/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
+++ b/test/smoke/framework/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
@@ -2,6 +2,7 @@ package com.microsoft.applicationinsights.test.fakeingestion;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.io.CharStreams;
@@ -135,7 +136,11 @@ public class MockedAppInsightsIngestionServlet extends HttpServlet {
         }
     }
 
-    public List<Envelope> waitForItems(final Predicate<Envelope> condition, final int numItems, int timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+    public void awaitAnyItems(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+        waitForItems(Predicates.alwaysTrue(), 1, timeout, timeUnit);
+    }
+
+    public List<Envelope> waitForItems(final Predicate<Envelope> condition, final int numItems, long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
         final Future<List<Envelope>> future = itemExecutor.submit(new Callable<List<Envelope>>() {
             @Override
             public List<Envelope> call() throws Exception {

--- a/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
+++ b/test/smoke/framework/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
@@ -91,6 +91,10 @@ public class MockedAppInsightsIngestionServer implements AutoCloseable {
 		return data.getBaseData();
 	}
 
+	public void awaitAnyItems(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+		servlet.awaitAnyItems(timeout, unit);
+	}
+
 	/**
 	 * Waits the given amount of time for this mocked server to recieve one telemetry item matching the given predicate.
 	 *

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/TargetUri.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/TargetUri.java
@@ -15,4 +15,9 @@ public @interface TargetUri {
      * The delay in milliseconds to wait before calling the target uri.
      */
     long delay() default 0L;
+
+    /**
+     * The number of milliseconds to wait for a response.
+     */
+    long timeout() default 0L;
 }

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -252,7 +252,7 @@ public class CoreAndFilterTests extends AiSmokeTest {
     }
 
     @Test
-    @TargetUri("/requestSlow")
+    @TargetUri(value="/requestSlow", timeout=25_000) // the servlet sleeps for 20 seconds
     public void testRequestSlowWithResponseTime() {
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
 


### PR DESCRIPTION
This adds an optional timeout to the `@TargetUri` annotation. Some tests will need more time, e.g. the one that sleeps for 20 seconds before responding.
