### PR TITLE
Increase persistent http connection validation period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-# Version 2.4.0-BETA (Unreleased)
+# Version 2.4.0
+- Fix [#898](https://github.com/Microsoft/ApplicationInsights-Java/issues/898) Increase persistent http connection validation
+timeout period.
+
+# Version 2.4.0-BETA
 - Removed support for multiple apps instrumented with single JVM Agent. Instrumentation will only work for single apps
   in application server. 
 - Fixed [#749](https://github.com/Microsoft/ApplicationInsights-Java/issues/749) introduce support for PostGre sql jdbc4 prepared statements.

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -60,6 +60,7 @@ final class ApacheSender43 implements ApacheSender {
                 PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
                 cm.setMaxTotal(DEFAULT_MAX_TOTAL_CONNECTIONS);
                 cm.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
+                cm.setValidateAfterInactivity(REQUEST_TIMEOUT_IN_MILLIS);
 
                 httpClientRef.compareAndSet(null, HttpClients.custom()
                         .setConnectionManager(cm)
@@ -120,7 +121,7 @@ final class ApacheSender43 implements ApacheSender {
                 .setConnectionRequestTimeout(REQUEST_TIMEOUT_IN_MILLIS)
                 .setSocketTimeout(REQUEST_TIMEOUT_IN_MILLIS)
                 .setConnectTimeout(REQUEST_TIMEOUT_IN_MILLIS)
-                .setSocketTimeout(REQUEST_TIMEOUT_IN_MILLIS).build();
+                .build();
 
         request.setConfig(requestConfig);
     }


### PR DESCRIPTION
Fix #898  .

Increase the persistent http connection validation period to be equal to the socket timeout period.

This prevents generation of messages like following:
` DEBUG wire                           - http-outgoing-11 << "[read] I/O error: Read timed out"` 
on the client side. 

Suggestion was borrowed based on stackoverflow article: https://stackoverflow.com/questions/34513826/apache-http-client-prints-read-i-o-error-read-timed-out