### PR TITLE
Fix the filter order in starter

### DIFF
--- a/azure-application-insights-spring-boot-starter/gradle.properties
+++ b/azure-application-insights-spring-boot-starter/gradle.properties
@@ -1,1 +1,1 @@
-spring.boot.starter.version-number=1.1.0-BETA
+spring.boot.starter.version-number=1.1.1-BETA

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsTelemetryAutoConfiguration.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsTelemetryAutoConfiguration.java
@@ -73,7 +73,8 @@ import org.springframework.core.env.Environment;
         ApplicationInsightsWebModuleConfiguration.class
 })
 @AutoConfigureBefore(name = {
-    "io.micrometer.spring.autoconfigure.export.azuremonitor.AzureMonitorMetricsExportAutoConfiguration"
+    "io.micrometer.spring.autoconfigure.export.azuremonitor.AzureMonitorMetricsExportAutoConfiguration",
+    "com.microsoft.azure.spring.autoconfigure.metrics.AzureMonitorMetricsExportAutoConfiguration"
 })
 public class ApplicationInsightsTelemetryAutoConfiguration {
 

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebMvcAutoConfiguration.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebMvcAutoConfiguration.java
@@ -69,7 +69,7 @@ public class ApplicationInsightsWebMvcAutoConfiguration {
         FilterRegistrationBean registration = new FilterRegistrationBean();
         registration.setFilter(webRequestTrackingFilter);
         registration.addUrlPatterns("/*");
-        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 10);
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
         return registration;
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 // Project properties
-version=2.2.0
+version=2.2.1
 group=com.microsoft.azure
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 // Project properties
-version=2.2.1
+version=2.2.0
 group=com.microsoft.azure
 

--- a/test/smoke/testApps/SpringBootTest/src/main/java/com/springbootstartertest/controller/TestController.java
+++ b/test/smoke/testApps/SpringBootTest/src/main/java/com/springbootstartertest/controller/TestController.java
@@ -36,4 +36,9 @@ public class TestController {
 		client.trackEvent("EventDataPropertyTest", properties, metrics);
 		return "hello";
 	}
+
+	@GetMapping("/throwsException")
+	public void resultCodeTest() throws Exception {
+		throw new Exception("This is an exception");
+	}
 }

--- a/test/smoke/testApps/SpringBootTest/src/main/resources/application.properties
+++ b/test/smoke/testApps/SpringBootTest/src/main/resources/application.properties
@@ -3,3 +3,4 @@ azure.application-insights.channel.in-process.endpoint-address=http://fakeingest
 azure.application-insights.instrumentation-key=00000000-0000-0000-0000-cba987654321
 azure.application-insights.logger.level=TRACE
 azure.application-insights.default-modules.ProcessPerformanceCountersModule.enabled=false
+azure.application-insights.heart-beat.enabled=false

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -43,11 +43,7 @@ public class SpringbootSmokeTest extends AiSmokeTest{
 	public void testResultCodeWhenRestControllerThrows() throws Exception {
 		assertEquals(1, mockedIngestion.getCountForType("RequestData"));
 		RequestData d = getTelemetryDataForType(0, "RequestData");
-//
-//		//final String expectedName = "HttpRequestDataTest";
 		final String expectedResponseCode = "500";
-//
-//		//assertEquals(expectedName, d.getName());
 		assertEquals(expectedResponseCode, d.getResponseCode());
 		assertEquals(false, d.getSuccess());
 	}

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -3,8 +3,11 @@ package com.springbootstartertest.smoketest;
 import static org.junit.Assert.assertEquals;
 
 import com.microsoft.applicationinsights.internal.schemav2.EventData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
 import com.microsoft.applicationinsights.smoketest.TargetUri;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import com.microsoft.localforwarder.library.inputs.contracts.Request;
 import org.junit.Test;
 
 public class SpringbootSmokeTest extends AiSmokeTest{
@@ -33,5 +36,19 @@ public class SpringbootSmokeTest extends AiSmokeTest{
 		assertEquals(expectedName, d2.getName());
 		assertEquals(expectedProperties, d2.getProperties().get("key"));
 		assertEquals(expectedMetric, d2.getMeasurements().get("key"));
+	}
+
+	@Test
+	@TargetUri("/throwsException")
+	public void testResultCodeWhenRestControllerThrows() throws Exception {
+		assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+//		RequestData d = getTelemetryDataForType(0, "RequestData");
+//
+//		//final String expectedName = "HttpRequestDataTest";
+//		final String expectedResponseCode = "500";
+//
+//		//assertEquals(expectedName, d.getName());
+//		assertEquals(expectedResponseCode, d.getResponseCode());
+//		assertEquals(false, d.getSuccess());
 	}
 }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -42,13 +42,13 @@ public class SpringbootSmokeTest extends AiSmokeTest{
 	@TargetUri("/throwsException")
 	public void testResultCodeWhenRestControllerThrows() throws Exception {
 		assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-//		RequestData d = getTelemetryDataForType(0, "RequestData");
+		RequestData d = getTelemetryDataForType(0, "RequestData");
 //
 //		//final String expectedName = "HttpRequestDataTest";
-//		final String expectedResponseCode = "500";
+		final String expectedResponseCode = "500";
 //
 //		//assertEquals(expectedName, d.getName());
-//		assertEquals(expectedResponseCode, d.getResponseCode());
-//		assertEquals(false, d.getSuccess());
+		assertEquals(expectedResponseCode, d.getResponseCode());
+		assertEquals(false, d.getSuccess());
 	}
 }


### PR DESCRIPTION
This fixes the order of Filter injection using SpringBoot starter. It allows to capture the correct response code for failed requests.

It turns out that :  Ordered.HIGHEST_PRECEDENCE = Integer.MIN_VALUE and we were adding 10 to it which reduced the priority eventually ;)

@grlima @littleaj could you please review this change. It is small and there is request to make hot fix for this. 

Deployed the changes in the test app and here is the distributed transaction. 

![image](https://user-images.githubusercontent.com/16353121/47517703-eddba680-d83d-11e8-9d63-8c4c94989b46.png)
