### PR TITLE
W3C Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # CHANGELOG
 
 # Version 2.2.1
+- Fixed [#767](https://github.com/Microsoft/ApplicationInsights-Java/issues/767). Updated gRPC dependencies which inlcudes latest netty version.
+- Fixed [#751](https://github.com/Microsoft/ApplicationInsights-Java/issues/751). Added support for absolute paths for log file output.
 - Abstracted Internal Logger in Core into separate reusable module. 
 - Deprecated InternalAgentLogger in favor of InternalLogger for better consistency.
-- Agent now supports diagnostic writing logs to file. 
+- Fixed [#752](https://github.com/Microsoft/ApplicationInsights-Java/issues/752). Agent now supports diagnostic writing logs to file. 
 - Added ability to configure FileLogger for SpringBootStarter. 
-- Fixed [#752](https://github.com/Microsoft/ApplicationInsights-Java/issues/752)
-- Fixed [#751](https://github.com/Microsoft/ApplicationInsights-Java/issues/751)
+- Fixed the `WebRequestTrackingFilter` order in FilterChain for SpringBoot Starter.
 
 
 # Version 2.2.0

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/DefaultClassDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/DefaultClassDataProvider.java
@@ -88,7 +88,9 @@ class DefaultClassDataProvider implements ClassDataProvider {
 
             if (agentConfiguration.getBuiltInConfiguration().isHttpEnabled()) {
 				InternalLogger.INSTANCE.trace("Adding built-in HTTP instrumentation");
-                new HttpClassDataProvider(classesToInstrument).add();
+                HttpClassDataProvider httpClassDataProvider= new HttpClassDataProvider(classesToInstrument);
+                httpClassDataProvider.setIsW3CEnabled(agentConfiguration.getBuiltInConfiguration().isW3cEnabled());
+                httpClassDataProvider.add();
             }
 
             if (agentConfiguration.getBuiltInConfiguration().isRedisEnabled()) {

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/HttpClientMethodVisitor.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/HttpClientMethodVisitor.java
@@ -54,6 +54,7 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
     private int correlationContextLocal;
     private int appCorrelationId;
     private int tracestate;
+    private int traceparent;
 
     @Override
     public void onMethodEnter() {
@@ -97,6 +98,12 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
             // generate child ID
             mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation",
                 "generateChildDependencyTraceparent", "()Ljava/lang/String;", false);
+            traceparent = this.newLocal(Type.getType(Object.class));
+            mv.visitVarInsn(ASTORE, traceparent);
+
+            mv.visitVarInsn(ALOAD, traceparent);
+            mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation",
+                "createChildIdFromTraceparentString", "(Ljava/lang/String;)Ljava/lang/String;", false);
             childIdLocal = this.newLocal(Type.getType(Object.class));
             mv.visitVarInsn(ASTORE, childIdLocal);
 
@@ -110,7 +117,7 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
             // 2 because the 1 is the method being instrumented
             mv.visitVarInsn(ALOAD, 2);
             mv.visitLdcInsn("traceparent");
-            mv.visitVarInsn(ALOAD, childIdLocal);
+            mv.visitVarInsn(ALOAD, traceparent);
             mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
 
             mv.visitVarInsn(ALOAD, tracestate);

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/HttpClientMethodVisitor.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/HttpClientMethodVisitor.java
@@ -119,7 +119,7 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
 
             mv.visitVarInsn(ALOAD, 2);
             mv.visitLdcInsn("tracestate");
-            mv.visitVarInsn(ALOAD, appCorrelationId);
+            mv.visitVarInsn(ALOAD, tracestate);
 
             mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/HttpClientMethodVisitor.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/HttpClientMethodVisitor.java
@@ -34,14 +34,17 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
 
     private final static String FINISH_DETECT_METHOD_NAME = "httpMethodFinished";
     private final static String FINISH_METHOD_RETURN_SIGNATURE = "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IJ)V";
+    private final boolean isW3CEnabled;
 
     public HttpClientMethodVisitor(int access,
                                    String desc,
                                    String owner,
                                    String methodName,
                                    MethodVisitor methodVisitor,
-                                   ClassToMethodTransformationData additionalData) {
+                                   ClassToMethodTransformationData additionalData,
+                                   boolean isW3CEnabled) {
         super(access, desc, owner, methodName, methodVisitor, additionalData);
+        this.isW3CEnabled = isW3CEnabled;
     }
 
     private int deltaInNS;
@@ -50,6 +53,7 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
     private int childIdLocal;
     private int correlationContextLocal;
     private int appCorrelationId;
+    private int tracestate;
 
     @Override
     public void onMethodEnter() {
@@ -57,36 +61,72 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
         deltaInNS = this.newLocal(Type.LONG_TYPE);
         mv.visitVarInsn(LSTORE, deltaInNS);
 
-        // generate child ID
-        mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "generateChildDependencyId", "()Ljava/lang/String;", false);
-        childIdLocal = this.newLocal(Type.getType(Object.class));
-        mv.visitVarInsn(ASTORE, childIdLocal);
-        
-        // retrieve correlation context
-        mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "retrieveCorrelationContext", "()Ljava/lang/String;", false);
-        correlationContextLocal = this.newLocal(Type.getType(Object.class));
-        mv.visitVarInsn(ASTORE, correlationContextLocal);
-        
-        // retrieve request context
-        mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "retrieveApplicationCorrelationId", "()Ljava/lang/String;", false);
-        appCorrelationId = this.newLocal(Type.getType(Object.class));
-        mv.visitVarInsn(ASTORE, appCorrelationId);
+        if (!isW3CEnabled) {
+            // generate child ID
+            mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "generateChildDependencyId", "()Ljava/lang/String;", false);
+            childIdLocal = this.newLocal(Type.getType(Object.class));
+            mv.visitVarInsn(ASTORE, childIdLocal);
 
-        // inject headers
-        mv.visitVarInsn(ALOAD, 2);
-        mv.visitLdcInsn("Request-Id");
-        mv.visitVarInsn(ALOAD, childIdLocal);
-        mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
+            // retrieve correlation context
+            mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "retrieveCorrelationContext", "()Ljava/lang/String;", false);
+            correlationContextLocal = this.newLocal(Type.getType(Object.class));
+            mv.visitVarInsn(ASTORE, correlationContextLocal);
 
-        mv.visitVarInsn(ALOAD, 2);
-        mv.visitLdcInsn("Correlation-Context");
-        mv.visitVarInsn(ALOAD, correlationContextLocal);
-        mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
-        
-        mv.visitVarInsn(ALOAD, 2);
-        mv.visitLdcInsn("Request-Context");
-        mv.visitVarInsn(ALOAD, appCorrelationId);
-        mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
+            // retrieve request context
+            mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "retrieveApplicationCorrelationId", "()Ljava/lang/String;", false);
+            appCorrelationId = this.newLocal(Type.getType(Object.class));
+            mv.visitVarInsn(ASTORE, appCorrelationId);
+
+            // inject headers
+            // 2 because the 1 is the method being instrumented
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitLdcInsn("Request-Id");
+            mv.visitVarInsn(ALOAD, childIdLocal);
+            mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
+
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitLdcInsn("Correlation-Context");
+            mv.visitVarInsn(ALOAD, correlationContextLocal);
+            mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
+
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitLdcInsn("Request-Context");
+            mv.visitVarInsn(ALOAD, appCorrelationId);
+            mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
+        } else {
+            // generate child ID
+            mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation",
+                "generateChildDependencyTraceparent", "()Ljava/lang/String;", false);
+            childIdLocal = this.newLocal(Type.getType(Object.class));
+            mv.visitVarInsn(ASTORE, childIdLocal);
+
+            // retrieve tracestate
+            mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation",
+                "retriveTracestate", "()Ljava/lang/String;", false);
+            tracestate = this.newLocal(Type.getType(Object.class));
+            mv.visitVarInsn(ASTORE, tracestate);
+
+            // inject headers
+            // 2 because the 1 is the method being instrumented
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitLdcInsn("traceparent");
+            mv.visitVarInsn(ALOAD, childIdLocal);
+            mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
+
+            mv.visitVarInsn(ALOAD, tracestate);
+            Label nullLabel = new Label();
+            mv.visitJumpInsn(IFNULL, nullLabel);
+
+            mv.visitVarInsn(ALOAD, 2);
+            mv.visitLdcInsn("tracestate");
+            mv.visitVarInsn(ALOAD, appCorrelationId);
+
+            mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "addHeader", "(Ljava/lang/String;Ljava/lang/String;)V", true);
+
+            // skip adding tracestate
+            mv.visitLabel(nullLabel);
+        }
+
 
         mv.visitVarInsn(ALOAD, 2);
         mv.visitMethodInsn(INVOKEINTERFACE, "org/apache/http/HttpRequest", "getRequestLine", "()Lorg/apache/http/RequestLine;", true);
