### PR TITLE
Fix smokeTests in Gradle 5

### DIFF
--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -50,14 +50,19 @@ subprojects {
 
 	processSmokeTestResources {
 		outputs.upToDateWhen { false }
+		dependsOn assemble
 		doLast {
+			def testAppFile = new File(testAppArtifactDir, testAppArtifactFilename)
+			if (!testAppFile.exists()) {
+				throw new GradleException("Missing $testAppArtifactFilename from $testAppArtifactDir")
+			}
 			copy {
 				from testAppArtifactDir
 				into processSmokeTestResources.destinationDir
 				include testAppArtifactFilename
 			}
 			copy {
-				from "$sharedResourcesDir"
+				from sharedResourcesDir
 				into processSmokeTestResources.destinationDir
 				include '**/*'
 			}


### PR DESCRIPTION
After #908, the upgrade broke one thing in the smokeTests. Apparently, `processSmokeTestResources` no longer ran after the `assemble` task. This adds that dependency and adds an error condition if the test app is missing from its libs directory.