### PR TITLE
Build script fixes

### DIFF
--- a/ApplicationInsightsInternalLogger/build.gradle
+++ b/ApplicationInsightsInternalLogger/build.gradle
@@ -3,6 +3,7 @@ apply from: "$buildScriptsDir/common-java.gradle"
 archivesBaseName = 'ApplicationInsightsInternalLogger'
 
 dependencies {
+    testCompile group: 'org.hamcrest', name:'hamcrest-core', version:'1.3'
     testCompile group: 'org.hamcrest', name:'hamcrest-library', version:'1.3'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile 'junit:junit:4.12'

--- a/ApplicationInsightsInternalLogger/build.gradle
+++ b/ApplicationInsightsInternalLogger/build.gradle
@@ -3,9 +3,9 @@ apply from: "$buildScriptsDir/common-java.gradle"
 archivesBaseName = 'ApplicationInsightsInternalLogger'
 
 dependencies {
-    testCompile('junit:junit:4.12')
+    testCompile group: 'org.hamcrest', name:'hamcrest-library', version:'1.3'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
-    testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.3'
+    testCompile 'junit:junit:4.12'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
 }

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     compile group: 'org.ow2.asm', name: 'asm-all', version: '5.2'
     compile group: 'org.apache.commons', name:'commons-lang3', version:'3.7'
     testCompile group: 'commons-io', name: 'commons-io', version: '2.6'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
 }
 