@@ -153,11 +193,20 @@ public final class HttpClientMethodVisitor extends AbstractHttpMethodVisitor {
                 int headerValueLocal = this.newLocal(Type.getType(Object.class));
                 mv.visitVarInsn(ASTORE, headerValueLocal);
 
-                //generate target
-                mv.visitVarInsn(ALOAD, headerValueLocal);
-                mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "generateChildDependencyTarget", "(Ljava/lang/String;)Ljava/lang/String;", false);
                 int targetLocal = this.newLocal(Type.getType(Object.class));
-                mv.visitVarInsn(ASTORE, targetLocal);
+                if (!isW3CEnabled) {
+                    //generate target
+                    mv.visitVarInsn(ALOAD, headerValueLocal);
+                    mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils", "generateChildDependencyTarget", "(Ljava/lang/String;)Ljava/lang/String;", false);
+                    mv.visitVarInsn(ASTORE, targetLocal);
+                } else {
+                    //generate target
+                    mv.visitVarInsn(ALOAD, headerValueLocal);
+                    mv.visitMethodInsn(INVOKESTATIC, "com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation",
+                        "generateChildDependencyTarget", "(Ljava/lang/String;)Ljava/lang/String;", false);
+                    mv.visitVarInsn(ASTORE, targetLocal);
+                }
+
 
                 mv.visitFieldInsn(Opcodes.GETSTATIC, internalName, "INSTANCE", "L" + internalName + ";");
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/http/HttpClassDataProvider.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/agent/http/HttpClassDataProvider.java
@@ -63,6 +63,12 @@ public final class HttpClassDataProvider {
 
     private final static String REST_TEMPLATE_METTHOD = "doExecute";
 
+    public static void setIsW3CEnabled(boolean isW3CEnabled) {
+        HttpClassDataProvider.isW3CEnabled = isW3CEnabled;
+    }
+
+    private static boolean isW3CEnabled;
+
     private final Map<String, ClassInstrumentationData> classesToInstrument;
 
     public HttpClassDataProvider(Map<String, ClassInstrumentationData> classesToInstrument) {
@@ -80,7 +86,7 @@ public final class HttpClassDataProvider {
                                             String methodName,
                                             MethodVisitor methodVisitor,
                                             ClassToMethodTransformationData additionalData) {
-                    return new HttpClientMethodVisitor(access, desc, className, methodName, methodVisitor, additionalData);
+                    return new HttpClientMethodVisitor(access, desc, className, methodName, methodVisitor, additionalData, isW3CEnabled);
                 }
             };
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentBuiltInConfiguration.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentBuiltInConfiguration.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class AgentBuiltInConfiguration {
     private final boolean enabled;
     private final boolean httpEnabled;
+    private final boolean w3cEnabled;
     private final boolean jdbcEnabled;
     private final boolean hibernateEnabled;
     private final boolean jedisEnabled;
@@ -43,6 +44,7 @@ public class AgentBuiltInConfiguration {
     public AgentBuiltInConfiguration(boolean enabled,
                                      List<ClassInstrumentationData> simpleBuiltInClasses,
                                      boolean httpEnabled,
+                                     boolean w3cEnabled,
                                      boolean jdbcEnabled,
                                      boolean hibernateEnabled,
                                      boolean jedisEnabled,
@@ -53,6 +55,7 @@ public class AgentBuiltInConfiguration {
         this.simpleBuiltInClasses = simpleBuiltInClasses;
         this.enabled = enabled;
         this.httpEnabled = httpEnabled;
+        this.w3cEnabled = w3cEnabled;
         this.jdbcEnabled = jdbcEnabled;
         this.hibernateEnabled = hibernateEnabled;
         this.jmxEnabled = jmxEnabled;
@@ -95,6 +98,10 @@ public class AgentBuiltInConfiguration {
 
     public boolean isJmxEnabled() {
         return jmxEnabled;
+    }
+
+    public boolean isW3cEnabled() {
+        return w3cEnabled;
     }
 
     public DataOfConfigurationForException getDataOfConfigurationForException() {

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentBuiltInConfigurationBuilder.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentBuiltInConfigurationBuilder.java
@@ -35,6 +35,7 @@ public class AgentBuiltInConfigurationBuilder {
     private boolean hibernateEnabled = false;
     private boolean jedisEnabled = false;
     private boolean jmxEnabled = false;
+    private boolean w3cEnabled = false;
     private long jedisThresholdInMS = 10000L;
     private Long maxSqlQueryLimitInMS = 10000L;
     private DataOfConfigurationForException dataOfConfigurationForException = new DataOfConfigurationForException();
@@ -48,6 +49,7 @@ public class AgentBuiltInConfigurationBuilder {
         return new AgentBuiltInConfiguration(enabled,
                                              simpleBuiltInClasses,
                                              httpEnabled && enabled,
+                                             w3cEnabled,
                                              jdbcEnabled && enabled,
                                              hibernateEnabled && enabled,
                                              jedisEnabled && enabled,
@@ -62,8 +64,9 @@ public class AgentBuiltInConfigurationBuilder {
         return this;
     }
 
-    public AgentBuiltInConfigurationBuilder setHttpEnabled(boolean httpEnabled) {
+    public AgentBuiltInConfigurationBuilder setHttpEnabled(boolean httpEnabled, boolean w3cEnabled) {
         this.httpEnabled = httpEnabled;
+        this.w3cEnabled = w3cEnabled;
         return this;
     }
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationBuilder.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationBuilder.java
@@ -226,7 +226,6 @@ final class XmlAgentConfigurationBuilder implements AgentConfigurationBuilder {
         nodes = builtInElement.getElementsByTagName(HTTP_TAG);
         Element httpElement = XmlParserUtils.getFirst(nodes);
         boolean isW3CEnabled = XmlParserUtils.w3cEnabled(httpElement, W3C_ENABLED);
-        System.out.println("!----------"+isW3CEnabled+"------!");
         builtInConfigurationBuilder.setHttpEnabled(XmlParserUtils.getEnabled(element, HTTP_TAG),isW3CEnabled);
 
         nodes = builtInElement.getElementsByTagName(JDBC_TAG);

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationBuilder.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationBuilder.java
@@ -69,6 +69,7 @@ final class XmlAgentConfigurationBuilder implements AgentConfigurationBuilder {
     @VisibleForTesting final static String SDK_LOGGER_NUMBER_OF_TOTAL_SIZE_IN_MB = "NumberOfTotalSizeInMB";
 
     private final static long JEDIS_ARGS_THRESHOLD_IN_MS = 10000L;
+    private final static String W3C_ENABLED = "W3C";
 
     private final static String EXCLUDED_PREFIXES_TAG = "ExcludedPrefixes";
     private final static String FORBIDDEN_PREFIX_TAG = "Prefix";
@@ -223,7 +224,10 @@ final class XmlAgentConfigurationBuilder implements AgentConfigurationBuilder {
         new ConfigRuntimeExceptionDataBuilder().setRuntimeExceptionData(builtInElement, builtInConfigurationBuilder);
 
         nodes = builtInElement.getElementsByTagName(HTTP_TAG);
-        builtInConfigurationBuilder.setHttpEnabled(XmlParserUtils.getEnabled(XmlParserUtils.getFirst(nodes), HTTP_TAG));
+        Element httpElement = XmlParserUtils.getFirst(nodes);
+        boolean isW3CEnabled = XmlParserUtils.w3cEnabled(httpElement, W3C_ENABLED);
+        System.out.println("!----------"+isW3CEnabled+"------!");
+        builtInConfigurationBuilder.setHttpEnabled(XmlParserUtils.getEnabled(element, HTTP_TAG),isW3CEnabled);
 
         nodes = builtInElement.getElementsByTagName(JDBC_TAG);
         builtInConfigurationBuilder.setJdbcEnabled(XmlParserUtils.getEnabled(XmlParserUtils.getFirst(nodes), JDBC_TAG));

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlParserUtils.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlParserUtils.java
@@ -23,6 +23,7 @@ package com.microsoft.applicationinsights.agent.internal.config;
 
 import com.microsoft.applicationinsights.agent.internal.common.StringUtils;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -67,7 +68,19 @@ final class XmlParserUtils {
      */
     static boolean w3cEnabled(Element element, String attributeName) {
         assert attributeName.equals("W3C");
-        return getEnabled(element, attributeName, false);
+        try {
+            String strValue = element.getAttribute(attributeName);
+            if (!StringUtils.isNullOrEmpty(strValue)) {
+                boolean value = Boolean.valueOf(strValue);
+                return value;
+            }
+            return false;
+
+        } catch (Exception e) {
+            InternalLogger.INSTANCE.error("cannot parse the correlation format, will default"
+                + "to AI proprietory correlation", ExceptionUtils.getStackTrace(e));
+        }
+        return false;
     }
 
     public static boolean getEnabled(Element element, String elementName, boolean defaultValue) {

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlParserUtils.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/XmlParserUtils.java
@@ -59,6 +59,17 @@ final class XmlParserUtils {
         return getEnabled(element, attributeName, true);
     }
 
+    /**
+     * Method to get the attribute value for W3C
+     * @param element
+     * @param attributeName
+     * @return boolean
+     */
+    static boolean w3cEnabled(Element element, String attributeName) {
+        assert attributeName.equals("W3C");
+        return getEnabled(element, attributeName, false);
+    }
+
     public static boolean getEnabled(Element element, String elementName, boolean defaultValue) {
         if (element == null) {
             return true;

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsProperties.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsProperties.java
@@ -407,12 +407,25 @@ public class ApplicationInsightsProperties {
      */
     private boolean enabled = true;
 
+    /**
+     * Flag to enable/disable W3C headers. It is disabled by default.
+     */
+    private boolean W3C = false;
+
     public boolean isEnabled() {
       return enabled;
     }
 
     public void setEnabled(boolean enabled) {
       this.enabled = enabled;
+    }
+
+    public boolean isW3C() {
+      return W3C;
+    }
+
+    public void setW3C(boolean w3C) {
+      W3C = w3C;
     }
   }
 

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebModuleConfiguration.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebModuleConfiguration.java
@@ -59,7 +59,9 @@ class ApplicationInsightsWebModuleConfiguration {
     @Bean
     @ConditionalOnProperty(value = "azure.application-insights.default-modules.WebRequestTrackingTelemetryModule.enabled", havingValue = "true", matchIfMissing = true)
     WebRequestTrackingTelemetryModule webRequestTrackingTelemetryModule() {
-        return new WebRequestTrackingTelemetryModule();
+        WebRequestTrackingTelemetryModule w = new WebRequestTrackingTelemetryModule();
+        w.isW3CEnabled = true;
+        return w;
     }
 
   /**

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebModuleConfiguration.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebModuleConfiguration.java
@@ -30,6 +30,7 @@ import com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTra
 import com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule;
 import com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule;
 import com.microsoft.applicationinsights.web.internal.perfcounter.WebPerformanceCounterModule;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
@@ -52,7 +53,18 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnWebApplication
 class ApplicationInsightsWebModuleConfiguration {
 
-  /**
+
+    /**
+     * Instance for the container of ApplicationInsights Properties
+     */
+    private ApplicationInsightsProperties applicationInsightsProperties;
+
+    @Autowired
+    public ApplicationInsightsWebModuleConfiguration(ApplicationInsightsProperties properties) {
+        this.applicationInsightsProperties = properties;
+    }
+
+    /**
    * Bean for WebRequestTrackingTelemetryModule
    * @return instance of {@link WebRequestTrackingTelemetryModule}
    */
@@ -60,7 +72,7 @@ class ApplicationInsightsWebModuleConfiguration {
     @ConditionalOnProperty(value = "azure.application-insights.default-modules.WebRequestTrackingTelemetryModule.enabled", havingValue = "true", matchIfMissing = true)
     WebRequestTrackingTelemetryModule webRequestTrackingTelemetryModule() {
         WebRequestTrackingTelemetryModule w = new WebRequestTrackingTelemetryModule();
-        w.isW3CEnabled = true;
+        w.isW3CEnabled = applicationInsightsProperties.getWeb().isW3C();
         return w;
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/agent/CoreAgentNotificationsHandler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/agent/CoreAgentNotificationsHandler.java
@@ -159,13 +159,15 @@ final class CoreAgentNotificationsHandler implements AgentNotificationsHandler {
 		telemetry.setTimestamp(dependencyStartTime);
         telemetry.setId(correlationId);
         telemetry.setResultCode(Integer.toString(result));
-        telemetry.setType("HTTP");
+        telemetry.setType("Http (tracked component)");
 
         // For Backward Compatibility
 		telemetry.getContext().getProperties().put("URI", uri);
 		telemetry.getContext().getProperties().put("Method", method);
 
         if (target != null && !target.isEmpty()) {
+            // AI correlation expects target to be of this format.
+            target = uriObject.getHost() + ":" + uriObject.getPort() + " | " + target;
             if (telemetry.getTarget() == null) {
                 telemetry.setTarget(target);
             } else {

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -21,7 +21,17 @@
 
 package com.microsoft.applicationinsights.web.extensibility.modules;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.common.CommonUtils;
+import com.microsoft.applicationinsights.extensibility.TelemetryModule;
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
+import com.microsoft.applicationinsights.web.internal.ApplicationInsightsHttpResponseWrapper;
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
+import com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils;
 import com.microsoft.applicationinsights.web.internal.correlation.TraceContextCorrelation;
 import java.util.Date;
 import java.util.Map;
@@ -29,17 +39,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import com.microsoft.applicationinsights.common.CommonUtils;
-import com.microsoft.applicationinsights.web.internal.ApplicationInsightsHttpResponseWrapper;
-import com.microsoft.applicationinsights.TelemetryClient;
-import com.microsoft.applicationinsights.TelemetryConfiguration;
-import com.microsoft.applicationinsights.extensibility.TelemetryModule;
-import com.microsoft.applicationinsights.internal.logger.InternalLogger;
-import com.microsoft.applicationinsights.telemetry.Duration;
-import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
-import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
-import com.microsoft.applicationinsights.web.internal.ThreadContext;
-import com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils;
 
 /**
  * Created by yonisha on 2/2/2015.

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.web.extensibility.modules;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.applicationinsights.web.internal.correlation.TraceContextCorrelation;
 import java.util.Date;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
     private TelemetryClient telemetryClient;
     private boolean isInitialized = false;
 
-    private boolean isW3CEnabled = false;
+    @VisibleForTesting boolean isW3CEnabled = false;
 
     /**
      * Field to indicate if W3C tracing protocol is enabled.

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -51,7 +51,7 @@ public class WebRequestTrackingTelemetryModule implements WebTelemetryModule, Te
     private TelemetryClient telemetryClient;
     private boolean isInitialized = false;
 
-    @VisibleForTesting boolean isW3CEnabled = false;
+    public boolean isW3CEnabled = false;
 
     /**
      * Field to indicate if W3C tracing protocol is enabled.

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/RequestTelemetryContext.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/RequestTelemetryContext.java
@@ -42,6 +42,7 @@ public class RequestTelemetryContext {
     private HttpServletRequest servletRequest;
     private final CorrelationContext correlationContext;
     private Tracestate tracestate;
+    private int traceflag;
     private final AtomicInteger currentChildId = new AtomicInteger();
 
     /**
@@ -71,6 +72,14 @@ public class RequestTelemetryContext {
         requestStartTimeTicks = ticks;
         this.servletRequest = servletRequest;
         correlationContext = new CorrelationContext();
+    }
+
+    public int getTraceflag() {
+        return traceflag;
+    }
+
+    public void setTraceflag(int traceflag) {
+        this.traceflag = traceflag;
     }
 
     /**

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/RequestTelemetryContext.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/RequestTelemetryContext.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.web.internal;
 
+import com.microsoft.applicationinsights.web.internal.correlation.tracecontext.Tracestate;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,6 +41,7 @@ public class RequestTelemetryContext {
     private boolean isNewSession = false;
     private HttpServletRequest servletRequest;
     private final CorrelationContext correlationContext;
+    private Tracestate tracestate;
     private final AtomicInteger currentChildId = new AtomicInteger();
 
     /**
@@ -48,6 +50,15 @@ public class RequestTelemetryContext {
      */
     public RequestTelemetryContext(long ticks) {
         this(ticks, null);
+    }
+
+    public Tracestate getTracestate() {
+        return tracestate;
+    }
+
+    public void setTracestate(
+        Tracestate tracestate) {
+        this.tracestate = tracestate;
     }
 
     /**

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
@@ -104,7 +104,7 @@ public class TraceContextCorrelation {
             addTracestateInResponseHeader(response);
 
         } catch (Exception e) {
-            InternalLogger.INSTANCE.trace("unable to perform correlation :%s", ExceptionUtils.
+            InternalLogger.INSTANCE.error("unable to perform correlation :%s", ExceptionUtils.
                 getStackTrace(e));
         }
     }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
@@ -235,16 +235,16 @@ public class TraceContextCorrelation {
                 outboundTracestate.append(",");
             }
         }
-        if (outboundTracestate.length() > 0) {
-            outboundTracestate.deleteCharAt(outboundTracestate.length()-1);
-        }
 
         if (sourceAppId != null && sourceAppId.length() > 0) {
-            if (outboundTracestate.length() > 0) {
-                outboundTracestate.append(",");
-            }
             outboundTracestate.append(AZURE_TRACEPARENT_COMPONENT_INITIAL).append("=").append(sourceAppId);
+        } else {
+            if (outboundTracestate.length() > 0) {
+                // removes the trailing ','
+                outboundTracestate.deleteCharAt(outboundTracestate.length()-1);
+            }
         }
+
         return new Tracestate(outboundTracestate.toString());
     }
 

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
@@ -21,8 +21,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  */
 public class TraceContextCorrelation {
 
-    public static final String CORRELATION_HEADER_NAME = "traceparent";
-    public static final String CORRELATION_COMPANION_HEADER_NAME = "tracestate";
+    public static final String TRACEPARENT_HEADER_NAME = "traceparent";
+    public static final String TRACESTATE_HEADER_NAME = "tracestate";
     public static final String AZURE_TRACEPARENT_COMPONENT_INITIAL = "az";
 
     /**
@@ -58,7 +58,7 @@ public class TraceContextCorrelation {
             }
 
 
-            String traceId = request.getHeader(CORRELATION_HEADER_NAME);
+            String traceId = request.getHeader(TRACEPARENT_HEADER_NAME);
 
             Traceparent outGoingTraceParent = null;
 
@@ -92,7 +92,7 @@ public class TraceContextCorrelation {
 
             }
 
-            String tracestate = request.getHeader(CORRELATION_COMPANION_HEADER_NAME);
+            String tracestate = request.getHeader(TRACESTATE_HEADER_NAME);
             Tracestate tracestateObject = Tracestate.fromString(tracestate);
             Map<String, String> tracestatePropertiesMap = getPropertiesMap(tracestateObject);
 
@@ -114,7 +114,7 @@ public class TraceContextCorrelation {
      */
     private static void addTracestateInResponseHeader(HttpServletResponse response) {
 
-        if (response.containsHeader(CORRELATION_COMPANION_HEADER_NAME)) {
+        if (response.containsHeader(TRACESTATE_HEADER_NAME)) {
             return;
         }
 
@@ -126,7 +126,7 @@ public class TraceContextCorrelation {
         // TODO: should we propagate the entire tracestate here?
         Tracestate tracestate = new Tracestate("az" + appId);
 
-        response.addHeader(CORRELATION_COMPANION_HEADER_NAME, tracestate.toString());
+        response.addHeader(TRACESTATE_HEADER_NAME, tracestate.toString());
     }
 
     /**
@@ -178,9 +178,10 @@ public class TraceContextCorrelation {
                 return;
             }
 
-            String tracestate = request.getHeader(CORRELATION_COMPANION_HEADER_NAME);
+            String tracestate = request.getHeader(TRACESTATE_HEADER_NAME);
             if (tracestate == null || tracestate.isEmpty()) {
-                InternalLogger.INSTANCE.info("Skip resolving request source as the following header was not found: %s", CORRELATION_COMPANION_HEADER_NAME);
+                InternalLogger.INSTANCE.info("Skip resolving request source as the following header was not found: %s",
+                    TRACESTATE_HEADER_NAME);
                 return;
             }
 

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
@@ -78,7 +78,7 @@ public class TraceContextCorrelation {
                 + ".");
 
                 // represents the trace-id of this distributed trace
-                requestTelemetry.getContext().getOperation().setId("|" + outGoingTraceParent.getTraceId() +".");
+                requestTelemetry.getContext().getOperation().setId(outGoingTraceParent.getTraceId());
 
                 // set parentId as null because this is the is the originating request
                 requestTelemetry.getContext().getOperation().setParentId(null);
@@ -106,7 +106,7 @@ public class TraceContextCorrelation {
                     + ".");
 
                     // represents the trace-id of this distributed trace
-                    requestTelemetry.getContext().getOperation().setId("|" + outGoingTraceParent.getTraceId() + ".");
+                    requestTelemetry.getContext().getOperation().setId(outGoingTraceParent.getTraceId());
 
                     if (incomingTraceparent != null) {
                         // represents the parent-id of this request which is combination of traceparent and incoming spanId
@@ -401,9 +401,6 @@ public class TraceContextCorrelation {
             RequestTelemetry requestTelemetry = context.getHttpRequestTelemetry();
             String traceId = requestTelemetry.getContext().getOperation().getId();
 
-            // get the necessary part as traceId in context is of legacy AI format.
-            traceId = traceId.substring(1, traceId.length() - 1);
-
             Traceparent tp = new Traceparent(0, traceId, null, context.getTraceflag());
 
             // We need to propagate full blown traceparent header.
@@ -423,12 +420,11 @@ public class TraceContextCorrelation {
      * @return legacy format traceparent
      */
     public static String createChildIdFromTraceparentString(String traceparent) {
-        System.out.println(traceparent + "-------");
         assert traceparent != null;
 
         String[] traceparentArr = traceparent.split("-");
         assert traceparentArr.length == 4;
 
-        return "|" + traceparentArr[0] + "." + traceparentArr[1] + ".";
+        return "|" + traceparentArr[1] + "." + traceparentArr[2] + ".";
     }
 }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Traceparent.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Traceparent.java
@@ -10,7 +10,7 @@ import org.apache.http.annotation.Experimental;
  *
  * @author Reily Yang
  * @author Dhaval Doshi
- * @link https://github.com/w3c/trace-context/blob/master/trace_context/HTTP_HEADER_FORMAT.md
+ * @see <a href="https://github.com/w3c/trace-context/blob/master/trace_context/HTTP_HEADER_FORMAT.md">Trace Context</a>
  */
 @Experimental
 public class Traceparent {

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Traceparent.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Traceparent.java
@@ -1,0 +1,185 @@
+package com.microsoft.applicationinsights.web.internal.correlation.tracecontext;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.http.annotation.Experimental;
+
+/**
+ * This class represents the Traceparent data structure based on
+ *
+ * @author Reily Yang
+ * @author Dhaval Doshi
+ * @link https://github.com/w3c/trace-context/blob/master/trace_context/HTTP_HEADER_FORMAT.md
+ */
+@Experimental
+public class Traceparent {
+
+    /**
+     * Version number between range [0,255] inclusive
+     */
+    @VisibleForTesting
+    final int version;
+
+    /**
+     * 16 byte trace-id that is used to uniquely identify a distributed trace
+     */
+    @VisibleForTesting
+    final String traceId;
+
+    /**
+     * It is a 8 byte ID that represents the caller span
+     */
+    @VisibleForTesting
+    final String spanId;
+
+    /**
+     * An 8-bit field that controls tracing flags such as sampling, trace level etc.
+     */
+    @VisibleForTesting
+    final int traceFlags;
+
+    private Traceparent(int version, String traceId, String spanId, int traceFlags, boolean check) {
+        if (check) {
+            validate(version, traceId, spanId, traceFlags);
+        }
+        this.version = version;
+        this.traceId = traceId;
+        this.spanId = spanId;
+        this.traceFlags = traceFlags;
+    }
+
+    /**
+     * The constructor that tries to create Traceparent Object from given version, traceId, spanID
+     * and traceFlags.
+     */
+    public Traceparent(int version, String traceId, String spanId, int traceFlags) {
+        this(version, traceId != null ? traceId : randomHex(16),
+            spanId != null ? spanId : randomHex(8),
+            traceFlags, true);
+    }
+
+    /**
+     * This constructor creates a new Traceparent object having new traceId. It should only be used
+     * if the call is the starting point of distributed trace.
+     */
+    public Traceparent() {
+        this(0, randomHex(16), randomHex(8), 0, false);
+    }
+
+    public String getTraceId() {
+        return traceId;
+    }
+
+    public int getTraceFlags() {
+        return traceFlags;
+    }
+
+    public String getSpanId() {
+        return spanId;
+    }
+
+    /**
+     * Validates the given input based on W3C specifications.
+     */
+    private static void validate(int version, String traceId, String spanId, int traceFlags)
+        throws IllegalArgumentException {
+        if (version < 0 || version > 254) {
+            throw new IllegalArgumentException("version must be within range [0, 255)");
+        }
+        if (!isHex(traceId, 32)) {
+            throw new IllegalArgumentException("invalid traceId");
+        }
+        if (traceId.equals("00000000000000000000000000000000")) {
+            throw new IllegalArgumentException("invalid traceId");
+        }
+        if (!isHex(spanId, 16)) {
+            throw new IllegalArgumentException("invalid spanId");
+        }
+        if (spanId.equals("0000000000000000")) {
+            throw new IllegalArgumentException("invalid spanId");
+        }
+        if (traceFlags < 0 || traceFlags > 255) {
+            throw new IllegalArgumentException("traceFlags must be within range [0, 255]");
+        }
+    }
+
+    /**
+     * Converts the Traceparent object to header format Eg: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+     *
+     * @return traceparent
+     */
+    @Override
+    public String toString() {
+        return String.format("%02x-%s-%s-%02x", version, traceId, spanId, traceFlags);
+    }
+
+    /**
+     * Helper method to create a random hexadecimal string of n bytes.
+     *
+     * @return n byte hexadecimal string
+     */
+    @VisibleForTesting
+    static String randomHex(int n) {
+        byte[] bytes = new byte[n];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Helper method to check if a given string of n bytes is hexadecimal
+     *
+     * @return boolean
+     */
+    private static boolean isHex(String s, int n) {
+        if (s == null || s.length() == 0) {
+            return false;
+        }
+        if (s.length() != n) {
+            return false;
+        }
+        for (int i = 0; i < n; i++) {
+            char c = s.charAt(i);
+            if ('0' <= c && c <= '9') {
+                continue;
+            }
+            if ('a' <= c && c <= 'f') {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * converts traceparent from String to Traceparent object
+     *
+     * @return Traceparent
+     */
+    public static Traceparent fromString(String s) {
+        if (s == null || s.length() == 0) {
+            return null;
+        }
+        String[] arr = s.split("-");
+        if (arr.length != 4) {
+            return null;
+        }
+        if (!isHex(arr[0], 2)) {
+            return null;
+        }
+        if (!isHex(arr[3], 2)) {
+            return null;
+        }
+
+        return new Traceparent(
+            (Character.digit(arr[0].charAt(0), 16) << 4) + Character.digit(arr[0].charAt(1), 16),
+            arr[1],
+            arr[2],
+            (Character.digit(arr[3].charAt(0), 16) << 4) + Character.digit(arr[3].charAt(1), 16));
+    }
+
+}

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
@@ -24,7 +24,7 @@ public class Tracestate {
      */
     public Tracestate(String value) {
         if (value == null || value.length() == 0) {
-            throw new IllegalArgumentException("invalid spanId");
+            throw new IllegalArgumentException("Tracestate cannot be null");
         }
         reserved = value;
     }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
@@ -7,7 +7,7 @@ import org.apache.http.annotation.Experimental;
  *
  * @author Reiley Yang
  * @author Dhaval Doshi
- * @link https://github.com/w3c/trace-context/blob/master/trace_context/HTTP_HEADER_FORMAT.md
+ * @see <a href = "https://github.com/w3c/trace-context/blob/master/trace_context/HTTP_HEADER_FORMAT.md">Trace Context</a>
  *
  * Implementations can add vendor specific details here.
  */

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
@@ -1,0 +1,46 @@
+package com.microsoft.applicationinsights.web.internal.correlation.tracecontext;
+
+import org.apache.http.annotation.Experimental;
+
+/**
+ * Class that represents Tracestate header based on
+ *
+ * @author Reiley Yang
+ * @author Dhaval Doshi
+ * @link https://github.com/w3c/trace-context/blob/master/trace_context/HTTP_HEADER_FORMAT.md
+ *
+ * Implementations can add vendor specific details here.
+ */
+@Experimental
+public class Tracestate {
+
+    /**
+     * Field to capture tracestate header
+     */
+    public final String reserved;
+
+    /**
+     * Ctor that creates tracestate object from given value
+     */
+    public Tracestate(String value) {
+        if (value == null || value.length() == 0) {
+            throw new IllegalArgumentException("invalid spanId");
+        }
+        reserved = value;
+    }
+
+    @Override
+    public String toString() {
+        return reserved;
+    }
+
+    /**
+     * Converts Tracestate header to Object representation
+     *
+     * @return Tracestate
+     */
+    public static Tracestate fromString(String s) {
+        return new Tracestate(s);
+    }
+
+}

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
@@ -268,14 +268,14 @@ public class WebRequestTrackingTelemetryModuleTests {
         RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
         // spanIds are different
-        Assert.assertNotEquals(tp.getTraceId(), requestTelemetry.getId());
+        Assert.assertNotEquals(tp.getTraceId(), formatedID(requestTelemetry.getId()));
         // traceIds are same
-        Assert.assertTrue(requestTelemetry.getId().startsWith(tp.getTraceId()));
+        Assert.assertTrue(requestTelemetry.getId().startsWith(formatedID(tp.getTraceId())));
 
         //validate operation context ID's
         OperationContext operation = requestTelemetry.getContext().getOperation();
-        Assert.assertEquals(tp.getTraceId(), operation.getId());
-        Assert.assertEquals(tp.getTraceId() + "-" + tp.getSpanId(), operation.getParentId());
+        Assert.assertEquals(formatedID(tp.getTraceId()), operation.getId());
+        Assert.assertEquals(formatedID(tp.getTraceId() + "." + tp.getSpanId()), operation.getParentId());
 
         //run onEnd
         defaultModule.onEndRequest(request, null);
@@ -284,6 +284,10 @@ public class WebRequestTrackingTelemetryModuleTests {
         Assert.assertNotNull(requestTelemetry.getSource());
         Assert.assertEquals(TraceContextCorrelationTests.getRequestSourceValue("id1"), requestTelemetry.getSource());
 
+    }
+
+    private String formatedID(String id) {
+        return "|" + id + ".";
     }
 
     @Test
@@ -364,7 +368,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
 
         //validate manually tracked telemetry is a child of the request telemetry
-        Assert.assertEquals(tp.getTraceId(), exceptionTelemetry.getContext().getOperation().getId());
+        Assert.assertEquals(formatedID(tp.getTraceId()), exceptionTelemetry.getContext().getOperation().getId());
         Assert.assertEquals(requestTelemetry.getId(), exceptionTelemetry.getContext().getOperation().getParentId());
 
         Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
@@ -435,7 +435,7 @@ public class WebRequestTrackingTelemetryModuleTests {
     }
 
     @Test
-    public void testTracestateIsNotSetWhenAppIdResolutionIsPending() {
+    public void testTracestateIsPassedAsItIsWhenAppIdResolutionIsPending() {
         //turn on W3C
         defaultModule.isW3CEnabled = true;
 
@@ -460,11 +460,13 @@ public class WebRequestTrackingTelemetryModuleTests {
         //run
         defaultModule.onBeginRequest(request, response);
 
-        Assert.assertNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertEquals(TraceContextCorrelationTests.getTracestateHeaderValue("id1"),
+            ThreadContext.getRequestTelemetryContext().getTracestate().toString());
     }
 
     @Test
-    public void testTracestateIsNotSetWhenAppIdResolutionIsFailed() {
+    public void testTracestateIsPassedAsIsWhenAppIdResolutionIsFailed() {
         //turn on W3C
         defaultModule.isW3CEnabled = true;
 
@@ -489,7 +491,9 @@ public class WebRequestTrackingTelemetryModuleTests {
         //run
         defaultModule.onBeginRequest(request, response);
 
-        Assert.assertNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertEquals(TraceContextCorrelationTests.getTracestateHeaderValue("id1"),
+            ThreadContext.getRequestTelemetryContext().getTracestate().toString());
     }
 
     @Test

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
@@ -268,7 +268,8 @@ public class WebRequestTrackingTelemetryModuleTests {
         RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
         // spanIds are different
-        Assert.assertNotEquals(tp.getTraceId(), formatedID(requestTelemetry.getId()));
+        String[] id = requestTelemetry.getId().split("[.]");
+        Assert.assertNotEquals(tp.getSpanId(), id[1]);
         // traceIds are same
         Assert.assertTrue(requestTelemetry.getId().startsWith(formatedID(tp.getTraceId())));
 

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
@@ -274,7 +274,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //validate operation context ID's
         OperationContext operation = requestTelemetry.getContext().getOperation();
-        Assert.assertEquals(formatedID(tp.getTraceId()), operation.getId());
+        Assert.assertEquals(tp.getTraceId(), operation.getId());
         Assert.assertEquals(formatedID(tp.getTraceId() + "." + tp.getSpanId()), operation.getParentId());
 
         //run onEnd
@@ -368,7 +368,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
 
         //validate manually tracked telemetry is a child of the request telemetry
-        Assert.assertEquals(formatedID(tp.getTraceId()), exceptionTelemetry.getContext().getOperation().getId());
+        Assert.assertEquals(tp.getTraceId(), exceptionTelemetry.getContext().getOperation().getId());
         Assert.assertEquals(requestTelemetry.getId(), exceptionTelemetry.getContext().getOperation().getParentId());
 
         Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
@@ -116,7 +116,7 @@ public class TraceContextCorrelationTests {
 
         TraceContextCorrelation.resolveRequestSource(request, requestTelemetry, "ikey1");
 
-        Assert.assertEquals("id1", requestTelemetry.getSource());
+        Assert.assertEquals("cid-v1:id1", requestTelemetry.getSource());
 
     }
 

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
@@ -45,12 +45,12 @@ public class TraceContextCorrelationTests {
         //validate we have generated proper ID's
         Assert.assertNotNull(requestTelemetry.getId());
 
-        Assert.assertTrue(requestTelemetry.getId().startsWith(t.getTraceId()));
+        Assert.assertTrue(requestTelemetry.getId().startsWith(formatedID(t.getTraceId())));
 
         //validate operation context ID's
         OperationContext operation = requestTelemetry.getContext().getOperation();
-        Assert.assertEquals(t.getTraceId(), operation.getId());
-        Assert.assertEquals(t.getTraceId() + "-" + t.getSpanId(), operation.getParentId());
+        Assert.assertEquals(formatedID(t.getTraceId()), operation.getId());
+        Assert.assertEquals(formatedID(t.getTraceId() + "." + t.getSpanId()), operation.getParentId());
     }
 
     @Test
@@ -73,7 +73,7 @@ public class TraceContextCorrelationTests {
         Assert.assertNotNull(requestTelemetry.getId());
 
         // First trace will have it's own spanId also.
-        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()+"-"));
+        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()));
         Assert.assertNull(operation.getParentId());
     }
 
@@ -98,7 +98,7 @@ public class TraceContextCorrelationTests {
 
         Assert.assertNotNull(requestTelemetry.getId());
         // First trace will have it's own spanId also.
-        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()+"-"));
+        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()));
         Assert.assertNull(operation.getParentId());
     }
 
@@ -248,4 +248,9 @@ public class TraceContextCorrelationTests {
 
         return String.format("cid-v1:%s", appId);
     }
+
+    private String formatedID(String id) {
+        return "|" + id + ".";
+    }
+
 }

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
@@ -32,7 +32,7 @@ public class TraceContextCorrelationTests {
         //setup
         Map<String, String> headers = new HashMap<>();
         Traceparent t = new Traceparent();
-        headers.put(TraceContextCorrelation.CORRELATION_HEADER_NAME, t.toString());
+        headers.put(TraceContextCorrelation.TRACEPARENT_HEADER_NAME, t.toString());
 
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
         HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
@@ -82,7 +82,7 @@ public class TraceContextCorrelationTests {
 
         //setup - empty RequestId
         Map<String, String> headers = new HashMap<>();
-        headers.put(TraceContextCorrelation.CORRELATION_HEADER_NAME, "");
+        headers.put(TraceContextCorrelation.TRACEPARENT_HEADER_NAME, "");
 
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
         HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
@@ -1,0 +1,104 @@
+package com.microsoft.applicationinsights.web.internal.correlation;
+
+import com.microsoft.applicationinsights.extensibility.context.OperationContext;
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
+import com.microsoft.applicationinsights.web.internal.correlation.mocks.MockProfileFetcher;
+import com.microsoft.applicationinsights.web.internal.correlation.tracecontext.Traceparent;
+import com.microsoft.applicationinsights.web.utils.ServletUtils;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TraceContextCorrelationTests {
+
+    private static MockProfileFetcher mockProfileFetcher;
+
+    @Before
+    public void testInitialize() {
+
+        // initialize mock profile fetcher (for resolving ikeys to appIds)
+        mockProfileFetcher = new MockProfileFetcher();
+        InstrumentationKeyResolver.INSTANCE.setProfileFetcher(mockProfileFetcher);
+        InstrumentationKeyResolver.INSTANCE.clearCache();
+    }
+
+    @Test
+    public void testCorrelationIdsAreResolved() {
+
+        //setup
+        Map<String, String> headers = new HashMap<>();
+        Traceparent t = new Traceparent();
+        headers.put(TraceContextCorrelation.CORRELATION_HEADER_NAME, t.toString());
+
+        HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
+        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+
+        RequestTelemetry requestTelemetry = new RequestTelemetry();
+
+        //run
+        TraceContextCorrelation.resolveCorrelation(request, response, requestTelemetry);
+
+        //validate we have generated proper ID's
+        Assert.assertNotNull(requestTelemetry.getId());
+
+        Assert.assertTrue(requestTelemetry.getId().startsWith(t.getTraceId()));
+
+        //validate operation context ID's
+        OperationContext operation = requestTelemetry.getContext().getOperation();
+        Assert.assertEquals(t.getTraceId(), operation.getId());
+        Assert.assertEquals(t.getTraceId() + "-" + t.getSpanId(), operation.getParentId());
+    }
+
+    @Test
+    public void testCorrelationIdsAreResolvedIfNoTraceIdHeader() {
+
+        //setup - no headers
+        Map<String, String> headers = new HashMap<>();
+        HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
+        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+
+        RequestTelemetry requestTelemetry = new RequestTelemetry();
+
+        //run
+        TraceContextCorrelation.resolveCorrelation(request, response, requestTelemetry);
+
+        //validate operation context ID's - there is no parent, so parentId should be null, traceId
+        // is newly generated and request.Id is based on new traceId-spanId
+        OperationContext operation = requestTelemetry.getContext().getOperation();
+
+        Assert.assertNotNull(requestTelemetry.getId());
+
+        // First trace will have it's own spanId also.
+        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()+"-"));
+        Assert.assertNull(operation.getParentId());
+    }
+
+    @Test
+    public void testCorrelationIdsAreResolvedIfRequestIdEmpty() {
+
+        //setup - empty RequestId
+        Map<String, String> headers = new HashMap<>();
+        headers.put(TraceContextCorrelation.CORRELATION_HEADER_NAME, "");
+
+        HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
+        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+
+        RequestTelemetry requestTelemetry = new RequestTelemetry();
+
+        //run
+        TraceContextCorrelation.resolveCorrelation(request, response, requestTelemetry);
+
+        //validate operation context ID's - there is no parent, so parentId should be null, traceId
+        // is newly generated and request.Id is based on new traceId-spanId
+        OperationContext operation = requestTelemetry.getContext().getOperation();
+
+        Assert.assertNotNull(requestTelemetry.getId());
+        // First trace will have it's own spanId also.
+        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()+"-"));
+        Assert.assertNull(operation.getParentId());
+    }
+}

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationTests.java
@@ -49,7 +49,7 @@ public class TraceContextCorrelationTests {
 
         //validate operation context ID's
         OperationContext operation = requestTelemetry.getContext().getOperation();
-        Assert.assertEquals(formatedID(t.getTraceId()), operation.getId());
+        Assert.assertEquals(t.getTraceId(), operation.getId());
         Assert.assertEquals(formatedID(t.getTraceId() + "." + t.getSpanId()), operation.getParentId());
     }
 
@@ -73,7 +73,7 @@ public class TraceContextCorrelationTests {
         Assert.assertNotNull(requestTelemetry.getId());
 
         // First trace will have it's own spanId also.
-        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()));
+        Assert.assertTrue(requestTelemetry.getId().startsWith(formatedID(operation.getId())));
         Assert.assertNull(operation.getParentId());
     }
 
@@ -98,7 +98,7 @@ public class TraceContextCorrelationTests {
 
         Assert.assertNotNull(requestTelemetry.getId());
         // First trace will have it's own spanId also.
-        Assert.assertTrue(requestTelemetry.getId().startsWith(operation.getId()));
+        Assert.assertTrue(requestTelemetry.getId().startsWith("|" + operation.getId()));
         Assert.assertNull(operation.getParentId());
     }
 

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/TraceparentTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/TraceparentTests.java
@@ -1,0 +1,116 @@
+package com.microsoft.applicationinsights.web.internal.correlation.tracecontext;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TraceparentTests {
+
+    @Test
+    public void canCreateValidTraceParentWithDefaultConstructor() {
+        Traceparent traceparent = new Traceparent();
+        Assert.assertNotNull(traceparent.traceId);
+        Assert.assertNotNull(traceparent.spanId);
+        Assert.assertEquals(0, traceparent.version);
+        Assert.assertNotNull(traceparent.traceFlags);
+    }
+
+    @Test
+    public void testTraceParentUniqueness() {
+        Traceparent t1 = new Traceparent();
+        Traceparent t2 = new Traceparent();
+        Assert.assertNotEquals(t1.traceId, t2.traceId);
+        Assert.assertNotEquals(t1.spanId, t2.spanId);
+
+        // version is always 0
+        Assert.assertEquals(t1.version, t2.version);
+
+        // flags are currently 0, may change in future
+        Assert.assertEquals(t1.traceFlags, t2.traceFlags);
+
+    }
+
+    @Test
+    public void canCreateTraceParentWithProvidedValues() {
+        String traceId = Traceparent.randomHex(16);
+        String spanId = Traceparent.randomHex(8);
+        Traceparent t1 = new Traceparent(0, traceId, spanId, 0);
+        Assert.assertEquals(traceId, t1.traceId);
+        Assert.assertEquals(spanId, t1.spanId);
+        Assert.assertEquals(0, t1.version);
+        Assert.assertEquals(0, t1.traceFlags);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenCreatingTraceParentWithIllegalTraceId() {
+        String invalidTraceId = Traceparent.randomHex(32);
+        String spanId = Traceparent.randomHex(8);
+        Traceparent t1 = new Traceparent(0, invalidTraceId, spanId, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenCreatingTraceParentWithIllegalSpanId() {
+        String traceId = Traceparent.randomHex(16);
+        String invalidSpanId = Traceparent.randomHex(16);
+        Traceparent t1 = new Traceparent(0, traceId, invalidSpanId, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenVersionNumberIsOutOfRange() {
+        String traceId = Traceparent.randomHex(16);
+        String spanId = Traceparent.randomHex(8);
+        Traceparent t1 = new Traceparent(256, traceId, spanId, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenVersionNumberIsOutOfLowerRange() {
+        String traceId = Traceparent.randomHex(16);
+        String spanId = Traceparent.randomHex(8);
+        Traceparent t1 = new Traceparent(-1, traceId, spanId, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenFlagIsOutOfLowerRange() {
+        String traceId = Traceparent.randomHex(16);
+        String spanId = Traceparent.randomHex(8);
+        Traceparent t1 = new Traceparent(0, traceId, spanId, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenFlagIsOutOfUpperRange() {
+        String traceId = Traceparent.randomHex(16);
+        String spanId = Traceparent.randomHex(8);
+        Traceparent t1 = new Traceparent(0, traceId, spanId, 256);
+    }
+
+    @Test
+    public void canCreateTraceParentFromString() {
+        String traceId = Traceparent.randomHex(16);
+        String spanId = Traceparent.randomHex(8);
+        Traceparent t1 = new Traceparent(0, traceId, spanId, 0);
+
+        Traceparent t2 = Traceparent.fromString(t1.toString());
+        Assert.assertEquals(t1.version, t2.version);
+        Assert.assertEquals(t1.traceId, t2.traceId);
+        Assert.assertEquals(t1.spanId, t2.spanId);
+        Assert.assertEquals(t1.traceFlags, t2.traceFlags);
+
+        // memory reference should be different
+        Assert.assertFalse(t1 == t2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenTryingToCreateWithMalformedTraceparentString() {
+        String invalidTraceId = Traceparent.randomHex(32);
+        String invalidSpanId = Traceparent.randomHex(16);
+        String invalidTraceparent = String.format("%02x-%s-%s-%02x", 0, invalidTraceId,
+            invalidSpanId, 0);
+
+        Traceparent t1 = Traceparent.fromString(invalidTraceparent);
+    }
+
+    @Test
+    public void returnsNullTraceParentWhenTryingToCreateFromEmptyString() {
+        Traceparent t1 = Traceparent.fromString("");
+        Assert.assertNull(t1);
+    }
+}

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/TracestateTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/TracestateTests.java
@@ -1,0 +1,24 @@
+package com.microsoft.applicationinsights.web.internal.correlation.tracecontext;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TracestateTests {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenTracestateIsNull() {
+        new Tracestate(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenTracestateIsEmpty() {
+        new Tracestate("");
+    }
+
+    @Test
+    public void canCreateTraceStateWithString() {
+        String tracestate = "az=cid-v1:120";
+        Tracestate t1 = new Tracestate(tracestate);
+        Assert.assertEquals(tracestate, t1.reserved);
+    }
+}


### PR DESCRIPTION
Fix #716 

This PR is super set of all previous PRs which completes the integration of W3C for both incoming and outbound calls.

Non Goals of this PR: Backward Compatibility with AI proprietary correlation protocol. 

Related #776 #775 


Enable W3C:

Incoming Side - 

J2EE Apps add the following to the `<TelemetryModules>` tag inside ApplicationInsights.xml

```<Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule"  W3CEnabled ="true"/>```

Springboot apps add the following property:
`azure.application-insights.web.w3c=true`

Outgoing Side - 

Add the following to AI-Agent.xml

```
<Instrumentation>
        <BuiltIn enabled="true">
            <HTTP enabled="true" W3C="true"/>
        </BuiltIn>
    </Instrumentation>
```

Remember : you need both inbound and outbound settings to be the same for correlation to work properly. 