### PR TITLE
upgrade grpc components

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,7 +57,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.14.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.16.1'
         }
     }
     generateProtoTasks {
@@ -123,14 +123,14 @@ dependencies {
     compile ([group: 'com.google.guava', name: 'guava', version: '20.0'])
     compile ([group: 'com.google.code.gson', name: 'gson', version: '2.8.2'])
     compile ([group: 'com.google.protobuf', name:'protobuf-java', version:'3.6.1'])
-    compile ([group: 'io.grpc', name: 'grpc-stub', version: '1.14.0'])
-    compile ([group: 'io.grpc', name: 'grpc-protobuf', version: '1.14.0'])
-    runtime ([group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.14.0'])
+    compile ([group: 'io.grpc', name: 'grpc-stub', version: '1.16.1'])
+    compile ([group: 'io.grpc', name: 'grpc-protobuf', version: '1.16.1'])
+    runtime ([group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.16.1'])
     testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
-    testCompile group: 'io.grpc', name:'grpc-testing', version:'1.14.0'
+    testCompile group: 'io.grpc', name:'grpc-testing', version:'1.16.1'
 }
 
 ext.dependenciesPrefix = 'com.microsoft.applicationinsights.core.dependencies'
@@ -144,6 +144,8 @@ shadowJar {
     relocate 'com.google', "${dependenciesPrefix}.google"
     relocate 'io.grpc', "${dependenciesPrefix}.io.grpc"
     relocate 'io.opencensus', "${dependenciesPrefix}.io.opencensus"
+    relocate 'org.codehaus', "${dependenciesPrefix}.codehaus"
+    relocate 'org.checkerframework', "${dependenciesPrefix}.checkerframework"
 
     exclude '**/*.proto'
 }


### PR DESCRIPTION
Fix #767.

Upgrades grpc dependency to 1.16.1 to include security fix.