### PR TITLE
Fix qps invariant version from 2 -> 1

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataFetcher.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataFetcher.java
@@ -52,7 +52,7 @@ final class DefaultQuickPulseDataFetcher implements QuickPulseDataFetcher {
         formatDocuments(sb);
         sb.append("\"Instance\": \"" + instanceName + "\",");
         sb.append("\"InstrumentationKey\": \"" + ikey + "\",");
-        sb.append("\"InvariantVersion\": 2,");      
+        sb.append("\"InvariantVersion\": 1,");
         sb.append("\"MachineName\": \"" + instanceName + "\",");
         sb.append("\"StreamId\": \"" + quickPulseId + "\",");
         


### PR DESCRIPTION
Fix QPS (Livemetrics) Invariant version number. Currently Java SDK only supports QPS v1. 