### PR TITLE
Add dependency-check tool to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,16 @@
 
 // region Common configurations
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+        classpath 'org.owasp:dependency-check-gradle:4.0.2'
+    }
+}
+
 ext.buildScriptsDir = "$rootDir/gradle"
 
 apply from: "$buildScriptsDir/common.gradle"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,14 +18,6 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
-    }
-}
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.1'

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat;
 apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'checkstyle'
+apply plugin: 'org.owasp.dependencycheck'
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = 1.7

--- a/test/smoke/framework/utils/build.gradle
+++ b/test/smoke/framework/utils/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compile 'com.google.code.gson:gson:2.8.2'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
 	compile 'com.google.guava:guava:20.0'
+	compile 'org.apache.commons:commons-lang3:3.7'
 	compile aiCoreJar
 
 	testCompile 'junit:junit:4.12'

--- a/test/smoke/framework/utils/build.gradle
+++ b/test/smoke/framework/utils/build.gradle
@@ -6,7 +6,7 @@ repositories {
 
 dependencies {
 	compile 'com.google.code.gson:gson:2.8.2'
-    compile 'org.apache.httpcomponents:httpclient:4.5.3'
+	compile 'org.apache.httpcomponents:httpclient:4.5.3'
 	compile 'com.google.guava:guava:20.0'
 	compile 'org.apache.commons:commons-lang3:3.7'
 	compile aiCoreJar


### PR DESCRIPTION
For reference:
https://www.owasp.org/index.php/OWASP_Dependency_Check
https://github.com/jeremylong/dependency-check-gradle
https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/index.html

Adding dependency checker to build script. This scans our dependnecies for NVD CVEs: https://nvd.nist.gov/

Run it with
```
gradlew dependencyCheckAnalyze
```

I'll update the CI build to run this task and generate a report for periodic review.