### PR TITLE
Add Async Listener Implementation

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
@@ -13,10 +13,20 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.annotation.Experimental;
 
+/**
+ * This class implements {@link AsyncListener} to handle span completion for async request handling.
+ */
 @Experimental
 public final class AIHttpServletListener implements Closeable, AsyncListener {
 
+    /**
+     * Instance of {@link RequestTelemetryContext}
+     */
     private final RequestTelemetryContext context;
+
+    /**
+     * Instance of {@link HttpServerHandler}
+     */
     private final HttpServerHandler<HttpServletRequest, HttpServletResponse> handler;
 
     public AIHttpServletListener(HttpServerHandler<HttpServletRequest, HttpServletResponse> handler,
@@ -58,7 +68,7 @@ public final class AIHttpServletListener implements Closeable, AsyncListener {
             try {
                 Throwable throwable = event.getThrowable();
                 if (throwable instanceof Exception) {
-                    // AI SDK can only track Exceptions.
+                    // AI SDK can only track Exceptions. It doesn't support tracking Throwable
                     handler.handleException((Exception) throwable);
                 }
             } finally{

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
@@ -30,7 +30,7 @@ public final class AIHttpServletListener implements Closeable, AsyncListener {
     private final HttpServerHandler<HttpServletRequest, HttpServletResponse> handler;
 
     public AIHttpServletListener(HttpServerHandler<HttpServletRequest, HttpServletResponse> handler,
-                                    RequestTelemetryContext context) {
+                                 RequestTelemetryContext context) {
         Validate.notNull(handler, "HttpServerHandler");
         Validate.notNull(context, "RequestTelemetryContext");
         this.handler = handler;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
@@ -30,7 +30,7 @@ public final class AIHttpServletListener implements Closeable, AsyncListener {
     private final HttpServerHandler<HttpServletRequest, HttpServletResponse> handler;
 
     public AIHttpServletListener(HttpServerHandler<HttpServletRequest, HttpServletResponse> handler,
-        RequestTelemetryContext context) {
+                                    RequestTelemetryContext context) {
         Validate.notNull(handler, "HttpServerHandler");
         Validate.notNull(context, "RequestTelemetryContext");
         this.handler = handler;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
@@ -3,19 +3,20 @@ package com.microsoft.applicationinsights.web.internal.httputils;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.common.CommonUtils;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import com.microsoft.applicationinsights.internal.util.ThreadLocalCleaner;
 import com.microsoft.applicationinsights.telemetry.Duration;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
 import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.WebModulesContainer;
+import java.net.MalformedURLException;
+import java.util.Date;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.annotation.Experimental;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.net.MalformedURLException;
-import java.util.Date;
 
 /**
  * This Helper Handler class provides the required methods to instrument requests.
@@ -42,6 +43,11 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
     private final TelemetryClient telemetryClient;
 
     /**
+     * ThreadLocal Cleaners for Agent connector
+     */
+    private final List<ThreadLocalCleaner> cleaners;
+
+    /**
      * Creates a new instance of {@link HttpServerHandler}
      *
      * @param extractor The {@code HttpExtractor} used to extract information from request and repsonse
@@ -51,11 +57,14 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
      */
     public HttpServerHandler(HttpExtractor<P, Q> extractor,
         WebModulesContainer<P, Q> webModulesContainer,
+        List<ThreadLocalCleaner> cleaners,
         /* Nullable */ TelemetryClient telemetryClient) {
         Validate.notNull(extractor, "extractor");
         Validate.notNull(webModulesContainer, "WebModuleContainer");
+        Validate.notNull(cleaners, "ThreadLocalCleaners");
         this.extractor = extractor;
         this.webModulesContainer = webModulesContainer;
+        this.cleaners = cleaners;
         this.telemetryClient = telemetryClient;
     }
 
@@ -69,6 +78,8 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
      */
     public RequestTelemetryContext handleStart(P request, Q response) throws MalformedURLException {
         RequestTelemetryContext context = new RequestTelemetryContext(new Date().getTime(),null);
+        // TODO: uncomment this line in final integration
+        //webModulesContainer.setRequestTelemetryContext(context);
         RequestTelemetry requestTelemetry = context.getHttpRequestTelemetry();
         ThreadContext.setRequestTelemetryContext(context);
         String method = extractor.getMethod(request);
@@ -94,9 +105,10 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
      * This method is used to indicate request end instrumentation, complete correlation and record timing, response
      * @param request HttpRequest object
      * @param response HttpResponse object
+     * @param context RequestTelemetryContext object
      */
-    public void handleEnd(P request, Q response) {
-        RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
+    public void handleEnd(P request, Q response,
+        RequestTelemetryContext context) {
         RequestTelemetry requestTelemetry = context.getHttpRequestTelemetry();
         long endTime = new Date().getTime();
         requestTelemetry.setDuration(new Duration(endTime - context.getRequestStartTimeTicks()));
@@ -104,6 +116,7 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
         requestTelemetry.setSuccess(resultCode < 400);
         requestTelemetry.setResponseCode(Integer.toString(resultCode));
         webModulesContainer.invokeOnEndRequest(request, response);
+        cleanup();
     }
 
     /**
@@ -119,6 +132,21 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
             }
         } catch (Exception ex) {
             // swallow AI Exception
+        }
+    }
+
+    /**
+     * Remove data from Threadlocal and ThreadLocalCleaners
+     */
+    private void cleanup() {
+        try {
+            ThreadContext.remove();
+            for (ThreadLocalCleaner cleaner : cleaners) {
+                cleaner.clean();
+            }
+        } catch (Exception t) {
+            InternalLogger.INSTANCE.warn(String.format("unable to perform TLS Cleaning: %s",
+                ExceptionUtils.getStackTrace(t)));
         }
     }
 }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
@@ -140,10 +140,11 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
      */
     private void cleanup() {
         try {
-            ThreadContext.remove();
             for (ThreadLocalCleaner cleaner : cleaners) {
                 cleaner.clean();
             }
+            // clean context after cleaners are run, in-case cleaners need the context object
+            ThreadContext.remove();
         } catch (Exception t) {
             InternalLogger.INSTANCE.warn(String.format("unable to perform TLS Cleaning: %s",
                 ExceptionUtils.getStackTrace(t)));

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
@@ -108,7 +108,7 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
      * @param context RequestTelemetryContext object
      */
     public void handleEnd(P request, Q response,
-        RequestTelemetryContext context) {
+                          RequestTelemetryContext context) {
         RequestTelemetry requestTelemetry = context.getHttpRequestTelemetry();
         long endTime = new Date().getTime();
         requestTelemetry.setDuration(new Duration(endTime - context.getRequestStartTimeTicks()));

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListenerTest.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListenerTest.java
@@ -1,0 +1,147 @@
+package com.microsoft.applicationinsights.web.internal.httputils;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.internal.util.ThreadLocalCleaner;
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.WebModulesContainer;
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncEvent;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+/**
+ * Tests for {@link AIHttpServletListener}
+ */
+@RunWith(JUnit4.class)
+public class AIHttpServletListenerTest {
+
+    @Rule public final ExpectedException thrown = ExpectedException.none();
+    @Mock public RequestTelemetryContext requestTelemetryContext;
+    @Mock public HttpExtractor<HttpServletRequest, HttpServletResponse> extractor;
+    private TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.getActive();
+    @Spy public WebModulesContainer<HttpServletRequest,HttpServletResponse> webModulesContainer =
+            new WebModulesContainer<>(telemetryConfiguration);
+    @Spy public TelemetryClient telemetryClient;
+    @Mock public List<ThreadLocalCleaner> threadLocalCleanerList;
+    @InjectMocks HttpServerHandler<HttpServletRequest, HttpServletResponse> httpServerHandler;
+    private AIHttpServletListener listener;
+    @Mock HttpServletRequest request;
+    @Mock HttpServletResponse response;
+    @Mock AsyncEvent asyncEvent;
+    @Mock AsyncContext asyncContext;
+    @Mock Exception exception;
+    private String url = "http://www.abc.com/xyz/opq";
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(extractor.getUrl(request)).thenReturn(url);
+        when(extractor.getUri(request)).thenReturn("/xyz/opq");
+        when(extractor.getScheme(request)).thenReturn("http");
+        when(extractor.getHost(request)).thenReturn("www.abc.com");
+        when(extractor.getQuery(request)).thenReturn("");
+        when(extractor.getMethod(request)).thenReturn("GET");
+        when(extractor.getUserAgent(request)).thenReturn("User-Agent");
+        when(extractor.getStatusCode(response)).thenReturn(500);
+        when(asyncEvent.getSuppliedResponse()).thenReturn(response);
+        when(asyncEvent.getSuppliedRequest()).thenReturn(request);
+        when(asyncEvent.getAsyncContext()).thenReturn(asyncContext);
+        when(asyncEvent.getThrowable()).thenReturn(exception);
+    }
+
+    @Test
+    public void cannotCreateListenerWithNullHttpServerHandler() {
+        thrown.expect(NullPointerException.class);
+        new AIHttpServletListener(null, requestTelemetryContext);
+    }
+
+    @Test
+    public void cannotCreateListenerWithNullRequestTelemetryContext() {
+        thrown.expect(NullPointerException.class);
+        new AIHttpServletListener(httpServerHandler, null);
+    }
+
+    @Test
+    public void listenerIsCreatedWhenCorrectArgsArePassed() {
+        new AIHttpServletListener(httpServerHandler, requestTelemetryContext);
+    }
+
+    @Test
+    public void testOnComplete() throws IOException {
+        requestTelemetryContext = httpServerHandler.handleStart(request, response);
+        listener = new AIHttpServletListener(httpServerHandler, requestTelemetryContext);
+        listener.onComplete(asyncEvent);
+        // since HttpServerHandler is a final class cannot call verify on httpServerHandler.handleEnd()
+        // Hence verifying invocation on webModuleContainers.invokeOnEndRequest() which is the last instruction
+        // in handleEnd() method.
+        verify(webModulesContainer, times(1)).invokeOnEndRequest(request, response);
+    }
+
+    @Test
+    public void testOnException() throws IOException {
+        requestTelemetryContext = httpServerHandler.handleStart(request, response);
+        listener = new AIHttpServletListener(httpServerHandler, requestTelemetryContext);
+        listener.onError(asyncEvent);
+        // since HttpServerHandler is a final class cannot call verify on httpServerHandler.handleException()
+        // Hence verifying invocation on telemetryClient.trackException() which is the last instruction
+        // in handleException() method.
+        verify(telemetryClient, times(1)).trackException(exception);
+        verify(webModulesContainer, times(1)).invokeOnEndRequest(request, response);
+    }
+
+    @Test
+    public void throwableAreNotTracked() throws IOException {
+        when(asyncEvent.getThrowable()).thenReturn(mock(Throwable.class));
+        requestTelemetryContext = httpServerHandler.handleStart(request, response);
+        listener = new AIHttpServletListener(httpServerHandler, requestTelemetryContext);
+        listener.onError(asyncEvent);
+        verify(telemetryClient, never()).trackException(exception);
+        verify(webModulesContainer, times(1)).invokeOnEndRequest(request, response);
+    }
+
+    @Test
+    public void testOnTimeout() throws IOException {
+        requestTelemetryContext = httpServerHandler.handleStart(request, response);
+        listener = new AIHttpServletListener(httpServerHandler, requestTelemetryContext);
+        listener.onComplete(asyncEvent);
+        // since HttpServerHandler is a final class cannot call verify on httpServerHandler.handleEnd()
+        // Hence verifying invocation on webModuleContainers.invokeOnEndRequest() which is the last instruction
+        // in handleEnd() method.
+        verify(webModulesContainer, times(1)).invokeOnEndRequest(request, response);
+    }
+
+    @Test
+    public void testOnAsyncStart() throws IOException {
+        requestTelemetryContext = httpServerHandler.handleStart(request, response);
+        listener = new AIHttpServletListener(httpServerHandler, requestTelemetryContext);
+        listener.onStartAsync(asyncEvent);
+        verify(webModulesContainer, never()).invokeOnEndRequest(request, response);
+        verify(asyncContext)
+                .addListener(
+                any(AIHttpServletListener.class),
+                any(ServletRequest.class),
+                any(ServletResponse.class));
+    }
+}
+


### PR DESCRIPTION
Related #816, #817, #818

Add Async Listener Implementation and tests.  Async Lister is used to complete the spans for Async Servlet Requests.

Note: There was a need to modify `handleEnd()` method's signature, as this method can be called in a different thread than that of `handleStart()`. Also it's not feasible to store the instance of `RequestTelemetryContext` as a final member variable of `HttpServerHandler` class, as it is created when `handleStart()` is invoked.

PS: The CI will fail as the integration with rest of the code is not part of this PR. I will push it as part of another PR.
