### PR TITLE
remove ThreadLocal when it's no longer used

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
@@ -155,6 +155,7 @@ public final class TransmissionPolicyManager implements Stoppable, TransmissionH
     @Override
     public synchronized void stop(long timeout, TimeUnit timeUnit) {
         ThreadPoolUtils.stop(threads, timeout, timeUnit);
+        this.backoffManager.remove();
     }
 
     /**


### PR DESCRIPTION
I found this during testing. We should include this in the next release.