### PR TITLE
simplified MapUtil.copy

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -23,6 +23,7 @@ package com.microsoft.applicationinsights;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.microsoft.applicationinsights.common.CommonUtils;
@@ -138,13 +139,8 @@ public class TelemetryClient {
 
         EventTelemetry et = new EventTelemetry(name);
 
-        if (properties != null && properties.size() > 0) {
-            MapUtil.copy(properties, et.getContext().getProperties());
-        }
-
-        if (metrics != null && metrics.size() > 0) {
-            MapUtil.copy(metrics, et.getMetrics());
-        }
+        MapUtil.copy(properties, et.getContext().getProperties());
+        MapUtil.copy(metrics, et.getMetrics());
 
         this.track(et);
     }
@@ -182,9 +178,7 @@ public class TelemetryClient {
 
         TraceTelemetry et = new TraceTelemetry(message, severityLevel);
 
-        if (properties != null && properties.size() > 0) {
-            MapUtil.copy(properties, et.getContext().getProperties());
-        }
+        MapUtil.copy(properties, et.getContext().getProperties());
 
         this.track(et);
     }
@@ -252,9 +246,7 @@ public class TelemetryClient {
         mt.setMin(min);
         mt.setMax(max);
         mt.setStandardDeviation(stdDev);
-        if (properties != null && properties.size() > 0) {
-            MapUtil.copy(properties, mt.getProperties());
-        }
+        MapUtil.copy(properties, mt.getProperties());
         this.track(mt);
     }
 
@@ -289,13 +281,8 @@ public class TelemetryClient {
 
         ExceptionTelemetry et = new ExceptionTelemetry(exception);
 
-        if (properties != null && properties.size() > 0) {
-            MapUtil.copy(properties, et.getContext().getProperties());
-        }
-
-        if (metrics != null && metrics.size() > 0) {
-            MapUtil.copy(metrics, et.getMetrics());
-        }
+        MapUtil.copy(properties, et.getContext().getProperties());
+        MapUtil.copy(metrics, et.getMetrics());
 
         this.track(et);
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -23,7 +23,6 @@ package com.microsoft.applicationinsights;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.microsoft.applicationinsights.common.CommonUtils;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/MapUtil.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/MapUtil.java
@@ -38,18 +38,20 @@ public class MapUtil
     /**
      * Copies entries from the source map to the target map, overwrites any values in target.
      * Filters out null values if target is a {@link ConcurrentHashMap}.
-     * @param source the source map. Cannot be null.
+     * @param source the source map. If null or empty, this is a nop.
      * @param target the target map. Cannot be null.
      * @param <Value> The type of the values in both maps
      * @throws IllegalArgumentException if either {@code source} or {@code target} are null.
      */
     public static <Value> void copy(Map<String, Value> source, Map<String, Value> target) {
-        if (source == null) {
-            throw new IllegalArgumentException("source must not be null");
-        }
         if (target == null) {
             throw new IllegalArgumentException("target must not be null");
         }
+
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+
         for (Map.Entry<String,Value> entry : source.entrySet()) {
             String key = entry.getKey();
             if (Strings.isNullOrEmpty(key)) {

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/TelemetryContext.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/TelemetryContext.java
@@ -200,12 +200,8 @@ public final class TelemetryContext {
         if (Strings.isNullOrEmpty(this.instrumentationKey) && !Strings.isNullOrEmpty(source.getInstrumentationKey()))
             setInstrumentationKey(source.getInstrumentationKey());
 
-        if (source.tags != null && source.tags.size() > 0) {
-            MapUtil.copy(source.tags, this.tags);
-        }
-        if (source.properties != null && source.properties.size() > 0) {
-            MapUtil.copy(source.properties, this.properties);
-        }
+        MapUtil.copy(source.tags, this.tags);
+        MapUtil.copy(source.properties, this.properties);
     }
 
     public InternalContext getInternal() {

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/util/MapUtilTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/util/MapUtilTest.java
@@ -1,13 +1,42 @@
 package com.microsoft.applicationinsights.internal.util;
 
-import org.junit.Assert;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class MapUtilTest {
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @Test
+    public void targetCannotBeNullInCopy() {
+        expected.expect(IllegalArgumentException.class);
+        MapUtil.copy(new HashMap<String, String>(), null);
+    }
+
+    @Test
+    public void copyIsNoOpIfSourceIsNullOrEmpty() {
+        Map<String, String> source = mock(Map.class);
+        Map<String, String> target = mock(Map.class);
+        when(source.size()).thenReturn(0);
+
+        MapUtil.copy(source, target);
+        // nothing should be put into target
+        verify(target, never()).put(anyString(), anyString());
+        verify(source, never()).get(any());
+
+        reset(target);
+
+        MapUtil.copy(null, target);
+        verify(target, never()).put(anyString(), anyString());
+    }
 
     @Test
     public void testCopyIntoHashMap() {
@@ -18,7 +47,7 @@ public class MapUtilTest {
         source.put("key2", null);
 
         MapUtil.copy(source, target);
-        Assert.assertEquals(2, target.size());
+        assertEquals(2, target.size());
     }
 
     @Test
@@ -30,6 +59,6 @@ public class MapUtilTest {
         source.put("key2", null);
 
         MapUtil.copy(source, target);
-        Assert.assertEquals(1, target.size());
+        assertEquals(1, target.size());
     }
 }


### PR DESCRIPTION
Mostly simplifying the caller side since each caller checked for null/empty. Plus, copy from source to target is a nop if it's null or empty, so why not just check for that in the method.
