### PR TITLE
Final Integration: Async Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+# Version 2.4.0
+- Introduced support for Manual Async and Explicit Multithreading correlation. 
+- Removed `InherritableThreadLocal` for storing context objects.
+- Introduced `setRequestTelemetryContext` API in `WebTelemetryModule` Interface.
+- Introduced experimental API's `AIHttpServletListner`, `HttpServerHandler`, `ApplicationInsightsServletExtractor`
+  and `HttpExtractor`.
+  
 # Version 2.3.1
 - Fixed [#799](https://github.com/Microsoft/ApplicationInsights-Java/issues/799) Removed dependency on Guava vulnerable to [CVE-2018-10237](https://nvd.nist.gov/vuln/detail/CVE-2018-10237).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Introduced `setRequestTelemetryContext` API in `WebTelemetryModule` Interface.
 - Introduced experimental API's `AIHttpServletListner`, `HttpServerHandler`, `ApplicationInsightsServletExtractor`
   and `HttpExtractor`.
+- Deprecated `ApplicationInsightsHttpResponseWrapper`
   
 # Version 2.3.1
 - Fixed [#799](https://github.com/Microsoft/ApplicationInsights-Java/issues/799) Removed dependency on Guava vulnerable to [CVE-2018-10237](https://nvd.nist.gov/vuln/detail/CVE-2018-10237).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 # Version 2.4.0
 - Introduced support for Manual Async and Explicit Multithreading correlation. 
-- Removed `InherritableThreadLocal` for storing context objects.
 - Introduced `setRequestTelemetryContext` API in `WebTelemetryModule` Interface.
 - Introduced experimental API's `AIHttpServletListner`, `HttpServerHandler`, `ApplicationInsightsServletExtractor`
   and `HttpExtractor`.

--- a/test/webapps/bookstore-spring/src/main/java/com/springapp/mvc/extensions/WebRequestRunIdTelemetryModule.java
+++ b/test/webapps/bookstore-spring/src/main/java/com/springapp/mvc/extensions/WebRequestRunIdTelemetryModule.java
@@ -27,7 +27,6 @@ import com.microsoft.applicationinsights.internal.util.LocalStringsUtils;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.web.extensibility.modules.WebTelemetryModule;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
-import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 

--- a/test/webapps/bookstore-spring/src/main/java/com/springapp/mvc/extensions/WebRequestRunIdTelemetryModule.java
+++ b/test/webapps/bookstore-spring/src/main/java/com/springapp/mvc/extensions/WebRequestRunIdTelemetryModule.java
@@ -26,6 +26,7 @@ import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.internal.util.LocalStringsUtils;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.web.extensibility.modules.WebTelemetryModule;
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
 import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,6 +42,22 @@ public class WebRequestRunIdTelemetryModule implements WebTelemetryModule<HttpSe
 
     protected static final String RUN_ID_QUERY_PARAM_NAME = "runid";
 
+    /**
+     * The {@link RequestTelemetryContext} instance propogated from
+     * {@link com.microsoft.applicationinsights.web.internal.httputils.HttpServerHandler}
+     */
+    private RequestTelemetryContext requestTelemetryContext;
+
+    public void setRequestTelemetryContext(
+        RequestTelemetryContext requestTelemetryContext) {
+        this.requestTelemetryContext = requestTelemetryContext;
+    }
+
+    /** Used for test */
+    RequestTelemetryContext getRequestTelemetryContext() {
+        return this.requestTelemetryContext;
+    }
+
     @Override
     public void initialize(TelemetryConfiguration telemetryConfiguration) {
     }
@@ -55,7 +72,7 @@ public class WebRequestRunIdTelemetryModule implements WebTelemetryModule<HttpSe
             return;
         }
 
-        RequestTelemetry httpRequestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry httpRequestTelemetry = this.requestTelemetryContext.getHttpRequestTelemetry();
         httpRequestTelemetry.getProperties().put(RUN_ID_QUERY_PARAM_NAME, runId);
     }
 

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -59,17 +59,31 @@ public class WebRequestTrackingTelemetryModule
      */
     private final String W3C_BACKCOMPAT_PARAMETER = "enableW3CBackCompat";
 
+    /**
+     * The {@link RequestTelemetryContext} instance propogated from
+     * {@link com.microsoft.applicationinsights.web.internal.httputils.HttpServerHandler}
+     */
+    private RequestTelemetryContext requestTelemetryContext;
+
+    public void setRequestTelemetryContext(
+        RequestTelemetryContext requestTelemetryContext) {
+        this.requestTelemetryContext = requestTelemetryContext;
+    }
+
+    /** Used for test */
+    RequestTelemetryContext getRequestTelemetryContext() {
+        return this.requestTelemetryContext;
+    }
+
     // endregion Members
 
     // region Public
 
