### PR TITLE
Improve lazy init; remove unnecessary executor

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender42.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender42.java
@@ -46,14 +46,14 @@ final class ApacheSender42 implements ApacheSender {
         InternalLogger.INSTANCE.info("Using Apache HttpClient 4.2");
     }
 
-    private PoolingClientConnectionManager initializeConnectionManager() {
+    private static PoolingClientConnectionManager initializeConnectionManager() {
         PoolingClientConnectionManager pccm = new PoolingClientConnectionManager();
         pccm.setMaxTotal(DEFAULT_MAX_TOTAL_CONNECTIONS);
         pccm.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
         return pccm;
     }
 
-    private HttpClient initializeHttpClient(PoolingClientConnectionManager pccm) {
+    private static HttpClient initializeHttpClient(PoolingClientConnectionManager pccm) {
         HttpClient client = new DefaultHttpClient(pccm);
 
         HttpParams params = client.getParams();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -93,14 +93,14 @@ final class ApacheSender43 implements ApacheSender {
         return result;
     }
 
-    private PoolingHttpClientConnectionManager initializeConnectionManager() {
+    private static PoolingHttpClientConnectionManager initializeConnectionManager() {
         PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
         cm.setMaxTotal(DEFAULT_MAX_TOTAL_CONNECTIONS);
         cm.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
         return cm;
     }
 
-    private CloseableHttpClient initializeClient(HttpClientConnectionManager cm) {
+    private static CloseableHttpClient initializeClient(HttpClientConnectionManager cm) {
         return HttpClients.custom()
                 .setConnectionManager(cm)
                 .setConnectionManagerShared(true)


### PR DESCRIPTION
Fix #721.

I updated the lazy initialization procedure. The extra thread was overkill and added overhead. This may slow the first send a bit, but I think this will resolve the issue.

Take a look and make sure I didn't miss something in the refactor. I still need to run a proper test.