--- a/collectd/build.gradle
+++ b/collectd/build.gradle
@@ -61,7 +61,7 @@ sourceSets {
 dependencies {
     compile project(':core')
     provided files(collectDLibPath)
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     compile ([group: 'io.grpc', name: 'grpc-stub', version: '1.16.1'])
     compile ([group: 'io.grpc', name: 'grpc-protobuf', version: '1.16.1'])
     runtime ([group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.16.1'])
-    testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.3'
+    testCompile group: 'org.hamcrest', name:'hamcrest-library', version:'1.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -118,9 +118,10 @@ dependencies {
     compile ([group: 'io.grpc', name: 'grpc-stub', version: '1.16.1'])
     compile ([group: 'io.grpc', name: 'grpc-protobuf', version: '1.16.1'])
     runtime ([group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.16.1'])
+    testCompile group: 'org.hamcrest', name:'hamcrest-core', version:'1.3'
     testCompile group: 'org.hamcrest', name:'hamcrest-library', version:'1.3'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
     testCompile group: 'io.grpc', name:'grpc-testing', version:'1.16.1'
 }

--- a/core/native.gradle
+++ b/core/native.gradle
@@ -36,8 +36,16 @@ def javaIncludeDir = new File(System.env.'JAVA_HOME', "include")
 def programFilesX86 = System.env.'ProgramFiles(x86)'
 def referenceAssembliesDir = new File("$programFilesX86\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v4.5")
 
-def winSdkDir = System.env.APPINSIGHTS_WIN_SDK_PATH ?: "C:\\Program Files (x86)\\Windows Kits\\8.1"
-def vsToolsDir = System.env.APPINSIGHTS_VS_PATH ?: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
+def winSdkDir = "C:\\Program Files (x86)\\Windows Kits\\8.1"
+if (System.env.APPINSIGHTS_WIN_SDK_PATH) {
+    winSdkDir = System.env.APPINSIGHTS_WIN_SDK_PATH
+    println "Using custom Windows SDK path: $winSdkDir"
+}
+def vsToolsDir = "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
+if (System.env.APPINSIGHTS_VS_PATH) {
+    vsToolsDir = System.env.APPINSIGHTS_VS_PATH
+    println "Using customer Visual Studio Tools path: $vsToolsDir"
+}
 
 // region Native binary definition and configuration
 model {

--- a/core/native.gradle
+++ b/core/native.gradle
@@ -44,7 +44,7 @@ if (System.env.APPINSIGHTS_WIN_SDK_PATH) {
 def vsToolsDir = "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
 if (System.env.APPINSIGHTS_VS_PATH) {
     vsToolsDir = System.env.APPINSIGHTS_VS_PATH
-    println "Using customer Visual Studio Tools path: $vsToolsDir"
+    println "Using custom Visual Studio Tools path: $vsToolsDir"
 }
 
 // region Native binary definition and configuration

--- a/core/native.gradle
+++ b/core/native.gradle
@@ -33,15 +33,14 @@ buildscript {
 import org.apache.commons.io.FilenameUtils
 
 def javaIncludeDir = new File(System.env.'JAVA_HOME', "include")
-def programFilesX86 = System.env.'ProgramFiles(x86)'
-def referenceAssembliesDir = new File("$programFilesX86\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v4.5")
+def programFilesX86 = System.env.'ProgramFiles(x86)' ?: 'C:\\Program Files (x86)'
 
-def winSdkDir = "C:\\Program Files (x86)\\Windows Kits\\8.1"
+def winSdkDir = "$programFilesX86\\Windows Kits\\8.1"
 if (System.env.APPINSIGHTS_WIN_SDK_PATH) {
     winSdkDir = System.env.APPINSIGHTS_WIN_SDK_PATH
     println "Using custom Windows SDK path: $winSdkDir"
 }
-def vsToolsDir = "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0"
+def vsToolsDir = "$programFilesX86\\Microsoft Visual Studio 14.0"
 if (System.env.APPINSIGHTS_VS_PATH) {
     vsToolsDir = System.env.APPINSIGHTS_VS_PATH
     println "Using custom Visual Studio Tools path: $vsToolsDir"
@@ -105,12 +104,6 @@ model {
 
                     // Produces an output file to run on the common language runtime.
                     cppCompiler.args "/clr"
-
-                    // Forces the use of a file name as if it had been passed to the #using directive.
-                    cppCompiler.args "/FU$referenceAssembliesDir\\mscorlib.dll"
-                    cppCompiler.args "/FU$referenceAssembliesDir\\System.Data.dll"
-                    cppCompiler.args "/FU$referenceAssembliesDir\\System.dll"
-                    cppCompiler.args "/FU$referenceAssembliesDir\\System.Xml.dll"
 
                     // Sets warning level.
                     cppCompiler.args "/W3"

--- a/core/src/windows/cpp/CppPerfCounters.cpp
+++ b/core/src/windows/cpp/CppPerfCounters.cpp
@@ -25,6 +25,11 @@
 
 #include <string>
 
+#using <System.dll> as_friend
+#using <mscorlib.dll> as_friend
+#using <System.Data.dll> as_friend
+#using <System.Xml.dll> as_friend
+
 using System::Text::Encoding;
 using namespace System::Reflection;
 using namespace System;

--- a/logging/logging.gradle
+++ b/logging/logging.gradle
@@ -61,14 +61,14 @@ findbugs.sourceSets = [sourceSets.main]
 // region Publishing properties
 
 whenPomConfigured = { p ->
-    p.dependencies = p.dependencies.findAll { dep -> dep.scope == "test" || dep.artifactId != "junit" && dep.artifactId != "mockito-all" }
+    p.dependencies = p.dependencies.findAll { dep -> dep.scope == "test" || dep.artifactId != "junit" && dep.artifactId != "mockito-core" }
 }
 
 // endregion Publishing properties
 
 dependencies {
     compile project(':core')
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
 }
 

--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -27,9 +27,10 @@ subprojects {
 	dependencies {
 		smokeTestCompile project(':test:smoke:framework:testCore')
 		smokeTestCompile project(':test:smoke:framework:utils')
+		smokeTestCompile 'org.hamcrest:hamcrest-core:1.3'
 		smokeTestCompile 'org.hamcrest:hamcrest-library:1.3'
 		smokeTestCompile 'junit:junit:4.12'
-		
+
 		testCompile project(':test:smoke:framework:testCore') // not necessary; vs code bug workaround
 		testCompile project(':test:smoke:framework:utils')
 		testCompile 'junit:junit:4.12'

--- a/test/smoke/testApps/build.gradle
+++ b/test/smoke/testApps/build.gradle
@@ -27,8 +27,8 @@ subprojects {
 	dependencies {
 		smokeTestCompile project(':test:smoke:framework:testCore')
 		smokeTestCompile project(':test:smoke:framework:utils')
-		smokeTestCompile 'junit:junit:4.12'
 		smokeTestCompile 'org.hamcrest:hamcrest-library:1.3'
+		smokeTestCompile 'junit:junit:4.12'
 		
 		testCompile project(':test:smoke:framework:testCore') // not necessary; vs code bug workaround
 		testCompile project(':test:smoke:framework:utils')

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -39,9 +39,10 @@ dependencies {
     provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'
     provided group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
     provided group: 'javax.enterprise', name: 'cdi-api', version: '1.1' // Java EE
+    testCompile group: 'org.hamcrest', name:'hamcrest-core', version:'1.3'
     testCompile group: 'org.hamcrest', name:'hamcrest-library', version:'1.3'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.14.v20181114'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.15.v20190215'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-servlets', version: '9.4.15.v20190215'

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'
     provided group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
     provided group: 'javax.enterprise', name: 'cdi-api', version: '1.1' // Java EE
+    testCompile group: 'org.hamcrest', name:'hamcrest-library', version:'1.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.14.v20181114'
@@ -48,7 +49,6 @@ dependencies {
     testCompile group: 'org.json', name:'json', version:'20090211'
     testCompile group: 'com.microsoft.azure', name: 'azure-storage', version: '2.1.0'
     testCompile group: 'com.google.guava', name: 'guava', version: '20.0'
-    testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.3'
 }
 
 shadowJar {


### PR DESCRIPTION
* Fixes issues with the hamcrest/mockito/junit combo.
* Adds env vars `APPINSIGHTS_WIN_SDK_PATH` and `APPINSIGHTS_VS_PATH` for specifying the location of the Windows SDK and Visual Studio build tools, respectively.
* Update native.gradle to not need absolute paths for .net reference assemblies (remove /FU option and add `#using` directive)

