### PR TITLE
fix jar task dependencies

### DIFF
--- a/collectd/build.gradle
+++ b/collectd/build.gradle
@@ -26,7 +26,10 @@ plugins {
 apply from: "$buildScriptsDir/common-java.gradle"
 
 // Since we're building the shadow jar, we have no use in the jar contains only CollectD code.
-jar.enabled = false
+jar {
+    dependsOn shadowJar
+    enabled = false
+}
 
 shadowJar {
     classifier = ''
@@ -48,7 +51,4 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile files(collectDLibPath)
 }
-
-// Building the shadow (fat) jar after compiling sources.
-shadowJar.dependsOn assemble
 

--- a/distributions/build.gradle
+++ b/distributions/build.gradle
@@ -28,7 +28,10 @@ apply from: "$buildScriptsDir/common-java.gradle"
 archivesBaseName = 'applicationinsights-all'
 
 // Since we're building the shadow jar, we have no use in the jar contains only CollectD code.
-jar.enabled = false
+jar {
+    dependsOn shadowJar
+    enabled = false
+}
 
 shadowJar {
     classifier = ''
@@ -46,6 +49,3 @@ dependencies {
     compile project(':logging:log4j2')
     compile project(':logging:logback')
 }
-
-// Building the shadow (fat) jar after compiling sources.
-shadowJar.dependsOn assemble


### PR DESCRIPTION
shadowJars were not being built.
updated jar closure to follow same convention as other build files.