### PR TITLE
DateFormatter is not null-safe

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
@@ -160,7 +160,7 @@ public abstract class BaseTelemetry<T extends Domain> implements Telemetry {
         tmp.setBaseData(getData());
         tmp.setBaseType(this.getBaseTypeName());
         envelope.setData(tmp);
-        envelope.setTime(getTimestamp() != null ? LocalStringsUtils.getDateFormatter().format(getTimestamp() : "null"));
+        if (getTimestamp() != null) envelope.setTime(LocalStringsUtils.getDateFormatter().format(getTimestamp());
         envelope.setTags(context.getTags());
 
         envelope.serialize(writer);

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
@@ -160,7 +160,7 @@ public abstract class BaseTelemetry<T extends Domain> implements Telemetry {
         tmp.setBaseData(getData());
         tmp.setBaseType(this.getBaseTypeName());
         envelope.setData(tmp);
-        if (getTimestamp() != null) envelope.setTime(LocalStringsUtils.getDateFormatter().format(getTimestamp());
+        if (getTimestamp() != null) envelope.setTime(LocalStringsUtils.getDateFormatter().format(getTimestamp()));
         envelope.setTags(context.getTags());
 
         envelope.serialize(writer);

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
@@ -160,7 +160,7 @@ public abstract class BaseTelemetry<T extends Domain> implements Telemetry {
         tmp.setBaseData(getData());
         tmp.setBaseType(this.getBaseTypeName());
         envelope.setData(tmp);
-        envelope.setTime(LocalStringsUtils.getDateFormatter().format(getTimestamp()));
+        envelope.setTime(getTimestamp() != null ? LocalStringsUtils.getDateFormatter().format(getTimestamp() : "null"));
         envelope.setTags(context.getTags());
 
         envelope.serialize(writer);


### PR DESCRIPTION
Fix #.
If the timestamp property is not set, a call to BaseTelemetry#toString will result in an NPE. This is irritating as for example IntelliJ's debugger and the Mockito mocking framework call #toString.

For significant contributions please make sure you have completed the following items:

- [-] Design discussion issue #
- [-] Changes in public surface reviewed
- [-] CHANGELOG.md updated