-    public WebRequestTrackingTelemetryModule() {
-
-    }
+    public WebRequestTrackingTelemetryModule() {}
 
     /**
      * Ctor that parses incoming configuration.
-     * @param configurationData
+     * @param configurationData SDK config Object
      */
     public WebRequestTrackingTelemetryModule(Map<String, String> configurationData) {
         assert configurationData != null;
@@ -111,8 +125,8 @@ public class WebRequestTrackingTelemetryModule
         }
 
         try {
-            RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
-            RequestTelemetry telemetry = context.getHttpRequestTelemetry();
+            //RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
+            RequestTelemetry telemetry = this.requestTelemetryContext.getHttpRequestTelemetry();
 
             // Look for cross-component correlation headers and resolve correlation ID's
             if (isW3CEnabled) {
@@ -142,8 +156,8 @@ public class WebRequestTrackingTelemetryModule
         }
 
         try {
-            RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
-            RequestTelemetry telemetry = context.getHttpRequestTelemetry();
+            //RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
+            RequestTelemetry telemetry = this.requestTelemetryContext.getHttpRequestTelemetry();
 
             String instrumentationKey = this.telemetryClient.getContext().getInstrumentationKey();
             if (isW3CEnabled) {

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModule.java
@@ -27,13 +27,11 @@ import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
-import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils;
 import com.microsoft.applicationinsights.web.internal.correlation.TraceContextCorrelation;
-
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Map;
 
 /**
  * Created by yonisha on 2/2/2015.

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
@@ -38,6 +38,22 @@ public class WebSessionTrackingTelemetryModule implements WebTelemetryModule<Htt
     // region Public
 
     /**
+     * The {@link RequestTelemetryContext} instance propogated from
+     * {@link com.microsoft.applicationinsights.web.internal.httputils.HttpServerHandler}
+     */
+    private RequestTelemetryContext requestTelemetryContext;
+
+    public void setRequestTelemetryContext(
+        RequestTelemetryContext requestTelemetryContext) {
+        this.requestTelemetryContext = requestTelemetryContext;
+    }
+
+    /** Used for test */
+    RequestTelemetryContext getRequestTelemetryContext() {
+        return this.requestTelemetryContext;
+    }
+
+    /**
      * Initializes the telemetry module.
      * @param configuration The configuration to used to initialize the module.
      */
@@ -52,7 +68,7 @@ public class WebSessionTrackingTelemetryModule implements WebTelemetryModule<Htt
      */
     @Override
     public void onBeginRequest(HttpServletRequest req, HttpServletResponse res) {
-        RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
+        RequestTelemetryContext context = this.requestTelemetryContext;
         SessionCookie sessionCookie =
             com.microsoft.applicationinsights.web.internal.cookies.Cookie.getCookie(
                 SessionCookie.class, req, SessionCookie.COOKIE_NAME);

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebSessionTrackingTelemetryModule.java
@@ -25,7 +25,6 @@ import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.extensibility.context.SessionContext;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
-import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.cookies.SessionCookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebTelemetryModule.java
@@ -21,6 +21,8 @@
 
 package com.microsoft.applicationinsights.web.extensibility.modules;
 
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+
 /**
  * Created by yonisha on 2/2/2015.
  */
@@ -38,4 +40,10 @@ public interface WebTelemetryModule<P, Q> {
      * @param res The response to modify
      */
     void onEndRequest(P req, Q res);
+
+    /**
+     * Set the context in the TelemetryModule
+     * @param context
+     */
+    void setRequestTelemetryContext(RequestTelemetryContext context);
 }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebUserTrackingTelemetryModule.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/modules/WebUserTrackingTelemetryModule.java
@@ -25,7 +25,6 @@ import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.extensibility.context.UserContext;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
-import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.applicationinsights.web.internal.cookies.UserCookie;
 import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
@@ -34,7 +33,24 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Created by yonisha on 2/7/2015.
  */
-public class WebUserTrackingTelemetryModule implements WebTelemetryModule<HttpServletRequest, HttpServletResponse>, TelemetryModule {
+public class WebUserTrackingTelemetryModule implements
+    WebTelemetryModule<HttpServletRequest, HttpServletResponse>, TelemetryModule {
+
+    /**
+     * The {@link RequestTelemetryContext} instance propogated from
+     * {@link com.microsoft.applicationinsights.web.internal.httputils.HttpServerHandler}
+     */
+    private RequestTelemetryContext requestTelemetryContext;
+
+    public void setRequestTelemetryContext(
+        RequestTelemetryContext requestTelemetryContext) {
+        this.requestTelemetryContext = requestTelemetryContext;
+    }
+
+    /** Used for test */
+    RequestTelemetryContext getRequestTelemetryContext() {
+        return this.requestTelemetryContext;
+    }
 
     /**
      * Initializes the telemetry module.
@@ -52,7 +68,7 @@ public class WebUserTrackingTelemetryModule implements WebTelemetryModule<HttpSe
      */
     @Override
     public void onBeginRequest(HttpServletRequest req, HttpServletResponse res) {
-        RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
+        RequestTelemetryContext context = this.requestTelemetryContext;
         UserCookie userCookie =
             com.microsoft.applicationinsights.web.internal.cookies.Cookie.getCookie(
                 UserCookie.class, req, UserCookie.COOKIE_NAME);

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/ThreadContext.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/ThreadContext.java
@@ -25,16 +25,31 @@ package com.microsoft.applicationinsights.web.internal;
  * Created by yonisha on 2/16/2015.
  */
 public class ThreadContext {
-    private static final InheritableThreadLocal<RequestTelemetryContext> threadLocal = new InheritableThreadLocal<RequestTelemetryContext>();
 
+    // No object creation allowed for this class.
+    private ThreadContext() {}
+
+    private static final ThreadLocal<RequestTelemetryContext> threadLocal = new ThreadLocal<>();
+
+    /**
+     * Set the context in ThreadLocal
+     * @param telemetryContext
+     */
     public static void setRequestTelemetryContext(RequestTelemetryContext telemetryContext) {
         threadLocal.set(telemetryContext);
     }
 
+    /**
+     * Get the context from ThreadLocal
+     * @return
+     */
     public static RequestTelemetryContext getRequestTelemetryContext() {
         return threadLocal.get();
     }
 
+    /**
+     * Remove the context from ThreadLocal
+     */
     public static void remove() {
         threadLocal.remove();
     }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/ThreadContext.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/ThreadContext.java
@@ -29,7 +29,7 @@ public class ThreadContext {
     // No object creation allowed for this class.
     private ThreadContext() {}
 
-    private static final ThreadLocal<RequestTelemetryContext> threadLocal = new ThreadLocal<>();
+    private static final InheritableThreadLocal<RequestTelemetryContext> threadLocal = new InheritableThreadLocal<>();
 
     /**
      * Set the context in ThreadLocal

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebModulesContainer.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebModulesContainer.java
@@ -25,10 +25,9 @@ import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.web.extensibility.modules.WebTelemetryModule;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
  * Created by yonisha on 2/3/2015.
@@ -36,6 +35,12 @@ import java.util.List;
 public class WebModulesContainer<P, Q> {
     private List<WebTelemetryModule<P, Q>> modules = new ArrayList<>();
     private int modulesCount = 0;
+    private RequestTelemetryContext requestTelemetryContext;
+
+    public void setRequestTelemetryContext(
+        RequestTelemetryContext requestTelemetryContext) {
+        this.requestTelemetryContext = requestTelemetryContext;
+    }
 
     /**
      * Constructs new WebModulesContainer object from the given configuration.
@@ -54,6 +59,7 @@ public class WebModulesContainer<P, Q> {
     public void invokeOnBeginRequest(P req, Q res) {
         for (WebTelemetryModule<P, Q> module : modules) {
             try {
+                module.setRequestTelemetryContext(requestTelemetryContext);
                 module.onBeginRequest(req, res);
             } catch (Exception e) {
                 InternalLogger.INSTANCE.error("Web module %s failed on BeginRequest with exception: %s", module.getClass().getSimpleName(), e.toString());

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -147,7 +147,6 @@ public final class WebRequestTrackingFilter implements Filter {
             if (configuration == null) {
                 InternalLogger.INSTANCE.error(
                     "Java SDK configuration cannot be null. Web request tracking filter will be disabled.");
-
                 return;
             }
             configureWebAppNameContextInitializer(appName, configuration);

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -117,18 +117,19 @@ public final class WebRequestTrackingFilter implements Filter {
             } catch (ServletException | IOException | RuntimeException e) {
                 handler.handleException(e);
                 throw e;
-            }
-            if (httpRequest.isAsyncStarted()) {
-                AsyncContext context = httpRequest.getAsyncContext();
-                context.addListener(aiHttpServletListener, httpRequest, httpResponse);
-            } else {
-                // In some cases filter can be called twice based on Web Servers while handling
-                // async requests. We should only process a request once.
-                if (!DispatcherType.ASYNC.equals(httpRequest.getDispatcherType())) {
-                    handler.handleEnd(httpRequest, httpResponse, requestTelemetryContext);
+            } finally {
+                if (httpRequest.isAsyncStarted()) {
+                    AsyncContext context = httpRequest.getAsyncContext();
+                    context.addListener(aiHttpServletListener, httpRequest, httpResponse);
+                } else {
+                    // In some cases filter can be called twice based on Web Servers while handling
+                    // async requests. We should only process a request once.
+                    if (!DispatcherType.ASYNC.equals(httpRequest.getDispatcherType())) {
+                        handler.handleEnd(httpRequest, httpResponse, requestTelemetryContext);
+                    }
                 }
+                setKeyOnTLS(null);
             }
-            setKeyOnTLS(null);
         } else {
             // we are only interested in Http Requests. Keep all other untouched.
             chain.doFilter(req, res);

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/AIHttpServletListener.java
@@ -1,5 +1,6 @@
 package com.microsoft.applicationinsights.web.internal.httputils;
 
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
 import java.io.Closeable;
 import java.io.IOException;
@@ -11,6 +12,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.annotation.Experimental;
 
 /**
@@ -70,6 +72,9 @@ public final class AIHttpServletListener implements Closeable, AsyncListener {
                 if (throwable instanceof Exception) {
                     // AI SDK can only track Exceptions. It doesn't support tracking Throwable
                     handler.handleException((Exception) throwable);
+                } else {
+                    InternalLogger.INSTANCE.warn(String.format("Throwable is not instance of exception,"
+                        + "cannot be captured. Stack trace is : %s", ExceptionUtils.getStackTrace(throwable)));
                 }
             } finally{
                 handler.handleEnd((HttpServletRequest) request, (HttpServletResponse) response, context);

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
@@ -78,8 +78,8 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
      */
     public RequestTelemetryContext handleStart(P request, Q response) throws MalformedURLException {
         RequestTelemetryContext context = new RequestTelemetryContext(new Date().getTime(),null);
-        // TODO: uncomment this line in final integration
-        //webModulesContainer.setRequestTelemetryContext(context);
+        // set the context object in WebModuleContainer (Container that holds web modules)
+        webModulesContainer.setRequestTelemetryContext(context);
         RequestTelemetry requestTelemetry = context.getHttpRequestTelemetry();
         ThreadContext.setRequestTelemetryContext(context);
         String method = extractor.getMethod(request);
@@ -102,7 +102,9 @@ public final class HttpServerHandler<P /* >>> extends @NonNull Object */, Q> {
     }
 
     /**
-     * This method is used to indicate request end instrumentation, complete correlation and record timing, response
+     * This method is used to indicate request end instrumentation, complete correlation and record timing, response.
+     * Context object is needed as a parameter because in Async requests, handleEnd() can be called
+     * on separate thread then where handleStart() was called.
      * @param request HttpRequest object
      * @param response HttpResponse object
      * @param context RequestTelemetryContext object

--- a/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/extensibility/modules/WebRequestTrackingTelemetryModuleTests.java
@@ -38,6 +38,7 @@ import com.microsoft.applicationinsights.web.internal.correlation.TraceContextCo
 import com.microsoft.applicationinsights.web.internal.correlation.TraceContextCorrelationTests;
 import com.microsoft.applicationinsights.web.internal.correlation.mocks.MockProfileFetcher;
 import com.microsoft.applicationinsights.web.internal.correlation.tracecontext.Traceparent;
+import com.microsoft.applicationinsights.web.internal.httputils.HttpServerHandler;
 import com.microsoft.applicationinsights.web.utils.HttpHelper;
 import com.microsoft.applicationinsights.web.utils.JettyTestServer;
 import com.microsoft.applicationinsights.web.utils.MockTelemetryChannel;
@@ -69,9 +70,6 @@ import static org.mockito.Mockito.when;
  * Created by yonisha on 2/2/2015.
  */
 public class WebRequestTrackingTelemetryModuleTests {
-    private static final String DEFAULT_REQUEST_URI = "/controller/action.action";
-    private static final String DEFAULT_REQUEST_NAME = HttpMethod.GET.asString() + " " + DEFAULT_REQUEST_URI;
-
     private static JettyTestServer server = new JettyTestServer();
     private static WebRequestTrackingTelemetryModule defaultModule;
     private static WebRequestTrackingTelemetryModule currentModule;
@@ -102,7 +100,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         defaultModule = new WebRequestTrackingTelemetryModule();
         defaultModule.initialize(TelemetryConfiguration.getActive());
-
+        defaultModule.setRequestTelemetryContext(null);
         channel.reset();
     }
 
@@ -110,7 +108,9 @@ public class WebRequestTrackingTelemetryModuleTests {
     public void testDestroy() {
         currentModule.isW3CEnabled = false;
         defaultModule.isW3CEnabled = false;
+        defaultModule.setRequestTelemetryContext(null);
         defaultModule.setEnableBackCompatibilityForW3C(true);
+        ThreadContext.remove();
     }
 
     @AfterClass
@@ -189,6 +189,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -198,7 +199,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TelemetryCorrelationUtils.CORRELATION_HEADER_NAME, incomingId);
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue("id1", null));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers, 1);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -208,7 +209,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onBeginRequest(request, response);
 
         // verify ID's are set as expected in request telemetry
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
         Assert.assertEquals(incomingId.length() + 9, requestTelemetry.getId().length());
         Assert.assertTrue(requestTelemetry.getId().startsWith(incomingId));
@@ -238,6 +239,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -257,7 +259,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onBeginRequest(request, response);
 
         // verify ID's are set as expected in request telemetry
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
         // spanIds are different
         String[] id = requestTelemetry.getId().split("[.]");
@@ -287,6 +289,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -307,7 +310,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onBeginRequest(request, response);
 
         // verify ID's are set as expected in request telemetry
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
 
         Assert.assertTrue(requestTelemetry.getId().startsWith("|"+tp.getTraceId()));
@@ -334,6 +337,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -344,7 +348,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.
             getRequestContextHeaderValue("id1", null));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -354,7 +358,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onBeginRequest(request, response);
 
         // verify ID's are set as expected in request telemetry
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
 
         //"guid" is invalid trace-id in W3C. A new Traceparent is created
@@ -385,6 +389,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -405,7 +410,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onBeginRequest(request, response);
 
         // verify ID's are set as expected in request telemetry
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
 
         //validate operation context ID's
@@ -434,6 +439,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -454,7 +460,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onBeginRequest(request, response);
 
         // verify ID's are set as expected in request telemetry
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
 
         //validate operation context ID's
@@ -484,6 +490,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -494,7 +501,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TelemetryCorrelationUtils.CORRELATION_HEADER_NAME, incomingId);
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue("id1", null));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -504,7 +511,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onBeginRequest(request, response);
 
         // verify ID's are set as expected in request telemetry
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNotNull(requestTelemetry.getId());
 
         // old headers are not captured
@@ -534,6 +541,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -546,7 +554,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TelemetryCorrelationUtils.CORRELATION_CONTEXT_HEADER_NAME, correlationContext);
 
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers, 1);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //run module
         defaultModule.onBeginRequest(request, response);
@@ -559,7 +567,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         Assert.assertEquals(1, items.size());
         ExceptionTelemetry exceptionTelemetry = items.get(0);
 
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
 
         //validate manually tracked telemetry is a child of the request telemetry
         Assert.assertEquals("guid", exceptionTelemetry.getContext().getOperation().getId());
@@ -577,6 +585,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -587,7 +596,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TraceContextCorrelation.TRACEPARENT_HEADER_NAME, tp.toString());
         headers.put(TraceContextCorrelation.TRACESTATE_HEADER_NAME, TraceContextCorrelationTests.getTracestateHeaderValue("id1"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -604,13 +613,13 @@ public class WebRequestTrackingTelemetryModuleTests {
         Assert.assertEquals(1, items.size());
         ExceptionTelemetry exceptionTelemetry = items.get(0);
 
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
 
         //validate manually tracked telemetry is a child of the request telemetry
         Assert.assertEquals(tp.getTraceId(), exceptionTelemetry.getContext().getOperation().getId());
         Assert.assertEquals(requestTelemetry.getId(), exceptionTelemetry.getContext().getOperation().getParentId());
 
-        Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertNotNull(defaultModule.getRequestTelemetryContext().getTracestate());
         Assert.assertEquals(TraceContextCorrelationTests.getTracestateHeaderValue("id2"),
             ThreadContext.getRequestTelemetryContext().getTracestate().toString());
 
@@ -623,6 +632,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -633,7 +643,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TraceContextCorrelation.TRACEPARENT_HEADER_NAME, tp.toString());
         headers.put(TraceContextCorrelation.TRACESTATE_HEADER_NAME, "");
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -642,7 +652,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         //run
         defaultModule.onBeginRequest(request, response);
 
-        Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertNotNull(defaultModule.getRequestTelemetryContext().getTracestate());
         Assert.assertEquals(TraceContextCorrelationTests.getTracestateHeaderValue("id2"),
             ThreadContext.getRequestTelemetryContext().getTracestate().toString());
     }
@@ -655,6 +665,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         //setup: initialize a request context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
         ThreadContext.setRequestTelemetryContext(context);
+        defaultModule.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<>();
@@ -672,7 +683,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         //run
         defaultModule.onBeginRequest(request, response);
 
-        Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertNotNull(defaultModule.getRequestTelemetryContext().getTracestate());
         Assert.assertEquals(TraceContextCorrelationTests.getTracestateHeaderValue("id2"),
             ThreadContext.getRequestTelemetryContext().getTracestate().toString());
     }
@@ -685,6 +696,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         //setup: initialize a request context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
         ThreadContext.setRequestTelemetryContext(context);
+        defaultModule.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<>();
@@ -694,7 +706,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TraceContextCorrelation.TRACEPARENT_HEADER_NAME, tp.toString());
         headers.put(TraceContextCorrelation.TRACESTATE_HEADER_NAME, TraceContextCorrelationTests.getTracestateHeaderValue("id1"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -703,7 +715,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         //run
         defaultModule.onBeginRequest(request, response);
 
-        Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertNotNull(defaultModule.getRequestTelemetryContext().getTracestate());
         Assert.assertEquals(TraceContextCorrelationTests.getTracestateHeaderValue("id1"),
             ThreadContext.getRequestTelemetryContext().getTracestate().toString());
     }
@@ -716,6 +728,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         //setup: initialize a request context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
         ThreadContext.setRequestTelemetryContext(context);
+        defaultModule.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<>();
@@ -725,7 +738,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         headers.put(TraceContextCorrelation.TRACEPARENT_HEADER_NAME, tp.toString());
         headers.put(TraceContextCorrelation.TRACESTATE_HEADER_NAME, TraceContextCorrelationTests.getTracestateHeaderValue("id1"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -734,7 +747,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         //run
         defaultModule.onBeginRequest(request, response);
 
-        Assert.assertNotNull(ThreadContext.getRequestTelemetryContext().getTracestate());
+        Assert.assertNotNull(defaultModule.getRequestTelemetryContext().getTracestate());
         Assert.assertEquals(TraceContextCorrelationTests.getTracestateHeaderValue("id1"),
             ThreadContext.getRequestTelemetryContext().getTracestate().toString());
     }
@@ -744,13 +757,14 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue("id1", null));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -761,7 +775,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onEndRequest(request, null);
 
         //validate source
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertEquals(TelemetryCorrelationUtilsTests.getRequestSourceValue("id1", null), requestTelemetry.getSource());
     }
 
@@ -771,12 +785,13 @@ public class WebRequestTrackingTelemetryModuleTests {
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
         ThreadContext.setRequestTelemetryContext(context);
+        defaultModule.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue("id1", null));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return the same appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id1");
@@ -787,7 +802,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onEndRequest(request, null);
 
         //validate source
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNull(requestTelemetry.getSource());
     }
 
