### PR TITLE
Accessor fixes

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixParsingState.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixParsingState.java
@@ -24,11 +24,46 @@ package com.microsoft.applicationinsights.internal.perfcounter;
 /**
  * Created by gupele on 3/16/2015.
  */
+@SuppressWarnings("deprecation")
 public class UnixParsingState {
+    // TODO v3 fields private
+    /**
+     * @deprecated use {@link #getDoneCounter()} and {@link #setDoneCounter(int)}
+     */
+    @Deprecated
     public int doneCounter;
+
+    /**
+     * @deprecated use {@link #getDoneCounter()} and {@link #setDoneCounter(int)}
+     */
+    @Deprecated
     public double returnValue;
 
     public UnixParsingState(int doneCounter) {
         this.doneCounter = doneCounter;
+    }
+
+    public int getDoneCounter() {
+        return doneCounter;
+    }
+
+    public void setDoneCounter(int doneCounter) {
+        this.doneCounter = doneCounter;
+    }
+
+    public void decrementDoneCounter() {
+        this.doneCounter--;
+    }
+
+    public double getReturnValue() {
+        return returnValue;
+    }
+
+    public void setReturnValue(double returnValue) {
+        this.returnValue = returnValue;
+    }
+
+    public void addToReturnValue(double addend) {
+        this.returnValue += addend;
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOtParser.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOtParser.java
@@ -28,33 +28,28 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  * Created by gupele on 3/16/2015.
  */
 final class UnixProcessIOtParser {
-    private final static String READ_BYTES_PART = "read_bytes:";
-    private final static String WRITE_BYTES_PART = "write_bytes:";
+    private static final String READ_BYTES_PART = "read_bytes:";
+    private static final String WRITE_BYTES_PART = "write_bytes:";
 
-    UnixParsingState state = new UnixParsingState(2);
-    boolean readBytesDone = false;
-    boolean writeBytesDone = false;
+    private UnixParsingState state = new UnixParsingState(2);
+    private boolean readBytesDone = false;
+    private boolean writeBytesDone = false;
 
     boolean done() {
-        return state.doneCounter == 0;
+        return state.getDoneCounter() == 0;
     }
 
     double getValue() {
-        return state.returnValue;
+        return state.getReturnValue();
     }
 
     void process(String line) {
-        if (!readBytesDone) {
-            if (parseValue(line, READ_BYTES_PART)) {
-                readBytesDone = true;
-                return;
-            }
+        if (!readBytesDone && parseValue(line, READ_BYTES_PART)) {
+            readBytesDone = true;
+            return;
         }
-        if (!writeBytesDone) {
-            if (parseValue(line, WRITE_BYTES_PART)) {
-                writeBytesDone = true;
-                return;
-            }
+        if (!writeBytesDone && parseValue(line, WRITE_BYTES_PART)) {
+            writeBytesDone = true;
         }
     }
 
@@ -63,8 +58,8 @@ final class UnixProcessIOtParser {
         if (index != -1) {
             String doubleValueAsString = line.substring(index + part.length());
             try {
-                state.returnValue += Double.valueOf(doubleValueAsString.trim());
-                --(state.doneCounter);
+                state.addToReturnValue(Double.parseDouble(doubleValueAsString.trim()));
+                state.decrementDoneCounter();
                 return true;
             } catch (Exception e) {
                 InternalLogger.INSTANCE.error("Error in parsing value of UnixProcess counter");

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalMemInfoParser.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalMemInfoParser.java
@@ -25,17 +25,17 @@ package com.microsoft.applicationinsights.internal.perfcounter;
  * Created by gupele on 3/16/2015.
  */
 final class UnixTotalMemInfoParser {
-    private final static String MEM_FREE_PREFIX = "MemFree:";
-    private final static String BUFFERS_PREFIX = "Buffers";
-    private final static String CACHED_PREFIX = "Cached";
+    private static final String MEM_FREE_PREFIX = "MemFree:";
+    private static final String BUFFERS_PREFIX = "Buffers";
+    private static final String CACHED_PREFIX = "Cached";
 
-    boolean memFreeDone = false;
-    boolean buffersDone = false;
-    boolean cachedDone = false;
-    UnixParsingState state = new UnixParsingState(3);
+    private boolean memFreeDone = false;
+    private boolean buffersDone = false;
+    private boolean cachedDone = false;
+    private UnixParsingState state = new UnixParsingState(3);
 
     boolean done() {
-        return state.doneCounter == 0;
+        return state.getDoneCounter() == 0;
     }
 
     void process(String line) {
@@ -43,28 +43,23 @@ final class UnixTotalMemInfoParser {
             return;
         }
 
-        if (!memFreeDone) {
-            if (parseValue(state, line, MEM_FREE_PREFIX)) {
-                memFreeDone = true;
-                return;
-            }
+        if (!memFreeDone && parseValue(state, line, MEM_FREE_PREFIX)) {
+            memFreeDone = true;
+            return;
         }
-        if (!buffersDone) {
-            if (parseValue(state, line, BUFFERS_PREFIX)) {
-                buffersDone = true;
-                return;
-            }
+
+        if (!buffersDone && parseValue(state, line, BUFFERS_PREFIX)) {
+            buffersDone = true;
+            return;
         }
-        if (!cachedDone) {
-            if (parseValue(state, line, CACHED_PREFIX)) {
-                cachedDone = true;
-                return;
-            }
+
+        if (!cachedDone && parseValue(state, line, CACHED_PREFIX)) {
+            cachedDone = true;
         }
     }
 
     public double getValue() {
-        return state.returnValue;
+        return state.getReturnValue();
     }
 
     private boolean parseValue(UnixParsingState parsingData, String line, String part) {
@@ -72,8 +67,8 @@ final class UnixTotalMemInfoParser {
         if (index != -1) {
             line = line.trim();
             String[] strings = line.split(" ");
-            parsingData.returnValue += Double.valueOf(strings[strings.length - 2]);
-            --(parsingData.doneCounter);
+            parsingData.addToReturnValue(Double.parseDouble(strings[strings.length - 2]));
+            parsingData.decrementDoneCounter();
             return true;
         }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
@@ -109,15 +109,15 @@ public final class WindowsPerformanceCounterAsMetric extends AbstractWindowsPerf
     private void register(Iterable<WindowsPerformanceCounterData> pcsData) {
         for (WindowsPerformanceCounterData data : pcsData) {
             try {
-                String key = JniPCConnector.addPerformanceCounter(data.categoryName, data.counterName, data.instanceName);
+                String key = JniPCConnector.addPerformanceCounter(data.getCategoryName(), data.getCounterName(), data.getInstanceName());
                 if (!StringUtils.isEmpty(key)) {
-                    keyToDisplayName.put(key, data.displayName);
+                    keyToDisplayName.put(key, data.getDisplayName());
                 }
             } catch (ThreadDeath td) {
             	throw td;
             } catch (Throwable t) {
                 try {
-                    InternalLogger.INSTANCE.trace("error registering %s, Stack trace generated is %s", data.displayName, ExceptionUtils.getStackTrace(t));
+                    InternalLogger.INSTANCE.trace("error registering %s, Stack trace generated is %s", data.getDisplayName(), ExceptionUtils.getStackTrace(t));
                 } catch (ThreadDeath td) {
                     throw td;
                 } catch (Throwable t2) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsPC.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsPC.java
@@ -70,19 +70,19 @@ public final class WindowsPerformanceCounterAsPC extends AbstractWindowsPerforma
             try {
                 double value = JniPCConnector.getValueOfPerformanceCounter(entry.getKey());
                 if (value < 0) {
-                    reportError(value, entry.getValue().displayName);
+                    reportError(value, entry.getValue().getDisplayName());
                 } else {
                     send(telemetryClient, value, entry.getValue());
                     WindowsPerformanceCounterData pcData = entry.getValue();
                     InternalLogger.INSTANCE.trace("Sent performance counter for '%s'(%s, %s, %s): '%s'",
-                            pcData.displayName, pcData.categoryName, pcData.counterName, pcData.instanceName, value);
+                            pcData.getDisplayName(), pcData.getCategoryName(), pcData.getCounterName(), pcData.getInstanceName(), value);
                 }
             } catch (ThreadDeath td) {
                 throw td;
             } catch (Throwable e) {
                 try {
                     if (InternalLogger.INSTANCE.isErrorEnabled()) {
-                        InternalLogger.INSTANCE.error("Failed to send performance counter for '%s': %s", entry.getValue().displayName, ExceptionUtils.getStackTrace(e));
+                        InternalLogger.INSTANCE.error("Failed to send performance counter for '%s': %s", entry.getValue().getDisplayName(), ExceptionUtils.getStackTrace(e));
                     }
                 } catch (ThreadDeath td) {
                     throw td;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterData.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterData.java
@@ -29,11 +29,48 @@ import com.google.common.base.Strings;
 /**
  * Created by gupele on 3/30/2015.
  */
+@SuppressWarnings("deprecation")
 public final class WindowsPerformanceCounterData {
+    // TODO v3 make fields private
+    /**
+     * @deprecated use {@link #getDisplayName()}
+     */
+    @Deprecated
     public String displayName;
+
+    /**
+     * @deprecated use {@link #getCategoryName()}
+     */
+    @Deprecated
     public String categoryName;
+
+    /**
+     * @deprecated use {@link #getCounterName()}
+     */
+    @Deprecated
     public String counterName;
+
+    /**
+     * @deprecated use {@link #getInstanceName()}
+     */
+    @Deprecated
     public String instanceName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public String getCounterName() {
+        return counterName;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
 
     public WindowsPerformanceCounterData setDisplayName(String displayName) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(displayName), "displayName must be non-null and non empty value.");

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/QuickPulseDataCollector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/QuickPulseDataCollector.java
@@ -95,18 +95,18 @@ public enum QuickPulseDataCollector {
     }
 
     private static class Counters {
-        private final static long MAX_COUNT = 524287L;
-        private final static long MAX_DURATION = 17592186044415L;
+        private static final long MAX_COUNT = 524287L;
+        private static final long MAX_DURATION = 17592186044415L;
 
-        public AtomicInteger exceptions = new AtomicInteger(0);
+        public static final AtomicInteger exceptions = new AtomicInteger(0);
 
-        public AtomicLong requestsAndDurations = new AtomicLong(0);
-        public AtomicInteger unsuccessfulRequests = new AtomicInteger(0);
+        static final AtomicLong requestsAndDurations = new AtomicLong(0);
+        static final AtomicInteger unsuccessfulRequests = new AtomicInteger(0);
 
-        public AtomicLong rddsAndDuations = new AtomicLong(0);
-        public AtomicInteger unsuccessfulRdds = new AtomicInteger(0);
+        static final AtomicLong rddsAndDuations = new AtomicLong(0);
+        static final AtomicInteger unsuccessfulRdds = new AtomicInteger(0);
 
-        public static long encodeCountAndDuration(long  count, long duration) {
+        static long encodeCountAndDuration(long  count, long duration) {
             if (count > MAX_COUNT || duration > MAX_DURATION) {
                 return 0;
             }
@@ -114,7 +114,7 @@ public enum QuickPulseDataCollector {
             return (count << 44) + duration;
         }
 
-        public static CountAndDuration decodeCountAndDuration(long countAndDuration) {
+        static CountAndDuration decodeCountAndDuration(long countAndDuration) {
             return new CountAndDuration(countAndDuration >> 44, countAndDuration & MAX_DURATION);
         }
     }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterDataTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterDataTest.java
@@ -39,10 +39,10 @@ public final class WindowsPerformanceCounterDataTest {
                 setInstanceName(MOCK_INSTANCE).
                 setDisplayName(MOCK_DISPLAY);
 
-        assertEquals(MOCK_CATEGORY, data.categoryName);
-        assertEquals(MOCK_COUNTER, data.counterName);
-        assertEquals(MOCK_INSTANCE, data.instanceName);
-        assertEquals(MOCK_DISPLAY, data.displayName);
+        assertEquals(MOCK_CATEGORY, data.getCategoryName());
+        assertEquals(MOCK_COUNTER, data.getCounterName());
+        assertEquals(MOCK_INSTANCE, data.getInstanceName());
+        assertEquals(MOCK_DISPLAY, data.getDisplayName());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
`UnixParsingState` and `WindowsPerformanceCounterData` missing accessors, making it possible to circumvent the setters with validation.

I'm deprecating the fields since their public facing. For v3, they'll be made private and deprecation removed.