### PR TITLE
Performance optimization/use concurrent collection

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TelemetryBuffer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TelemetryBuffer.java
@@ -21,18 +21,19 @@
 
 package com.microsoft.applicationinsights.internal.channel.common;
 
-import java.util.*;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
 import com.google.common.base.Preconditions;
 import com.microsoft.applicationinsights.internal.channel.TelemetriesTransmitter;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.util.LimitsEnforcer;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The class is responsible for getting instances of {@link com.microsoft.applicationinsights.telemetry.Telemetry}


### PR DESCRIPTION
This PR is the first step to increase the performance of the SDK by removing the low level locking mechanism to add telemetries in the buffer.

It uses `ConcurrentLinkedQueue` which uses optimized lock free algorithm (http://www.cs.rochester.edu/~scott/papers/1996_PODC_queues.pdf) and is Thread safe.

It also removes the primitive `long` used to check the Telemetry container and instead uses `AtomicLong` so the `fetch()` method can be made lock free.
