### PR TITLE
Fix quickpulse post interval bug

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseCoordinator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseCoordinator.java
@@ -44,7 +44,7 @@ final class DefaultQuickPulseCoordinator implements QuickPulseCoordinator, Runna
         dataFetcher = initData.dataFetcher;
 
         waitBetweenPingsInMS = initData.waitBetweenPingsInMS;
-        waitBetweenPostsInMS = initData.waitBetweenPingsInMS;
+        waitBetweenPostsInMS = initData.waitBetweenPostsInMS;
         waitOnErrorInMS = initData.waitBetweenPingsInMS;
     }
 


### PR DESCRIPTION
This fixes an issue in QuickPulse where default post interval which was being used was 5 seconds instead of 1 second.