### PR TITLE
Fix log4j2 appender build

### DIFF
--- a/collectd/build.gradle
+++ b/collectd/build.gradle
@@ -66,5 +66,5 @@ dependencies {
 }
 
 // Building the shadow (fat) jar after compiling sources.
-assemble.dependsOn(shadowJar)
+shadowJar.dependsOn assemble
 

--- a/distributions/build.gradle
+++ b/distributions/build.gradle
@@ -73,4 +73,4 @@ gradle.projectsEvaluated {
 }
 
 // Building the shadow (fat) jar after compiling sources.
-assemble.dependsOn(shadowJar)
+shadowJar.dependsOn assemble

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -97,18 +97,13 @@ if (!isJava7Compatible) {
     }
 }
 if (java7JreDir) {
-    def requiredJavaBootArchives = ["rt.jar", "jsse.jar"]
-    def bootClasspath = ""
-    requiredJavaBootArchives.each { a ->
-        def archivePath = new File(java7JreDir, "lib/$a")
-        if (!archivePath.exists()) {
-            throw new ProjectConfigurationException("Archive $archivePath required for building in Java 7 could not be found.", null)
-        }
-        logger.info "Archive '$archivePath' added to boot class path"
+    def jre7libDir = fileTree(dir: "$java7JreDir/lib", include: '*.jar')
+    if (!jre7libDir.any()) {
+        throw new GradleException("Invalid JAVA_JRE_7 directory. ${jre7libDir.dir} was empty")
     }
     
     tasks.withType(JavaCompile) {
-        options.bootstrapClasspath = files(java7JreDir + "/lib/rt.jar", java7JreDir + "/lib/jsse.jar")
+        options.bootstrapClasspath = jre7libDir
     }
 } else {
     def msg = "IMPORTANT: Environment variable 'JAVA_JRE_7' is not defined - Install JRE 7 and set 'JAVA_JRE_7' to prevent runtime compatibility issues!"

--- a/logging/log4j2/build.gradle
+++ b/logging/log4j2/build.gradle
@@ -33,5 +33,6 @@ projectPomDescription = "This module provides a $project.msftAppInsights appende
 // endregion Publishing properties
 
 dependencies {
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
+    annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,9 +29,11 @@ include 'web'
 include 'azure-application-insights-spring-boot-starter'
 include 'ApplicationInsightsInternalLogger'
 include 'distributions'
-include 'samples'
-include 'test:performance'
-include 'test:webapps:bookstore-spring'
+//  TODO rewrite samples; current ones are not representative of "real-world" usage
+if (System.properties.AI_SAMPLES) {
+    include 'samples'
+    include 'test:webapps:bookstore-spring'
+}
 
 // Projects for smokeTests
 include ':test:smoke'

--- a/test/smoke/appServers/JBossEAP.7/build.gradle
+++ b/test/smoke/appServers/JBossEAP.7/build.gradle
@@ -2,5 +2,5 @@ ext.jbossEapVersion = 7
 apply from: '../JBossEAP.gradle'
 if (jbossZipFile) {
 	ext.additionalReplaceTokenMap << [ZIP_FILENAME: ext.jbossZipFile.name]
-	ext.additionalReplaceTokenMap << [JBOSS_HOME_DIR: "jboss-eap-7.1"] // TODO find a way to set this automatically
+	ext.additionalReplaceTokenMap << [JBOSS_HOME_DIR: "jboss-eap-7.2"] // TODO find a way to set this automatically
 }

--- a/test/smoke/build.gradle
+++ b/test/smoke/build.gradle
@@ -20,7 +20,7 @@ subprojects {
 		aiCoreJar = project(':core')
 		aiWebJar =  project(':web')
 		aiLog4j1_2Jar = project(':logging:log4j1_2')
-		aiLo4j2Jar = project(':logging:log4j2')
+		aiLog4j2Jar = project(':logging:log4j2')
 		aiLogbackJar = project(':logging:logback')
 		springBootStarterJar = project(':azure-application-insights-spring-boot-starter')
 	}

--- a/test/smoke/testApps/TraceLog4j2/build.gradle
+++ b/test/smoke/testApps/TraceLog4j2/build.gradle
@@ -1,18 +1,19 @@
 apply plugin: 'war'
 
 dependencies {
+    compile 'org.apache.logging.log4j:log4j-api:2.11.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.11.0'
     compile aiCoreJar
     compile aiWebJar
-    compile aiLo4j2Jar
+    compile aiLog4j2Jar
     compile 'com.google.guava:guava:20.0'
-    
+
     providedCompile 'javax.servlet:javax.servlet-api:3.0.1'
 
     smokeTestCompile 'com.google.guava:guava:23.0'
 
     testCompile 'com.google.guava:guava:23.0' // VSCODE intellisense bug workaround
 
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.1'
 }
 
 compileJava.sourceCompatibility = 1.7

--- a/test/smoke/testApps/TraceLog4j2/src/main/java/com/microsoft/ajl/simplecalc/SimpleTestTraceLog4j2Servlet.java
+++ b/test/smoke/testApps/TraceLog4j2/src/main/java/com/microsoft/ajl/simplecalc/SimpleTestTraceLog4j2Servlet.java
@@ -19,14 +19,14 @@ public class SimpleTestTraceLog4j2Servlet extends HttpServlet {
 
 	private static final long serialVersionUID = 3048578125004678364L;
 
+	private static final Logger logger = LogManager.getRootLogger();
+
 	/**
      * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
      */
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         ServletFuncs.geRrenderHtml(request, response);
-        
-        Logger logger = LogManager.getRootLogger();
         logger.trace("This is log4j2 trace.");
         logger.debug("This is log4j2 debug.");
         logger.info("This is log4j2 info.");

--- a/test/smoke/testApps/TraceLog4j2/src/main/java/com/microsoft/ajl/simplecalc/SimpleTestTraceLog4j2WithExceptionServlet.java
+++ b/test/smoke/testApps/TraceLog4j2/src/main/java/com/microsoft/ajl/simplecalc/SimpleTestTraceLog4j2WithExceptionServlet.java
@@ -18,16 +18,16 @@ import org.apache.logging.log4j.Logger;
 public class SimpleTestTraceLog4j2WithExceptionServlet extends HttpServlet {
 
 	private static final long serialVersionUID = 9101440811626233466L;
+    private static final Logger logger = LogManager.getRootLogger();
 
-	/**
+    /**
      * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
      */
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         ServletFuncs.geRrenderHtml(request, response);
 
-        Logger logger = LogManager.getRootLogger();
-        logger.error("This is an exception!", new Exception("Fake Exception")); 
+        logger.error("This is an exception!", new Exception("Fake Exception"));
 
     }
 }

--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -39,7 +39,7 @@ subprojects {
 		// TODO this adds the whole tree rooted at :appServers. Could this depend on :appServers which depends on :appServers:*:build?
 		dependsOn project(':test:smoke:appServers').getTasksByName('buildDockerImage', true)
 		
-		testClassesDirs = files(sourceSets.smokeTest.output.classesDirs)
+		testClassesDirs = sourceSets.smokeTest.output.classesDirs
 
 		classpath = sourceSets.smokeTest.runtimeClasspath
 		outputs.upToDateWhen { false }


### PR DESCRIPTION
for some reason, pre-v5 gradle ran the annotation processors even when included in a `compile` dependency. In gradle 5, they must be declared as `annotationProcessor` dependencies.

Also:
* corrected some task dependencies from gradle upgrade.
* simplified the bootstrapClasspath code
* removed some redundant file collection construction
