### PR TITLE
In SmokeTests, always set container name

### DIFF
--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -193,7 +193,7 @@ public abstract class AiSmokeTest {
 		protected void failed(Throwable t, Description description) {
 			// NOTE this happens after @After :)
 			String containerId = currentContainerInfo.getContainerId();
-			System.out.println("Test failure detected.");
+			System.out.printf("Test failure detected in %s.%s%n", description.getTestClass().getSimpleName(), description.getMethodName());
 			// FIXME tailLastLog consistantly timeouts after 10s. container logs generally contain enough information. remove tailLastLog.sh in the future if this continues
 //			runTailLastLog(containerId);
 			printContainerLogs(containerId);

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/AiSmokeTest.java
@@ -459,24 +459,15 @@ public abstract class AiSmokeTest {
 			return;
 		}
 
-		for (DependencyContainer dc : dependencyImages) {
+		for (int i = 0; i < dependencyImages.size(); i++) {
+			DependencyContainer dc = dependencyImages.get(i);
 			String imageName = Strings.isNullOrEmpty(dc.imageName()) ? dc.value() : dc.imageName();
 			System.out.printf("Starting container: %s%n", imageName);
-			final String containerId = docker.startContainer(imageName, dc.portMapping(), networkId);
-			assertFalse("'containerId' was null/empty attempting to start container: "+imageName, Strings.isNullOrEmpty(containerId));
-			System.out.printf("Dependency container started: %s (%s)%n", imageName, containerId);
+			String containerName = "aiDependency" + StringUtils.capitalize(imageName) + i;
+			final String containerId = docker.startContainer(imageName, dc.portMapping(), networkId, containerName);
+			assertFalse("'containerId' was null/empty attempting to start container: " + imageName, Strings.isNullOrEmpty(containerId));
+			System.out.printf("Dependency container started: %s (%s:%s)%n", imageName, containerId, containerName);
 
-			String containerName = docker.getRunningContainerName(containerId);
-			if (containerName == null) {
-				String message = String.format("Could not get container name for id=%s. ", containerId);
-				if (docker.isContainerRunning(containerId)) {
-					message += "It appears to be running.";
-				} else {
-					message += "It appears to have stopped.";
-				}
-				System.err.println(message);
-				throw new SmokeTestException("Couldn't get container name for image="+imageName);
-			}
 			ContainerInfo depConInfo = new ContainerInfo(containerId, containerName);
 			depConInfo.setContainerName(containerName);
 			depConInfo.setDependencyContainerInfo(dc);
@@ -488,7 +479,8 @@ public abstract class AiSmokeTest {
 	private static void startTestApplicationContainer() throws Exception {
 		System.out.printf("Starting container: %s%n", currentImageName);
 		Map<String, String> envVars = generateAppContainerEnvVarMap();
-		String containerId = docker.startContainer(currentImageName, appServerPort+":8080", networkId, null, envVars);
+		final String containerName = "aiSmokeTestTargetApp";
+		String containerId = docker.startContainer(currentImageName, appServerPort+":8080", containerName, networkId, envVars);
 		assertFalse("'containerId' was null/empty attempting to start container: "+currentImageName, Strings.isNullOrEmpty(containerId));
 		System.out.printf("Container started: %s (%s)%n", currentImageName, containerId);
 
@@ -497,6 +489,7 @@ public abstract class AiSmokeTest {
 		TimeUnit.SECONDS.sleep(appServerDelayAfterStart_seconds);
 
 		currentContainerInfo = new ContainerInfo(containerId, currentImageName);
+		currentContainerInfo.setContainerName(containerName);
 		try {
 			String url = String.format("http://localhost:%s/", String.valueOf(appServerPort));
 			System.out.printf("Verifying appserver has started (%s)...%n", url);

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
@@ -88,7 +88,7 @@ public class AiDockerClient {
 		Preconditions.checkNotNull(containerName, "containerName");
 
 		String localIp = InetAddress.getLocalHost().getHostAddress();
-		List<String> cmd = new ArrayList<>(Arrays.asList(dockerExePath, "run", "-d", "-p", portMapping, "--add-host=fakeingestion:"+localIp));
+		List<String> cmd = new ArrayList<>(Arrays.asList(dockerExePath, "run", "-d", "-p", portMapping, "--add-host=fakeingestion:"+localIp, "--rm"));
 		if (!Strings.isNullOrEmpty(network)) {
 		    // TODO assert the network exists
 		    cmd.add("--network");
@@ -138,13 +138,13 @@ public class AiDockerClient {
 		Preconditions.checkNotNull(cmd, "cmd");
 
 		List<String> cmdList = new ArrayList<>();
-		cmdList.addAll(Arrays.asList(new String[]{dockerExePath, "container", "exec", id, cmd}));
+		cmdList.addAll(Arrays.asList(dockerExePath, "container", "exec", id, cmd));
 		if (args.length > 0) {
 			cmdList.addAll(Arrays.asList(args));
 		}
 		Process p = buildProcess(cmdList).start();
 		try {
-			waitAndCheckCodeForProcess(p, 10, TimeUnit.SECONDS, String.format("executing command on container: '%s'", id, Joiner.on(' ').join(cmdList)));
+			waitAndCheckCodeForProcess(p, 10, TimeUnit.SECONDS, String.format("executing command on container: '%s %s'", id, Joiner.on(' ').join(cmdList)));
 			flushStdout(p);
 		}
 		catch (Exception e) {

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
@@ -78,13 +78,14 @@ public class AiDockerClient {
 		return new ProcessBuilder(cmdLine).redirectErrorStream(true);
 	}
 
-	public String startContainer(String image, String portMapping, String network) throws IOException, InterruptedException {
-		return startContainer(image, portMapping, network, null, null);
+	public String startContainer(String image, String portMapping, String network, String containerName) throws IOException, InterruptedException {
+		return startContainer(image, portMapping, containerName, network, null);
 	}
 
-	public String startContainer(String image, String portMapping, String network, String containerName, Map<String, String> envVars) throws IOException, InterruptedException {
+	public String startContainer(String image, String portMapping, String containerName, String network, Map<String, String> envVars) throws IOException, InterruptedException {
 		Preconditions.checkNotNull(image, "image");
 		Preconditions.checkNotNull(portMapping, "portMapping");
+		Preconditions.checkNotNull(containerName, "containerName");
 
 		String localIp = InetAddress.getLocalHost().getHostAddress();
 		List<String> cmd = new ArrayList<>(Arrays.asList(dockerExePath, "run", "-d", "-p", portMapping, "--add-host=fakeingestion:"+localIp));


### PR DESCRIPTION
For some reason, the generated container names don't always end up in the docker DNS. Setting the container name explicitly addressed the issue.

Fix #861 