### PR TITLE
Optimize smoke tests channel config

### DIFF
--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentConfigurationDefaultImpl.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/AgentConfigurationDefaultImpl.java
@@ -35,7 +35,7 @@ final class AgentConfigurationDefaultImpl implements AgentConfiguration {
     private boolean selfRegistrationMode = false;
     private boolean debugMode = false;
     private String sdkPath;
-    private Map<String, ClassInstrumentationData> classesToInstrument;
+    private Map<String, ClassInstrumentationData> classesToInstrument = new HashMap<>();
     private Map<String, String> agentLoggerConfiguration;
     private AgentBuiltInConfiguration builtInConfiguration = new AgentBuiltInConfigurationBuilder().create();
     private Set<String> excludedPrefixes = new HashSet<String>();

--- a/agent/src/test/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationTest.java
+++ b/agent/src/test/java/com/microsoft/applicationinsights/agent/internal/config/XmlAgentConfigurationTest.java
@@ -33,7 +33,7 @@ public final class XmlAgentConfigurationTest {
     public void testCtor() {
         AgentConfigurationDefaultImpl tested = new AgentConfigurationDefaultImpl();
         assertFalse(tested.getBuiltInConfiguration().isEnabled());
-        assertNull(tested.getRequestedClassesToInstrument());
+        assertTrue(tested.getRequestedClassesToInstrument().isEmpty());
     }
 
     @Test

--- a/test/smoke/framework/utils/build.gradle
+++ b/test/smoke/framework/utils/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compile 'org.apache.httpcomponents:httpclient:4.5.3'
 	compile 'com.google.guava:guava:20.0'
 	compile 'org.apache.commons:commons-lang3:3.7'
+	compile 'org.hamcrest:hamcrest-library:1.3'
 	compile aiCoreJar
 
 	testCompile 'junit:junit:4.12'

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/ExceptionDataMatchers.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/ExceptionDataMatchers.java
@@ -1,0 +1,67 @@
+package com.microsoft.applicationinsights.smoketest.matchers;
+
+import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
+import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
+import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+
+public class ExceptionDataMatchers {
+
+    public static Matcher<ExceptionData> hasSeverityLevel(SeverityLevel level) {
+        return new FeatureMatcher<ExceptionData, SeverityLevel>(equalTo(level), "seveirity level to be", "severity level") {
+
+            @Override
+            protected SeverityLevel featureValueOf(ExceptionData actual) {
+                return actual.getSeverityLevel();
+            }
+        };
+    }
+
+    public static Matcher<ExceptionData> hasProperty(String key, String value) {
+        return new FeatureMatcher<ExceptionData, Map<String, String>>(hasEntry(key, value), "ExceptionData with property", "") {
+
+            @Override
+            protected Map<String, String> featureValueOf(ExceptionData actual) {
+                return actual.getProperties();
+            }
+        };
+    }
+
+    public static Matcher<ExceptionData> hasMeasurement(String key, Double value) {
+        return new FeatureMatcher<ExceptionData, Map<String, Double>>(hasEntry(key, value), "ExceptionData with measurement", "") {
+
+            @Override
+            protected Map<String, Double> featureValueOf(ExceptionData actual) {
+                return actual.getMeasurements();
+            }
+        };
+    }
+
+    public static Matcher<ExceptionData> hasException(Matcher<ExceptionDetails> exception) {
+        return new FeatureMatcher<ExceptionData, List<ExceptionDetails>>(hasItem(exception), "ExceptionData with exception", "") {
+
+            @Override
+            protected List<ExceptionDetails> featureValueOf(ExceptionData actual) {
+                return actual.getExceptions();
+            }
+        };
+    }
+
+    public static class ExceptionDetailsMatchers {
+        public static Matcher<ExceptionDetails> withMessage(String message) {
+            return new FeatureMatcher<ExceptionDetails, String>(equalTo(message), "ExceptionDetails with message", "message") {
+
+                @Override
+                protected String featureValueOf(ExceptionDetails actual) {
+                    return actual.getMessage();
+                }
+            };
+        }
+    }
+}

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/PageViewDataMatchers.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/PageViewDataMatchers.java
@@ -1,0 +1,39 @@
+package com.microsoft.applicationinsights.smoketest.matchers;
+
+import com.microsoft.applicationinsights.internal.schemav2.PageViewData;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+
+public class PageViewDataMatchers {
+    public static Matcher<PageViewData> hasName(String name) {
+        return new FeatureMatcher<PageViewData, String>(equalTo(name), "PageViewData with name", "name") {
+            @Override
+            protected String featureValueOf(PageViewData actual) {
+                return actual.getName();
+            }
+        };
+    }
+
+    public static Matcher<PageViewData> hasDuration(Duration duration) {
+        return new FeatureMatcher<PageViewData, Duration>(equalTo(duration), "PageViewData with duration", "duration") {
+            @Override
+            protected Duration featureValueOf(PageViewData actual) {
+                return actual.getDuration();
+            }
+        };
+    }
+
+    public static Matcher<PageViewData> hasProperty(String key, String value) {
+        return new FeatureMatcher<PageViewData, Map<String, String>>(hasEntry(key, value), "PageViewData with property", "property") {
+            @Override
+            protected Map<String, String> featureValueOf(PageViewData actual) {
+                return actual.getProperties();
+            }
+        };
+    }
+}

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/RequestDataMatchers.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/RequestDataMatchers.java
@@ -1,0 +1,55 @@
+package com.microsoft.applicationinsights.smoketest.matchers;
+
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.Matchers.*;
+
+public class RequestDataMatchers {
+    public static Matcher<RequestData> hasName(String name) {
+        return new FeatureMatcher<RequestData, String>(equalTo(name), "RequestData with name", "name") {
+            @Override
+            protected String featureValueOf(RequestData actual) {
+                return actual.getName();
+            }
+        };
+    }
+
+    public static Matcher<RequestData> hasDuration(Duration duration) {
+        return new FeatureMatcher<RequestData, Duration>(equalTo(duration), "RequestData with duration", "duration") {
+            @Override
+            protected Duration featureValueOf(RequestData actual) {
+                return actual.getDuration();
+            }
+        };
+    }
+
+    public static Matcher<RequestData> hasSuccess(boolean success) {
+        return new FeatureMatcher<RequestData, Boolean>(equalTo(success), "RequestData with success", "success") {
+            @Override
+            protected Boolean featureValueOf(RequestData actual) {
+                return actual.getSuccess();
+            }
+        };
+    }
+
+    public static Matcher<RequestData> hasResponseCode(String responseCode) {
+        return new FeatureMatcher<RequestData, String>(equalTo(responseCode), "RequestData with response code", "response code") {
+            @Override
+            protected String featureValueOf(RequestData actual) {
+                return actual.getResponseCode();
+            }
+        };
+    }
+
+    public static Matcher<RequestData> hasUrl(String url) {
+        return new FeatureMatcher<RequestData, String>(equalTo(url), "ReqeustData with url", "url") {
+            @Override
+            protected String featureValueOf(RequestData actual) {
+                return actual.getUrl();
+            }
+        };
+    }
+}

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/TraceDataMatchers.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/TraceDataMatchers.java
@@ -1,0 +1,39 @@
+package com.microsoft.applicationinsights.smoketest.matchers;
+
+import com.microsoft.applicationinsights.internal.schemav2.MessageData;
+import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+
+public class TraceDataMatchers {
+    public static Matcher<MessageData> hasMessage(String expectedMessage) {
+        return new FeatureMatcher<MessageData, String>(equalTo(expectedMessage), "MessageData with message", "message") {
+            @Override
+            protected String featureValueOf(MessageData actual) {
+                return actual.getMessage();
+            }
+        };
+    }
+
+    public static Matcher<MessageData> hasSeverityLevel(SeverityLevel severityLevel) {
+        return new FeatureMatcher<MessageData, SeverityLevel>(equalTo(severityLevel), "MessageData with SeverityLevel", "SeverityLevel") {
+            @Override
+            protected SeverityLevel featureValueOf(MessageData actual) {
+                return actual.getSeverityLevel();
+            }
+        };
+    }
+
+    public static Matcher<MessageData> hasProperty(String key, String value) {
+        return new FeatureMatcher<MessageData, Map<String, String>>(hasEntry(key, value), "MessageData with property", "property") {
+            @Override
+            protected Map<String, String> featureValueOf(MessageData actual) {
+                return actual.getProperties();
+            }
+        };
+    }
+}

--- a/test/smoke/testApps/AutoPerfCounters/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/AutoPerfCounters/src/main/resources/ApplicationInsights.xml
@@ -34,5 +34,7 @@
 	<Channel>
         <!-- <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress> -->
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
     </Channel>
 </ApplicationInsights>

--- a/test/smoke/testApps/CachingCalculator/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/CachingCalculator/src/main/resources/ApplicationInsights.xml
@@ -35,5 +35,7 @@
 	<Channel>
 		<!-- <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress> -->
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
 	</Channel>
 </ApplicationInsights>

--- a/test/smoke/testApps/CoreAndFilter/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/CoreAndFilter/src/main/resources/ApplicationInsights.xml
@@ -35,6 +35,8 @@
 	<Channel>
         <!-- <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress> -->
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
     </Channel>
 	<PerformanceCounters>
 		<UseBuiltIn>False</UseBuiltIn>

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -2,6 +2,7 @@ package com.microsoft.applicationinsights.smoketest;
 
 import com.microsoft.applicationinsights.internal.schemav2.DataPoint;
 import com.microsoft.applicationinsights.internal.schemav2.DataPointType;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.EventData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
@@ -11,11 +12,17 @@ import com.microsoft.applicationinsights.internal.schemav2.PageViewData;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
+import com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers;
+import com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.ExceptionDetailsMatchers;
 import com.microsoft.applicationinsights.telemetry.Duration;
 
 
 import org.junit.*;
 
+import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.ExceptionDetailsMatchers.withMessage;
+import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.hasException;
+import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.hasMeasurement;
+import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.hasSeverityLevel;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -86,20 +93,31 @@ public class CoreAndFilterTests extends AiSmokeTest {
         final String expectedProperties = "value";
         final Double expectedMetrice = 1d;
 
-        ExceptionData d = getTelemetryDataForType(0, "ExceptionData");
-        ExceptionDetails eDetails = getExceptionDetails(d);
-        assertEquals(expectedName, eDetails.getMessage());
+        final List<ExceptionData> exceptions = mockedIngestion.getTelemetryDataByType("ExceptionData");
+        assertThat(exceptions, hasItem(hasException(withMessage(expectedName))));
 
-        ExceptionData d2 = getTelemetryDataForType(1, "ExceptionData");
-        ExceptionDetails eDetails2 = getExceptionDetails(d2);
-        assertEquals(expectedName, eDetails2.getMessage());
-        assertEquals(expectedProperties, d2.getProperties().get("key"));
-        assertEquals(expectedMetrice, d2.getMeasurements().get("key"));
+//        ExceptionData d = getTelemetryDataForType(0, "ExceptionData");
+//        ExceptionDetails eDetails = getExceptionDetails(d);
+//        assertEquals(expectedName, eDetails.getMessage());
 
-        ExceptionData d3 = getTelemetryDataForType(2, "ExceptionData");
-        ExceptionDetails eDetails3 = getExceptionDetails(d3);
-        assertEquals(expectedName, eDetails3.getMessage());
-        assertEquals(SeverityLevel.Error, d3.getSeverityLevel());
+        assertThat(exceptions, hasItem(allOf(
+                hasException(withMessage(expectedName)),
+                ExceptionDataMatchers.hasProperty("key", expectedProperties),
+                hasMeasurement("key", expectedMetrice))));
+//        ExceptionData d2 = getTelemetryDataForType(1, "ExceptionData");
+//        ExceptionDetails eDetails2 = getExceptionDetails(d2);
+//        assertEquals(expectedName, eDetails2.getMessage());
+//        assertEquals(expectedProperties, d2.getProperties().get("key"));
+//        assertEquals(expectedMetrice, d2.getMeasurements().get("key"));
+
+        assertThat(exceptions, hasItem(allOf(
+                hasException(withMessage(expectedName)),
+                hasSeverityLevel(SeverityLevel.Error)
+        )));
+//        ExceptionData d3 = getTelemetryDataForType(2, "ExceptionData");
+//        ExceptionDetails eDetails3 = getExceptionDetails(d3);
+//        assertEquals(expectedName, eDetails3.getMessage());
+//        assertEquals(SeverityLevel.Error, d3.getSeverityLevel());
     }
 
 

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -15,10 +15,12 @@ import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
 import com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers;
 import com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.ExceptionDetailsMatchers;
+import com.microsoft.applicationinsights.smoketest.matchers.PageViewDataMatchers;
 import com.microsoft.applicationinsights.smoketest.matchers.RequestDataMatchers;
 import com.microsoft.applicationinsights.telemetry.Duration;
 
 
+import com.microsoft.localforwarder.library.inputs.contracts.PageView;
 import org.junit.*;
 
 import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.ExceptionDetailsMatchers.withMessage;
@@ -121,58 +123,26 @@ public class CoreAndFilterTests extends AiSmokeTest {
         // TODO get HttpRequest data envelope and verify value
         final List<Domain> requests = mockedIngestion.getTelemetryDataByType("RequestData");
         //true
-//        RequestData d = getTelemetryDataForType(0, "RequestData");
-        final String expectedName = "HttpRequestDataTest";
-        final String expectedResponseCode = "200";
-
-//        assertEquals(expectedName, d.getName());
-//        assertEquals(expectedResponseCode, d.getResponseCode());
-//        assertEquals(new Duration(4711), d.getDuration());
-//        assertEquals(true, d.getSuccess());
         assertThat(requests, hasItem(allOf(
-                hasName(expectedName),
-                hasResponseCode(expectedResponseCode),
+                hasName("HttpRequestDataTest"),
+                hasResponseCode("200"),
                 hasDuration(new Duration(4711)),
                 hasSuccess(true))));
-
-//        RequestData d1 = getTelemetryDataForType(1, "RequestData");
-
-        final String expectedName1 = "PingTest";
-        final String expectedResponseCode1 = "200";
-        final String expectedURL = "http://tempuri.org/ping";
-
-//        assertEquals(expectedName1, d1.getName());
-//        assertEquals(expectedResponseCode1, d1.getResponseCode());
-//        assertEquals(new Duration(1), d1.getDuration());
-//        assertEquals(true, d1.getSuccess());
-//        assertEquals(expectedURL, d1.getUrl());
         assertThat(requests, hasItem(allOf(
-                hasName(expectedName1),
-                hasResponseCode(expectedResponseCode1),
+                hasName("PingTest"),
+                hasResponseCode("200"),
                 hasDuration(new Duration(1)),
                 hasSuccess(true),
-                hasUrl(expectedURL)
+                hasUrl("http://tempuri.org/ping")
         )));
 
         //false
-//        RequestData rd1 = getTelemetryDataForType(2, "RequestData");
-//        assertEquals("FailedHttpRequest", rd1.getName());
-//        assertEquals("404", rd1.getResponseCode());
-//        assertEquals(new Duration(6666), rd1.getDuration());
-//        assertEquals(false, rd1.getSuccess());
         assertThat(requests, hasItem(allOf(
                 hasName("FailedHttpRequest"),
                 hasResponseCode("404"),
                 hasDuration(new Duration(6666)),
                 hasSuccess(false)
         )));
-
-//        RequestData rd2 = getTelemetryDataForType(3, "RequestData");
-//        assertEquals("FailedHttpRequest2", rd2.getName());
-//        assertEquals("505", rd2.getResponseCode());
-//        assertEquals(new Duration(8888), rd2.getDuration());
-//        assertEquals(false, rd2.getSuccess());
-//        assertEquals("https://www.bingasdasdasdasda.com/", rd2.getUrl());
         assertThat(requests, hasItem(allOf(
                 hasName("FailedHttpRequest2"),
                 hasResponseCode("505"),
@@ -244,14 +214,17 @@ public class CoreAndFilterTests extends AiSmokeTest {
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
         assertEquals(2, mockedIngestion.getCountForType("PageViewData"));
 
-        PageViewData pv1 = getTelemetryDataForType(0, "PageViewData");
-        assertEquals("test-page", pv1.getName());
-        assertEquals(new Duration(0), pv1.getDuration());
+        final List<Domain> pageViews = mockedIngestion.getTelemetryDataByType("PageViewData");
+        assertThat(pageViews, hasItem(allOf(
+                PageViewDataMatchers.hasName("test-page"),
+                PageViewDataMatchers.hasDuration(new Duration(0))
+        )));
 
-        PageViewData pv2 = getTelemetryDataForType(1, "PageViewData");
-        assertEquals("test-page-2", pv2.getName());
-        assertEquals(new Duration(123456), pv2.getDuration());
-        assertEquals("value", pv2.getProperties().get("key"));
+        assertThat(pageViews, hasItem(allOf(
+                PageViewDataMatchers.hasName("test-page-2"),
+                PageViewDataMatchers.hasDuration(new Duration(123456)),
+                PageViewDataMatchers.hasProperty("key", "value")
+        )));
     }
 
     @Test

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -2,6 +2,7 @@ package com.microsoft.applicationinsights.smoketest;
 
 import com.microsoft.applicationinsights.internal.schemav2.DataPoint;
 import com.microsoft.applicationinsights.internal.schemav2.DataPointType;
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.EventData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
@@ -14,6 +15,7 @@ import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.internal.schemav2.SeverityLevel;
 import com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers;
 import com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.ExceptionDetailsMatchers;
+import com.microsoft.applicationinsights.smoketest.matchers.RequestDataMatchers;
 import com.microsoft.applicationinsights.telemetry.Duration;
 
 
@@ -23,6 +25,7 @@ import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionData
 import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.hasException;
 import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.hasMeasurement;
 import static com.microsoft.applicationinsights.smoketest.matchers.ExceptionDataMatchers.hasSeverityLevel;
+import static com.microsoft.applicationinsights.smoketest.matchers.RequestDataMatchers.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -95,32 +98,15 @@ public class CoreAndFilterTests extends AiSmokeTest {
 
         final List<ExceptionData> exceptions = mockedIngestion.getTelemetryDataByType("ExceptionData");
         assertThat(exceptions, hasItem(hasException(withMessage(expectedName))));
-
-//        ExceptionData d = getTelemetryDataForType(0, "ExceptionData");
-//        ExceptionDetails eDetails = getExceptionDetails(d);
-//        assertEquals(expectedName, eDetails.getMessage());
-
         assertThat(exceptions, hasItem(allOf(
                 hasException(withMessage(expectedName)),
                 ExceptionDataMatchers.hasProperty("key", expectedProperties),
                 hasMeasurement("key", expectedMetrice))));
-//        ExceptionData d2 = getTelemetryDataForType(1, "ExceptionData");
-//        ExceptionDetails eDetails2 = getExceptionDetails(d2);
-//        assertEquals(expectedName, eDetails2.getMessage());
-//        assertEquals(expectedProperties, d2.getProperties().get("key"));
-//        assertEquals(expectedMetrice, d2.getMeasurements().get("key"));
-
         assertThat(exceptions, hasItem(allOf(
                 hasException(withMessage(expectedName)),
                 hasSeverityLevel(SeverityLevel.Error)
         )));
-//        ExceptionData d3 = getTelemetryDataForType(2, "ExceptionData");
-//        ExceptionDetails eDetails3 = getExceptionDetails(d3);
-//        assertEquals(expectedName, eDetails3.getMessage());
-//        assertEquals(SeverityLevel.Error, d3.getSeverityLevel());
     }
-
-
 
 	@Test
     @TargetUri("/trackHttpRequest")
@@ -133,43 +119,67 @@ public class CoreAndFilterTests extends AiSmokeTest {
                 expectedItems, totalItems);
 
         // TODO get HttpRequest data envelope and verify value
+        final List<Domain> requests = mockedIngestion.getTelemetryDataByType("RequestData");
         //true
-        RequestData d = getTelemetryDataForType(0, "RequestData");
-
+//        RequestData d = getTelemetryDataForType(0, "RequestData");
         final String expectedName = "HttpRequestDataTest";
         final String expectedResponseCode = "200";
 
-        assertEquals(expectedName, d.getName());
-        assertEquals(expectedResponseCode, d.getResponseCode());
-        assertEquals(new Duration(4711), d.getDuration());
-        assertEquals(true, d.getSuccess());
+//        assertEquals(expectedName, d.getName());
+//        assertEquals(expectedResponseCode, d.getResponseCode());
+//        assertEquals(new Duration(4711), d.getDuration());
+//        assertEquals(true, d.getSuccess());
+        assertThat(requests, hasItem(allOf(
+                hasName(expectedName),
+                hasResponseCode(expectedResponseCode),
+                hasDuration(new Duration(4711)),
+                hasSuccess(true))));
 
-        RequestData d1 = getTelemetryDataForType(1, "RequestData");
+//        RequestData d1 = getTelemetryDataForType(1, "RequestData");
 
         final String expectedName1 = "PingTest";
         final String expectedResponseCode1 = "200";
         final String expectedURL = "http://tempuri.org/ping";
 
-        assertEquals(expectedName1, d1.getName());
-        assertEquals(expectedResponseCode1, d1.getResponseCode());
-        assertEquals(new Duration(1), d1.getDuration());
-        assertEquals(true, d1.getSuccess());
-        assertEquals(expectedURL, d1.getUrl());
+//        assertEquals(expectedName1, d1.getName());
+//        assertEquals(expectedResponseCode1, d1.getResponseCode());
+//        assertEquals(new Duration(1), d1.getDuration());
+//        assertEquals(true, d1.getSuccess());
+//        assertEquals(expectedURL, d1.getUrl());
+        assertThat(requests, hasItem(allOf(
+                hasName(expectedName1),
+                hasResponseCode(expectedResponseCode1),
+                hasDuration(new Duration(1)),
+                hasSuccess(true),
+                hasUrl(expectedURL)
+        )));
 
         //false
-        RequestData rd1 = getTelemetryDataForType(2, "RequestData");
-        assertEquals("FailedHttpRequest", rd1.getName());
-        assertEquals("404", rd1.getResponseCode());
-        assertEquals(new Duration(6666), rd1.getDuration());
-        assertEquals(false, rd1.getSuccess());
+//        RequestData rd1 = getTelemetryDataForType(2, "RequestData");
+//        assertEquals("FailedHttpRequest", rd1.getName());
+//        assertEquals("404", rd1.getResponseCode());
+//        assertEquals(new Duration(6666), rd1.getDuration());
+//        assertEquals(false, rd1.getSuccess());
+        assertThat(requests, hasItem(allOf(
+                hasName("FailedHttpRequest"),
+                hasResponseCode("404"),
+                hasDuration(new Duration(6666)),
+                hasSuccess(false)
+        )));
 
-        RequestData rd2 = getTelemetryDataForType(3, "RequestData");
-        assertEquals("FailedHttpRequest2", rd2.getName());
-        assertEquals("505", rd2.getResponseCode());
-        assertEquals(new Duration(8888), rd2.getDuration());
-        assertEquals(false, rd2.getSuccess());
-        assertEquals("https://www.bingasdasdasdasda.com/", rd2.getUrl());
-
+//        RequestData rd2 = getTelemetryDataForType(3, "RequestData");
+//        assertEquals("FailedHttpRequest2", rd2.getName());
+//        assertEquals("505", rd2.getResponseCode());
+//        assertEquals(new Duration(8888), rd2.getDuration());
+//        assertEquals(false, rd2.getSuccess());
+//        assertEquals("https://www.bingasdasdasdasda.com/", rd2.getUrl());
+        assertThat(requests, hasItem(allOf(
+                hasName("FailedHttpRequest2"),
+                hasResponseCode("505"),
+                hasDuration(new Duration(8888)),
+                hasSuccess(false),
+                hasUrl("https://www.bingasdasdasdasda.com/")
+        )));
 	}
 
 	@Test

--- a/test/smoke/testApps/FixedRateSampling/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/FixedRateSampling/src/main/resources/ApplicationInsights.xml
@@ -34,6 +34,8 @@
 	<Channel>
         <!-- <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress> -->
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
     </Channel>
 
 	<PerformanceCounters>

--- a/test/smoke/testApps/HeartBeat/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/HeartBeat/src/main/resources/ApplicationInsights.xml
@@ -33,6 +33,8 @@
 	<Channel>
         <!-- <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress> -->
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
     </Channel>
 	<PerformanceCounters>
 		<UseBuiltIn>False</UseBuiltIn>

--- a/test/smoke/testApps/SpringBootTest/src/main/java/com/springbootstartertest/controller/JdbcTestController.java
+++ b/test/smoke/testApps/SpringBootTest/src/main/java/com/springbootstartertest/controller/JdbcTestController.java
@@ -1,5 +1,6 @@
 package com.springbootstartertest.controller;
 
+import com.google.common.base.Strings;
 import org.hsqldb.jdbc.JDBCDriver;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,9 +13,9 @@ public class JdbcTestController {
     static {
         try {
             setupHsqldb();
-            setupMysql();
-            setupPostgres();
-            setupSqlServer();
+            if (!Strings.isNullOrEmpty(System.getenv("MYSQL"))) setupMysql();
+            if (!Strings.isNullOrEmpty(System.getenv("POSTGRES"))) setupPostgres();
+            if (!Strings.isNullOrEmpty(System.getenv("SQLSERVER"))) setupSqlServer();
             // setupOracle();
         } catch (Exception e) {
             // print stack trace to stdout to make sure it shows up in docker log

--- a/test/smoke/testApps/SpringBootTest/src/main/resources/application.properties
+++ b/test/smoke/testApps/SpringBootTest/src/main/resources/application.properties
@@ -6,5 +6,7 @@ azure.application-insights.default-modules.ProcessPerformanceCountersModule.enab
 azure.application-insights.default-modules.JvmPerformanceCountersModule.enabled=false
 azure.application-insights.heart-beat.enabled=false
 azure.application-insights.quick-pulse.enabled=false
+azure.application-insights.channel.in-process.developer-mode=true
+azure.application-insights.channel.in-process.flush-interval-in-seconds=1
 spring.mvc.favicon.enabled=false
 

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -18,24 +18,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @UseAgent
-// NOTE this test doesn't need dependency containers, but currently all test classes need to specify the dependency
-// containers since they are set up statically in AiSmokeTest
-@WithDependencyContainers({
-        @DependencyContainer(
-                value = "mysql:5",
-                environmentVariables = {"MYSQL_ROOT_PASSWORD=password"},
-                portMapping = "3306",
-                hostnameEnvironmentVariable = "MYSQL"),
-        @DependencyContainer(
-                value = "postgres:11",
-                portMapping = "5432",
-                hostnameEnvironmentVariable = "POSTGRES"),
-        @DependencyContainer(
-                value = "mcr.microsoft.com/mssql/server:2017-latest",
-                environmentVariables = {"ACCEPT_EULA=Y", "SA_PASSWORD=Password1"},
-                portMapping = "1433",
-                hostnameEnvironmentVariable = "SQLSERVER")
-})
 public class SpringbootSmokeTest extends AiSmokeTest {
 
     @Test

--- a/test/smoke/testApps/TraceLog4j1_2/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/TraceLog4j1_2/src/main/resources/ApplicationInsights.xml
@@ -30,6 +30,8 @@
 	<Channel>
         <!-- <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress> -->
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
     </Channel>
 	<PerformanceCounters>
 		<UseBuiltIn>False</UseBuiltIn>

--- a/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -2,6 +2,7 @@ package com.microsoft.applicationinsights.smoketest;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Comparator;
 import java.util.List;
 
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
@@ -18,43 +19,55 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
     @Test
     @TargetUri("/traceLog4j1_2")
     public void testTraceLog4j1_2() {
-        // this doesn't work with jbosseap6; under investigation
+        // FIXME this doesn't work with jbosseap6; under investigation
         Assume.assumeFalse(currentImageName.contains("jbosseap6"));
 
         assertEquals(6, mockedIngestion.getCountForType("MessageData"));
 
-        MessageData md1 = getTelemetryDataForType(0, "MessageData");
+        final List<MessageData> logs = mockedIngestion.getTelemetryDataByType("MessageData");
+        logs.sort(new Comparator<MessageData>() {
+            @Override
+            public int compare(MessageData o1, MessageData o2) {
+                final int i = o1.getSeverityLevel().compareTo(o2.getSeverityLevel());
+                if (i == 0) {
+                    return o1.getProperties().get("LoggingLevel").compareTo(o2.getProperties().get("LoggingLevel"));
+                }
+                return i;
+            }
+        });
+
+        MessageData md1 = logs.get(1);
         assertEquals("This is log4j1.2 trace.", md1.getMessage());
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("Log4j", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
 
-        MessageData md2 = getTelemetryDataForType(1, "MessageData");
+        MessageData md2 = logs.get(0);
         assertEquals("This is log4j1.2 debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("Log4j", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
 
-        MessageData md3 = getTelemetryDataForType(2, "MessageData");
+        MessageData md3 = logs.get(2);
         assertEquals("This is log4j1.2 info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("Log4j", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
 
-        MessageData md4 = getTelemetryDataForType(3, "MessageData");
+        MessageData md4 = logs.get(3);
         assertEquals("This is log4j1.2 warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("Log4j", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
 
 
-        MessageData md5 = getTelemetryDataForType(4, "MessageData");
+        MessageData md5 = logs.get(4);
         assertEquals("This is log4j1.2 error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("Log4j", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
 
-        MessageData md6 = getTelemetryDataForType(5, "MessageData");
+        MessageData md6 = logs.get(5);
         assertEquals("This is log4j1.2 fatal.", md6.getMessage());
         assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
         assertEquals("Log4j", md6.getProperties().get("SourceType"));

--- a/test/smoke/testApps/TraceLog4j2/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/TraceLog4j2/src/main/resources/ApplicationInsights.xml
@@ -28,6 +28,8 @@
 
 	<Channel>
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
     </Channel>
 	<PerformanceCounters>
 		<UseBuiltIn>False</UseBuiltIn>

--- a/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -2,6 +2,7 @@ package com.microsoft.applicationinsights.smoketest;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Comparator;
 import java.util.List;
 
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
@@ -19,38 +20,50 @@ public class TraceLog4j2Test extends AiSmokeTest {
     public void testTraceLog4j2() {
         assertEquals(6, mockedIngestion.getCountForType("MessageData"));
 
-        MessageData md1 = getTelemetryDataForType(0, "MessageData");
+        final List<MessageData> logs = mockedIngestion.getTelemetryDataByType("MessageData");
+        logs.sort(new Comparator<MessageData>() {
+            @Override
+            public int compare(MessageData o1, MessageData o2) {
+                final int i = o1.getSeverityLevel().compareTo(o2.getSeverityLevel());
+                if (i == 0) {
+                    return o1.getProperties().get("LoggingLevel").compareTo(o2.getProperties().get("LoggingLevel"));
+                }
+                return i;
+            }
+        });
+
+        MessageData md1 = logs.get(1);
         assertEquals("This is log4j2 trace.", md1.getMessage());
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("Log4j", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
 
-        MessageData md2 = getTelemetryDataForType(1, "MessageData");
+        MessageData md2 = logs.get(0);
         assertEquals("This is log4j2 debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("Log4j", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
 
-        MessageData md3 = getTelemetryDataForType(2, "MessageData");
+        MessageData md3 = logs.get(2);
         assertEquals("This is log4j2 info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("Log4j", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
 
-        MessageData md4 = getTelemetryDataForType(3, "MessageData");
+        MessageData md4 = logs.get(3);
         assertEquals("This is log4j2 warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("Log4j", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
 
 
-        MessageData md5 = getTelemetryDataForType(4, "MessageData");
+        MessageData md5 = logs.get(4);
         assertEquals("This is log4j2 error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("Log4j", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
 
-        MessageData md6 = getTelemetryDataForType(5, "MessageData");
+        MessageData md6 = logs.get(5);
         assertEquals("This is log4j2 fatal.", md6.getMessage());
         assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
         assertEquals("Log4j", md6.getProperties().get("SourceType"));

--- a/test/smoke/testApps/TraceLogBack/src/main/resources/ApplicationInsights.xml
+++ b/test/smoke/testApps/TraceLogBack/src/main/resources/ApplicationInsights.xml
@@ -29,6 +29,8 @@
 	<Channel>
         <!-- <EndpointAddress>http://localhost:60606/v2/track</EndpointAddress> -->
 		<EndpointAddress>http://fakeingestion:60606/v2/track</EndpointAddress>
+		<DeveloperMode>true</DeveloperMode>
+		<FlushIntervalInSeconds>1</FlushIntervalInSeconds>
     </Channel>
 	<PerformanceCounters>
 		<UseBuiltIn>False</UseBuiltIn>

--- a/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -2,6 +2,7 @@ package com.microsoft.applicationinsights.smoketest;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Comparator;
 import java.util.List;
 
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
@@ -28,31 +29,43 @@ public class TraceLogBackTest extends AiSmokeTest {
     public void testTraceLogBack() {
         assertEquals(5, mockedIngestion.getCountForType("MessageData"));
 
-        MessageData md1 = getTelemetryDataForType(0, "MessageData");
+        final List<MessageData> logs = mockedIngestion.getTelemetryDataByType("MessageData");
+        logs.sort(new Comparator<MessageData>() {
+            @Override
+            public int compare(MessageData o1, MessageData o2) {
+                final int i = o1.getSeverityLevel().compareTo(o2.getSeverityLevel());
+                if (i == 0) {
+                    return o1.getProperties().get("LoggingLevel").compareTo(o2.getProperties().get("LoggingLevel"));
+                }
+                return i;
+            }
+        });
+
+        MessageData md1 = logs.get(1);
         assertEquals("This is logback trace.", md1.getMessage());
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("LOGBack", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
 
-        MessageData md2 = getTelemetryDataForType(1, "MessageData");
+        MessageData md2 = logs.get(0);
         assertEquals("This is logback debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("LOGBack", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
 
-        MessageData md3 = getTelemetryDataForType(2, "MessageData");
+        MessageData md3 = logs.get(2);
         assertEquals("This is logback info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("LOGBack", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
 
-        MessageData md4 = getTelemetryDataForType(3, "MessageData");
+        MessageData md4 = logs.get(3);
         assertEquals("This is logback warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("LOGBack", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
 
-        MessageData md5 = getTelemetryDataForType(4, "MessageData");
+        MessageData md5 = logs.get(4);
         assertEquals("This is logback error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("LOGBack", md5.getProperties().get("SourceType"));


### PR DESCRIPTION
# Main Purpose
1. Alters configuration files to accelerate telemetry buffer flush time.
2. Updates the JdbcTestController to skip init for drivers without hostname var set. This is so `@WithDependencyContainers` could be removed from SpringBootSmokeTest (which does not need dependency containers).

# Side Effects
Two things caused failing tests while making these changes:
1. Npe from the agent:
```
AI_AGENT_MODE=default
Running Jetty:
AI: ERROR 03-07-2019 23:29:29.226+0000, 1(main): cannot parse the correlation format, will defaultto AI proprietory correlation
AI: ERROR 03-07-2019 23:29:29.228+0000, 1(main): cannot parse the correlation format, will defaultto AI proprietory correlation
AI: TRACE 03-07-2019 23:29:29.231+0000, 1(main): Outbound W3C tracing is enabled : false
AI: TRACE 03-07-2019 23:29:29.231+0000, 1(main): Outbound W3C backport mode is enabled : true
AI: TRACE 03-07-2019 23:29:29.232+0000, 1(main): Adding built-in instrumentation
AI: TRACE 03-07-2019 23:29:29.233+0000, 1(main): Adding built-in JDBC Statements instrumentation
AI: TRACE 03-07-2019 23:29:29.234+0000, 1(main): Adding built-in JDBC Prepared Statements instrumentation
AI: TRACE 03-07-2019 23:29:29.239+0000, 1(main): Adding built-in HTTP instrumentation
AI: TRACE 03-07-2019 23:29:29.241+0000, 1(main): Adding built-in Jedis instrumentation
AI: TRACE 03-07-2019 23:29:29.242+0000, 1(main): Adding 'org/mule/module/client/MuleClient'
AI: ERROR 03-07-2019 23:29:29.243+0000, 1(main): Agent is NOT activated: failed to initialize CodeInjector: 'java.lang.NullPointerException
        at com.microsoft.applicationinsights.agent.internal.agent.DefaultClassDataProvider.setConfiguration(DefaultClassDataProvider.java:109)
        at com.microsoft.applicationinsights.agent.internal.agent.CodeInjector.loadConfiguration(CodeInjector.java:113)
        at com.microsoft.applicationinsights.agent.internal.agent.CodeInjector.<init>(CodeInjector.java:50)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at com.microsoft.applicationinsights.agent.internal.agent.AgentImplementation.initializeCodeInjector(AgentImplementation.java:94)
        at com.microsoft.applicationinsights.agent.internal.agent.AgentImplementation.premain(AgentImplementation.java:62)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
        at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
'
2019-07-03 23:29:29.787:INFO::main: Logging initialized @701ms to org.eclipse.jetty.util.log.StdErrLog
2019-07-03 23:29:30.032:INFO::main: Console stderr/stdout captured to /opt/jetty-base/logs/2019_07_03.jetty.log
```
This appeared to be the only place this could be thrown.

2. The event test sends two events but expects them in a particular order. Since things are being sent faster, that ordering is less probable (but still likely). This change just removes that factor. 

We'll likely have to update other tests which rely on ordering in the future, but let's update them as needed.