### PR TITLE
smoketest update

### DIFF
--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
@@ -100,6 +100,9 @@ public class AiDockerClient {
         }
         if (envVars != null && !envVars.isEmpty()) {
 		    for (Entry<String, String> entry : envVars.entrySet()) {
+		    	if (entry.getKey() == null || entry.getValue() == null) {
+		    		continue;
+				}
 		        cmd.add("--env");
 		        cmd.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
             }

--- a/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
+++ b/test/smoke/framework/testCore/src/main/java/com/microsoft/applicationinsights/smoketest/docker/AiDockerClient.java
@@ -102,7 +102,7 @@ public class AiDockerClient {
 		    for (Entry<String, String> entry : envVars.entrySet()) {
 		    	if (entry.getKey() == null || entry.getValue() == null) {
 		    		continue;
-				}
+		    	}
 		        cmd.add("--env");
 		        cmd.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
             }

--- a/test/smoke/testApps/AutoPerfCounters/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/AutoPerfCounters/src/main/resources/ApplicationInsights.xml
@@ -11,6 +11,7 @@
 		<UniquePrefix>JavaSDKLog</UniquePrefix>
 	</SDKLogger>
 
+	<QuickPulse enabled="false" />
 	<!-- HTTP request component (not required for bare API) -->
 
 	<TelemetryModules>

--- a/test/smoke/testApps/CachingCalculator/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/CachingCalculator/src/main/resources/ApplicationInsights.xml
@@ -11,6 +11,7 @@
 		<UniquePrefix>JavaSDKLog</UniquePrefix>
 	</SDKLogger>
 
+	<QuickPulse enabled="false" />
 	<!-- HTTP request component (not required for bare API) -->
 
 	<TelemetryModules>

--- a/test/smoke/testApps/CoreAndFilter/src/main/java/com/microsoft/ajl/simplecalc/SimpleTestRequestSlowWithResponseTime.java
+++ b/test/smoke/testApps/CoreAndFilter/src/main/java/com/microsoft/ajl/simplecalc/SimpleTestRequestSlowWithResponseTime.java
@@ -1,5 +1,7 @@
 package com.microsoft.ajl.simplecalc;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -24,9 +26,20 @@ public class SimpleTestRequestSlowWithResponseTime extends HttpServlet {
             throws ServletException, IOException {
         ServletFuncs.geRrenderHtml(request, response);
 
+        int sleepTime = 25;
+        final String customSleepTime = request.getParameter("sleeptime");
+        if (StringUtils.isNotBlank(customSleepTime)) {
+            try {
+                sleepTime = Integer.parseInt(customSleepTime);
+            } catch (NumberFormatException e) {
+                System.err.printf("Invalid value for 'sleeptime': '%s'%n", customSleepTime);
+            }
+        }
         try {
-            TimeUnit.SECONDS.sleep(20);
-        } catch (Exception ex) {
+            System.out.printf("Sleeping for %d seconds.%n", sleepTime);
+            TimeUnit.SECONDS.sleep(sleepTime);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/test/smoke/testApps/CoreAndFilter/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/CoreAndFilter/src/main/resources/ApplicationInsights.xml
@@ -11,6 +11,8 @@
 		<UniquePrefix>JavaSDKLog</UniquePrefix>
 	</SDKLogger>
 
+	<QuickPulse enabled="false" />
+
 	<!-- HTTP request component (not required for bare API) -->
 
 	<TelemetryModules>

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -252,7 +252,7 @@ public class CoreAndFilterTests extends AiSmokeTest {
     }
 
     @Test
-    @TargetUri(value="/requestSlow", timeout=25_000) // the servlet sleeps for 20 seconds
+    @TargetUri(value="/requestSlow", timeout=35_000) // the servlet sleeps for 20 seconds
     public void testRequestSlowWithResponseTime() {
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
 
@@ -260,7 +260,12 @@ public class CoreAndFilterTests extends AiSmokeTest {
         long actual = rd1.getDuration().getTotalMilliseconds();
         long expected = (new Duration(0, 0, 0, 20, 0).getTotalMilliseconds());
         long tolerance = 2 * 1000; // 2 seconds
-        assertThat(actual, both(greaterThanOrEqualTo(expected - tolerance)).and(lessThan(expected + tolerance)));
+
+        final long min = expected - tolerance;
+        final long max = expected + tolerance;
+
+        System.out.printf("Slow response time: expected=%d, actual=%d%n", expected, actual);
+        assertThat(actual, both(greaterThanOrEqualTo(min)).and(lessThan(max)));
     }
 
     @Ignore // See github issue #600. This should pass when that is fixed.

--- a/test/smoke/testApps/FixedRateSampling/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/FixedRateSampling/src/main/resources/ApplicationInsights.xml
@@ -11,6 +11,7 @@
 		<UniquePrefix>JavaSDKLog</UniquePrefix>
 	</SDKLogger>
 
+	<QuickPulse enabled="false" />
 	<!-- HTTP request component (not required for bare API) -->
 
 	<TelemetryModules>

--- a/test/smoke/testApps/HeartBeat/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/HeartBeat/src/main/resources/ApplicationInsights.xml
@@ -6,6 +6,7 @@
 
 	<InstrumentationKey>00000000-0000-0000-0000-0FEEDDADBEEF</InstrumentationKey>
 
+	<QuickPulse enabled="false" />
 	<!-- HTTP request component (not required for bare API) -->
 
 	<TelemetryModules>

--- a/test/smoke/testApps/PerfTestApp/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/PerfTestApp/src/main/resources/ApplicationInsights.xml
@@ -9,6 +9,9 @@
         <enabled>true</enabled>
         <UniquePrefix>JavaSDKLog</UniquePrefix>
     </SDKLogger>
+
+    <QuickPulse enabled="false" />
+
     <!--<Channel>
         <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress>
     </Channel>-->

--- a/test/smoke/testApps/SpringBootTest/src/main/resources/application.properties
+++ b/test/smoke/testApps/SpringBootTest/src/main/resources/application.properties
@@ -4,5 +4,6 @@ azure.application-insights.instrumentation-key=00000000-0000-0000-0000-cba987654
 azure.application-insights.logger.level=TRACE
 azure.application-insights.default-modules.ProcessPerformanceCountersModule.enabled=false
 azure.application-insights.heart-beat.enabled=false
+azure.application-insights.quick-pulse.enabled=false
 spring.mvc.favicon.enabled=false
 

--- a/test/smoke/testApps/TraceLog4j1_2/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/TraceLog4j1_2/src/main/resources/ApplicationInsights.xml
@@ -8,6 +8,8 @@
 
 	<!-- HTTP request component (not required for bare API) -->
 
+	<QuickPulse enabled="false" />
+
 	<TelemetryModules>
 		<Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule" />
 		<Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule" />

--- a/test/smoke/testApps/TraceLog4j2/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/TraceLog4j2/src/main/resources/ApplicationInsights.xml
@@ -7,6 +7,7 @@
 	<InstrumentationKey>00000000-0000-0000-0000-0FEEDDADBEEF</InstrumentationKey>
 
 	<!-- HTTP request component (not required for bare API) -->
+	<QuickPulse enabled="false" />
 
 	<TelemetryModules>
 		<Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule" />

--- a/test/smoke/testApps/TraceLogBack/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/TraceLogBack/src/main/resources/ApplicationInsights.xml
@@ -7,6 +7,8 @@
 
 	<!-- HTTP request component (not required for bare API) -->
 
+	<QuickPulse enabled="false" />
+
 	<TelemetryModules>
 		<Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule" />
 		<Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule" />


### PR DESCRIPTION
Adjust timeout for failing test.
Disable QuickPulse in smoketests since it continually pings the actual QuickPulse endpoint.
Parameterized the "slow response time" smoketest app.