### PR TITLE
Fix broken log4j2 unit test

### DIFF
--- a/logging/log4j2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEventTest.java
+++ b/logging/log4j2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEventTest.java
@@ -71,85 +71,10 @@ public final class ApplicationInsightsLogEventTest {
     }
 
     private static void testSeverityLevel(final Level level, SeverityLevel expected) {
-        org.apache.logging.log4j.core.LogEvent logEvent = new LogEvent() {
-            @Override
-            public Map<String, String> getContextMap() {
-                return null;
-            }
-
-            @Override
-            public ThreadContext.ContextStack getContextStack() {
-                return null;
-            }
-
-            @Override
-            public String getLoggerFqcn() {
-                return null;
-            }
-
+        org.apache.logging.log4j.core.LogEvent logEvent = new AbstractLogEvent() {
             @Override
             public Level getLevel() {
                 return level;
-            }
-
-            @Override
-            public String getLoggerName() {
-                return null;
-            }
-
-            @Override
-            public Marker getMarker() {
-                return null;
-            }
-
-            @Override
-            public Message getMessage() {
-                return null;
-            }
-
-            @Override
-            public long getTimeMillis() {
-                return 0;
-            }
-
-            @Override
-            public StackTraceElement getSource() {
-                return null;
-            }
-
-            @Override
-            public String getThreadName() {
-                return null;
-            }
-
-            @Override
-            public Throwable getThrown() {
-                return null;
-            }
-
-            @Override
-            public ThrowableProxy getThrownProxy() {
-                return null;
-            }
-
-            @Override
-            public boolean isEndOfBatch() {
-                return false;
-            }
-
-            @Override
-            public boolean isIncludeLocation() {
-                return false;
-            }
-
-            @Override
-            public void setEndOfBatch(boolean endOfBatch) {
-                /* NOP */
-            }
-
-            @Override
-            public void setIncludeLocation(boolean locationRequired) {
-                /* NOP */
             }
         };
         ApplicationInsightsLogEvent event = new ApplicationInsightsLogEvent(logEvent);

--- a/logging/log4j2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEventTest.java
+++ b/logging/log4j2/appenderSrc/test/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEventTest.java
@@ -71,7 +71,7 @@ public final class ApplicationInsightsLogEventTest {
     }
 
     private static void testSeverityLevel(final Level level, SeverityLevel expected) {
-        org.apache.logging.log4j.core.LogEvent logEvent = new AbstractLogEvent() {
+        org.apache.logging.log4j.core.LogEvent logEvent = new org.apache.logging.log4j.core.AbstractLogEvent() {
             @Override
             public Level getLevel() {
                 return level;


### PR DESCRIPTION
Compile errors from last merge: some interface methods not implemented. The must've added some between 2.1 and 2.11.0