### PR TITLE
Tests for WebAppNameContextInitializer

### DIFF
--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/initializers/WebAppNameContextInitializerTest.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/initializers/WebAppNameContextInitializerTest.java
@@ -1,0 +1,43 @@
+package com.microsoft.applicationinsights.web.extensibility.initializers;
+
+import com.microsoft.applicationinsights.telemetry.TelemetryContext;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+public class WebAppNameContextInitializerTest {
+    private WebAppNameContextInitializer underTest;
+    private TelemetryContext context;
+
+    @Before
+    public void setup() {
+        underTest = new WebAppNameContextInitializer();
+        context = new TelemetryContext();
+    }
+
+    @After
+    public void tearDown() {
+        underTest = null;
+        context = null;
+    }
+
+    @Test
+    public void noOpIfNullAppName() {
+        underTest.initialize(context);
+        assertNull(context.getCloud().getRole());
+    }
+
+    @Test
+    public void noOpIfEmptyAppName() {
+        underTest.initialize(context);
+        assertNull(context.getCloud().getRole());
+    }
+
+    @Test
+    public void nonEmptyAppNameSetCloudContextRole() {
+        final String theAppName = "testAppName";
+        underTest.setAppName(theAppName);
+        underTest.initialize(context);
+        assertEquals(theAppName, context.getCloud().getRole());
+    }
+}

--- a/web/src/test/resources/ApplicationInsights.xml
+++ b/web/src/test/resources/ApplicationInsights.xml
@@ -25,6 +25,7 @@
         A-test-instrumentation-key
     </InstrumentationKey>
     <ContextInitializers>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebAppNameContextInitializer" />
     </ContextInitializers>
     <TelemetryInitializers>
         <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationIdTelemetryInitializer"/>


### PR DESCRIPTION
I noticed this was missing tests. They're pretty straightforward.

I did optimize the filter test class a bit: using mockito instead of class override to give it more flexibility.