### PR TITLE
command name string comparison case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix [#898](https://github.com/Microsoft/ApplicationInsights-Java/issues/898) Increase persistent http connection validation
 timeout period.
 - Upgrade gradle to 5.3.1
+- Fix [#907](https://github.com/microsoft/ApplicationInsights-Java/issues/907) - ensure string compare is case insensitive when running a SQL explain on a select statement. 
 
 # Version 2.4.0-BETA
 - Removed support for multiple apps instrumented with single JVM Agent. Instrumentation will only work for single apps

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/agent/CoreAgentNotificationsHandler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/agent/CoreAgentNotificationsHandler.java
@@ -556,7 +556,7 @@ final class CoreAgentNotificationsHandler implements AgentNotificationsHandler {
         Statement explain = null;
         ResultSet rs = null;
         try {
-            if (commandName.startsWith("SELECT ")) {
+            if (commandName.toLowerCase().startsWith("select ")) {
                 Connection connection = (Connection)object;
                 if (connection == null) {
                     return explainSB;


### PR DESCRIPTION
Make the Explain query string comparison continue regardless of the casing (upper, lower, mixed) for a statement starting with `SELECT`.

Fix #907 .


For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated
