### PR TITLE
Add lf channel in starter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
 # Version 2.2.0
-- Introduces SpringBoot Starter 1.0.2-BETA
+- Introduces SpringBoot Starter 1.1.0-BETA
 - Starter now respects autoconfiguration for Micrometer metrics.
+- Starter adds autoconfiguration for Local Forwarder gRPC Telemetry Channel. (Please look at readme for details on configuration.)
 - Fix [#712](https://github.com/Microsoft/ApplicationInsights-Java/issues/712) the thread shutdown issue in SpringBoot Starter by registering `ApplicationInsightsServletContextListener`.
 - SpringBoot Starter now supports reading iKey using all the variable names as core sdk.
 - Starter would no longer support relaxed binding of ikey property due to complex conditional need and backport problems with RelaxedBinder from Boot 2 to 1.5.x.

--- a/azure-application-insights-spring-boot-starter/gradle.properties
+++ b/azure-application-insights-spring-boot-starter/gradle.properties
@@ -1,1 +1,1 @@
-spring.boot.starter.version-number=1.0.1-BETA
+spring.boot.starter.version-number=1.1.0-BETA

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsProperties.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsProperties.java
@@ -24,6 +24,7 @@ package com.microsoft.applicationinsights.autoconfigure;
 import com.microsoft.applicationinsights.autoconfigure.helpers.IkeyResolver;
 import com.microsoft.applicationinsights.channel.concrete.TelemetryChannelBase;
 import com.microsoft.applicationinsights.channel.concrete.inprocess.InProcessTelemetryChannel;
+import com.microsoft.applicationinsights.channel.concrete.localforwarder.LocalForwarderTelemetriesTransmitter;
 import com.microsoft.applicationinsights.internal.channel.common.TransmissionFileSystemOutput;
 import com.microsoft.applicationinsights.internal.channel.common.TransmissionNetworkOutput;
 import com.microsoft.applicationinsights.internal.channel.samplingV2.FixedRateSamplingTelemetryProcessor;
@@ -179,6 +180,18 @@ public class ApplicationInsightsProperties {
     /** Configuration of {@link InProcessTelemetryChannel}. */
     private InProcess inProcess = new InProcess();
 
+    /** Configuration of {@link com.microsoft.applicationinsights.channel.concrete.localforwarder.LocalForwarderTelemetryChannel}*/
+    private LocalForwarder localForwarder = new LocalForwarder();
+
+    public LocalForwarder getLocalForwarder() {
+      return localForwarder;
+    }
+
+    public void setLocalForwarder(
+        LocalForwarder localForwarder) {
+      this.localForwarder = localForwarder;
+    }
+
     public InProcess getInProcess() {
       return inProcess;
     }
@@ -271,6 +284,23 @@ public class ApplicationInsightsProperties {
 
       public void setThrottling(boolean throttling) {
         this.throttling = throttling;
+      }
+    }
+
+    /**
+     * The config class to encapsulate the LocalForwarder properties.
+     */
+    static class LocalForwarder {
+
+      /** Local Forwarder Endpoint address. */
+      private String endpointAddress;
+
+      public String getEndpointAddress() {
+        return endpointAddress;
+      }
+
+      public void setEndpointAddress(String endpointAddress) {
+        this.endpointAddress = endpointAddress;
       }
     }
   }

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/exceptions/IllegalConfigurationException.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/exceptions/IllegalConfigurationException.java
@@ -1,0 +1,8 @@
+package com.microsoft.applicationinsights.exceptions;
+
+public class IllegalConfigurationException extends IllegalStateException {
+
+  public IllegalConfigurationException(String s) {
+    super(s);
+  }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,3 @@
-#Fri Feb 09 18:53:31 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,4 @@
+#Fri Feb 09 18:53:31 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
PR adds Auto Configuration for Local Forwarder Telemetry Channel. The Local Forwarder channel would be configured if following property is present -

`azure.application-insights.channel.local-forwarder.endpoint-address`

If both `azure.application-insights.channel.local-forwarder.endpoint-address` as well as 
`azure.application-insights.channel.in-process.endpoint-address` are present in the properties this would be considered as Illegal Configuration and the application would throw in this case.


For significant contributions please make sure you have completed the following items:

- [ ] CHANGELOG.md updated
