### PR TITLE
update auto config of QuickPulse

### DIFF
--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsTelemetryAutoConfiguration.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsTelemetryAutoConfiguration.java
@@ -192,10 +192,15 @@ public class ApplicationInsightsTelemetryAutoConfiguration {
             inProcess.getMaxInstantRetry());
     }
 
+    // If local forwarder channel is present quick pulse would not be initialized.
     @Bean
     @ConditionalOnProperty(value = "azure.application-insights.quick-pulse.enabled", havingValue = "true", matchIfMissing = true)
     @DependsOn("telemetryConfiguration")
     public QuickPulse quickPulse() {
+        String inProcessEndPoint = environment.getProperty("azure.application-insights.channel.local-forwarder.endpoint-address");
+        if (StringUtils.isNotBlank(inProcessEndPoint)) {
+          return QuickPulse.INSTANCE;
+        }
         QuickPulse.INSTANCE.initialize();
         return QuickPulse.INSTANCE;
     }


### PR DESCRIPTION
This PR updates the auto configure of QuickPulse in starter to prevent initialization if Local Forwarder is present. 