@@ -796,13 +811,14 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue(null, "Front End"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -813,7 +829,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onEndRequest(request, null);
 
         //validate source
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertEquals(TelemetryCorrelationUtilsTests.getRequestSourceValue(null, "Front End"), requestTelemetry.getSource());
     }
 
@@ -822,13 +838,14 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue("id1", "Front End"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -839,7 +856,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onEndRequest(request, null);
 
         //validate source
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertEquals(TelemetryCorrelationUtilsTests.getRequestSourceValue("id1", "Front End"), requestTelemetry.getSource());
     }
 
@@ -848,13 +865,14 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue("id1", "Front End"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return the same appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id1");
@@ -865,7 +883,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onEndRequest(request, null);
 
         //validate source
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertEquals(TelemetryCorrelationUtilsTests.getRequestSourceValue(null, "Front End"), requestTelemetry.getSource());
     }
 
@@ -874,15 +892,16 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         requestTelemetry.setSource("myAppId");
 
         //mock a servlet request with cross-component correlation headers
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(TelemetryCorrelationUtils.REQUEST_CONTEXT_HEADER_NAME, TelemetryCorrelationUtilsTests.getRequestContextHeaderValue("id1", "Front End"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -904,6 +923,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
         RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
         requestTelemetry.setSource("myAppId");
@@ -912,7 +932,7 @@ public class WebRequestTrackingTelemetryModuleTests {
         Map<String, String> headers = new HashMap<String, String>();
         headers.put(TraceContextCorrelation.TRACESTATE_HEADER_NAME, TraceContextCorrelationTests.getTracestateHeaderValue("id1"));
         HttpServletRequest request = ServletUtils.createServletRequestWithHeaders(headers);
-        HttpServletResponse response = (HttpServletResponse)ServletUtils.generateDummyServletResponse();
+        HttpServletResponse response = ServletUtils.generateDummyServletResponse();
 
         //configure mock appId fetcher to return different appId from what's on the request header
         mockProfileFetcher.setAppIdToReturn("id2");
@@ -950,6 +970,7 @@ public class WebRequestTrackingTelemetryModuleTests {
 
         //setup: initialize a request telemetry context
         RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
+        defaultModule.setRequestTelemetryContext(context);
         ThreadContext.setRequestTelemetryContext(context);
 
         //mock a servlet request with cross-component correlation headers
@@ -980,12 +1001,12 @@ public class WebRequestTrackingTelemetryModuleTests {
         Assert.assertEquals(2, mockProfileFetcher.callCount());
 
         // at this point source won't be set yet because the ikey has changed and so a new resolve task has started
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertNull(requestTelemetry.getSource());
 
         //another request comes in
         RequestTelemetryContext context2 = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
-        ThreadContext.setRequestTelemetryContext(context2);
+        defaultModule.setRequestTelemetryContext(context2);
         HttpServletRequest request2 = ServletUtils.createServletRequestWithHeaders(headers);
 
         mockProfileFetcher.setResultStatus(ProfileFetcherResultTaskStatus.COMPLETE);
@@ -998,12 +1019,12 @@ public class WebRequestTrackingTelemetryModuleTests {
         defaultModule.onEndRequest(request, null);
         Assert.assertEquals(3, mockProfileFetcher.callCount());
 
-        RequestTelemetry requestTelemetry2 = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry2 = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertEquals("cid-v1:id1", requestTelemetry2.getSource());
 
         // if another request comes in, it should retrieve appId from cache
         RequestTelemetryContext context3 = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
-        ThreadContext.setRequestTelemetryContext(context3);
+        defaultModule.setRequestTelemetryContext(context3);
         HttpServletRequest request3 = ServletUtils.createServletRequestWithHeaders(headers);
         defaultModule.onBeginRequest(request3, response);
         Assert.assertEquals(3, mockProfileFetcher.callCount());
@@ -1011,53 +1032,13 @@ public class WebRequestTrackingTelemetryModuleTests {
         // module.onEndRequest will attempt to retrieve new appId from task if it is completed
         defaultModule.onEndRequest(request, null);
         Assert.assertEquals(3, mockProfileFetcher.callCount());
-        RequestTelemetry requestTelemetry3 = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
+        RequestTelemetry requestTelemetry3 = defaultModule.getRequestTelemetryContext().getHttpRequestTelemetry();
         Assert.assertEquals("cid-v1:id1", requestTelemetry3.getSource());
     }
 
     // endregion Tests
 
     // region Private methods
-
-    private void testRequestNameCalculationWithGivenQueryString(String queryString, String pathVariable) {
-        RequestTelemetryContext context = new RequestTelemetryContext(DateTimeUtils.getDateTimeNow().getTime());
-        ThreadContext.setRequestTelemetryContext(context);
-
-        HttpServletRequest servletRequest = createServletRequest(queryString, pathVariable);
-        defaultModule.onBeginRequest(servletRequest, null);
-
-        RequestTelemetry requestTelemetry = ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry();
-        Assert.assertEquals("Request name not valid.", DEFAULT_REQUEST_NAME, requestTelemetry.getName());
-    }
-
-    private HttpServletRequest createServletRequest(String queryString, String pathVariable) {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
-        String uri = DEFAULT_REQUEST_URI;
-        if (pathVariable != null) {
-            uri = uri.concat(pathVariable);
-        }
-
-        when(request.getRequestURI()).thenReturn(uri);
-        when(request.getMethod()).thenReturn(HttpMethod.GET.asString());
-        when(request.getScheme()).thenReturn("http");
-        when(request.getHeader("Host")).thenReturn("localhost:" + server.getPortNumber());
-        when(request.getQueryString()).thenReturn(queryString);
-
-        return request;
-    }
-
-    private ServletRequest createFaultyServletRequestMock() {
-        ServletRequest request = mock(ServletRequest.class);
-        Mockito.doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                throw new Exception("FATAL!");
-            }
-        }).when(request).getScheme();
-
-        return request;
-    }
 
     private static WebRequestTrackingTelemetryModule getCurrentWebRequestTrackingModule() {
         List<TelemetryModule> modules = TelemetryConfiguration.getActive().getTelemetryModules();

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
@@ -60,7 +60,7 @@ public class ThreadContextTests {
     }
 
     @Test
-    public void testNewCreatedThreadDoesNotGetsTheParentContextByDefault() throws InterruptedException {
+    public void testNewCreatedThreadTheParentContextByDefault() throws InterruptedException {
         final String expectedRequestName = "inherited_context";
         RequestTelemetryContext requestTelemetryContext = new RequestTelemetryContext(0);
         requestTelemetryContext.getHttpRequestTelemetry().setName(expectedRequestName);
@@ -78,7 +78,39 @@ public class ThreadContextTests {
         thread.start();
         thread.join();
 
-        Assert.assertNull(context[0]);
+        Assert.assertNotNull(context[0]);
+        Assert.assertSame(expectedRequestName, ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry()
+            .getName());
+    }
+
+    @Test
+    public void testChildThreadDoesnotGetContextUpdatedWhenrelyingonItls()
+        throws InterruptedException {
+        final String expectedRequestName = "inherited_context";
+        RequestTelemetryContext requestTelemetryContext = new RequestTelemetryContext(0);
+        requestTelemetryContext.getHttpRequestTelemetry().setName(expectedRequestName);
+
+        ThreadContext.setRequestTelemetryContext(requestTelemetryContext);
+
+        final RequestTelemetryContext[] context = new RequestTelemetryContext[1];
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                context[0] = ThreadContext.getRequestTelemetryContext();
+            }
+        });
+
+        thread.start();
+        thread.join();
+
+
+        final String expectedRequestName1 = "inherited_context1";
+        RequestTelemetryContext requestTelemetryContext1 = new RequestTelemetryContext(0);
+        requestTelemetryContext.getHttpRequestTelemetry().setName(expectedRequestName1);
+        ThreadContext.setRequestTelemetryContext(requestTelemetryContext1);
+
+        Assert.assertNotSame(expectedRequestName, ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry()
+            .getName());
     }
 
     @Test

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.web.internal;
 
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import com.microsoft.applicationinsights.web.utils.ThreadContextValidator;
@@ -40,7 +41,7 @@ public class ThreadContextTests {
 
     @Test
     public void testConcurrentThreadsGetTheirOwnContext() throws InterruptedException {
-        ArrayList<ThreadContextValidator> threadContextValidators = new ArrayList<ThreadContextValidator>();
+        List<ThreadContextValidator> threadContextValidators = new ArrayList<ThreadContextValidator>();
 
         // Initializing validators.
         for (int i = 0; i < NUMBER_OF_VALIDATOR_THREADS; i++) {
@@ -59,7 +60,7 @@ public class ThreadContextTests {
     }
 
     @Test
-    public void testNewCreatedThreadGetsTheParentContext() throws InterruptedException {
+    public void testNewCreatedThreadDoesNotGetsTheParentContextByDefault() throws InterruptedException {
         final String expectedRequestName = "inherited_context";
         RequestTelemetryContext requestTelemetryContext = new RequestTelemetryContext(0);
         requestTelemetryContext.getHttpRequestTelemetry().setName(expectedRequestName);
@@ -77,7 +78,50 @@ public class ThreadContextTests {
         thread.start();
         thread.join();
 
+        Assert.assertNull(context[0]);
+    }
+
+    @Test
+    public void testNewThreadCreatedWithWrappedRunnableGetsTheParentContext() throws InterruptedException {
+        final String expectedRequestName = "inherited_context";
+        RequestTelemetryContext requestTelemetryContext = new RequestTelemetryContext(0);
+        requestTelemetryContext.getHttpRequestTelemetry().setName(expectedRequestName);
+
+        ThreadContext.setRequestTelemetryContext(requestTelemetryContext);
+
+        final RequestTelemetryContext[] context = new RequestTelemetryContext[1];
+        Thread thread = new Thread(new MyRunnable(new Runnable() {
+            @Override
+            public void run() {
+                    context[0] = ThreadContext.getRequestTelemetryContext();
+            }
+        }, requestTelemetryContext));
+
+        thread.start();
+        thread.join();
+
         Assert.assertNotNull(context[0]);
-        Assert.assertEquals(expectedRequestName, context[0].getHttpRequestTelemetry().getName());
+        Assert.assertSame(expectedRequestName, ThreadContext.getRequestTelemetryContext().getHttpRequestTelemetry()
+                            .getName());
+    }
+
+    private static class MyRunnable implements Runnable {
+        private final Runnable task;
+        private final RequestTelemetryContext rtc;
+
+        MyRunnable(Runnable task,
+            RequestTelemetryContext rtc) {
+            this.task = task;
+            this.rtc = rtc;
+        }
+
+        @Override
+        public void run() {
+            if (ThreadContext.getRequestTelemetryContext() != null) {
+                ThreadContext.remove();
+            }
+            ThreadContext.setRequestTelemetryContext(rtc);
+            task.run();
+        }
     }
 }

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/ThreadContextTests.java
@@ -84,7 +84,7 @@ public class ThreadContextTests {
     }
 
     @Test
-    public void testChildThreadDoesnotGetContextUpdatedWhenrelyingonItls()
+    public void childThreadDoesNotGetContextUpdatedWithITLS()
         throws InterruptedException {
         final String expectedRequestName = "inherited_context";
         RequestTelemetryContext requestTelemetryContext = new RequestTelemetryContext(0);

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilterTests.java
@@ -27,6 +27,7 @@ import com.microsoft.applicationinsights.internal.reflect.ClassDataVerifier;
 import com.microsoft.applicationinsights.web.internal.httputils.ApplicationInsightsServletExtractor;
 import com.microsoft.applicationinsights.web.internal.httputils.HttpExtractor;
 import com.microsoft.applicationinsights.web.internal.httputils.HttpServerHandler;
+import java.util.List;
 import org.apache.http.HttpRequest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -236,7 +237,7 @@ public class WebRequestTrackingFilterTests {
         }
         HttpExtractor<HttpServletRequest, HttpServletResponse> extractor = spy(new ApplicationInsightsServletExtractor());
         HttpServerHandler<HttpServletRequest, HttpServletResponse> handler = new HttpServerHandler<>(
-            extractor, mock(WebModulesContainer.class), mockTelemetryClient
+            extractor, mock(WebModulesContainer.class), mock(List.class), mockTelemetryClient
         );
         field.set(filter, mockTelemetryClient);
         field1.set(filter,  handler);

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandlerTest.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandlerTest.java
@@ -100,6 +100,12 @@ public class HttpServerHandlerTest {
     }
 
     @Test
+    public void handleStartShouldSetContextInWebModulesContainer() throws MalformedURLException {
+        RequestTelemetryContext context = httpServerHandler.handleStart(request, response);
+        verify(webModulesContainer, times(1)).setRequestTelemetryContext(context);
+    }
+
+    @Test
     public void handleEndThrowsWhenCalledBeforeHandleStart() {
         thrown.expect(NullPointerException.class);
         httpServerHandler.handleEnd(request, response, mock(RequestTelemetryContext.class));


### PR DESCRIPTION
Merge #827 first

This PR integrates Async Listener to `WebRequestTrackingFilter`. I have introduced `setRequestTelemetryContext()` API for `WebTelemetryModule` interface as all the web modules need to use the same context which is propagated. 

Deprecated the usage of `InherritableThreadLocal` in favor of `ThreadLocal` as ITLS doesn't work when performing correlation in ThreadPools. 

For significant contributions please make sure you have completed the following items:

- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated
