### PR TITLE
Enable dependency-check build plugin

### DIFF
--- a/agent/dependency-check-suppressions.xml
+++ b/agent/dependency-check-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+      file name: instrumentation-logback-0.14.2.jar
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glowroot\.instrumentation/instrumentation\-logback@.*$</packageUrl>
+        <cve>CVE-2017-5929</cve>
+    </suppress>
+</suppressions>

--- a/agent/dependency-check-suppressions.xml
+++ b/agent/dependency-check-suppressions.xml
@@ -3,6 +3,7 @@
     <suppress>
         <notes><![CDATA[
       file name: instrumentation-logback-0.14.2.jar
+      This is logback instrumentation, not the logback library itself.
       ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.glowroot\.instrumentation/instrumentation\-logback@.*$</packageUrl>
         <cve>CVE-2017-5929</cve>

--- a/azure-application-insights-spring-boot-starter/build.gradle
+++ b/azure-application-insights-spring-boot-starter/build.gradle
@@ -45,21 +45,22 @@ sourceSets {
     }
 }
 
+def springBootVersion = '1.5.21.RELEASE'
 dependencies {
     compile(project(':core'))
     compile(project(':web'))
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
-    compileOnly('org.springframework.boot:spring-boot:1.5.9.RELEASE')
-    compileOnly('org.springframework.boot:spring-boot-autoconfigure:1.5.9.RELEASE')
-    compileOnly('org.springframework.boot:spring-boot-starter-web:1.5.9.RELEASE')
-    compileOnly('org.springframework.boot:spring-boot-configuration-processor:1.5.9.RELEASE')
+    compileOnly("org.springframework.boot:spring-boot:$springBootVersion")
+    compileOnly("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
+    compileOnly("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+    compileOnly("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
     testCompile('junit:junit:4.12')
-    testCompile('org.springframework.boot:spring-boot-starter-test:1.5.9.RELEASE')
-    testCompile('org.springframework.boot:spring-boot:1.5.9.RELEASE')
-    testCompile('org.springframework.boot:spring-boot-autoconfigure:1.5.9.RELEASE')
-    testCompile('org.springframework.boot:spring-boot-starter-web:1.5.9.RELEASE')
-    testCompile('org.springframework.boot:spring-boot-configuration-processor:1.5.9.RELEASE')
+    testCompile("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
+    testCompile("org.springframework.boot:spring-boot:$springBootVersion")
+    testCompile("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
+    testCompile("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+    testCompile("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
     testCompile('org.assertj:assertj-core:2.6.0')
 }
 

--- a/azure-application-insights-spring-boot-starter/dependency-check-suppressions.xml
+++ b/azure-application-insights-spring-boot-starter/dependency-check-suppressions.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+   file name: jackson-databind-2.8.11.3.jar
+   Dependency of spring-boot-starter-web.
+   No XML parsing/databinding used in our starter implementation.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+        <cve>CVE-2018-1000873</cve>
+        <cve>CVE-2018-14719</cve>
+        <cve>CVE-2018-14720</cve>
+        <cve>CVE-2018-14721</cve>
+        <cve>CVE-2018-19360</cve>
+        <cve>CVE-2018-19361</cve>
+        <cve>CVE-2018-19362</cve>
+        <cve>CVE-2019-12086</cve>
+        <cve>CVE-2019-12384</cve>
+        <cve>CVE-2019-12814</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-embed-websocket-8.5.40.jar
+   Dependency of spring-boot-starter-web.
+   Not applicable to our starter implementation.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
+        <cve>CVE-2019-10072</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: tomcat-embed-core-8.5.40.jar
+   Dependency of spring-boot-starter-web.
+   Not applicable to our starter implementation.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+        <cve>CVE-2019-10072</cve>
+    </suppress>
+</suppressions>

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
-        classpath 'org.owasp:dependency-check-gradle:4.0.2'
+        classpath 'org.owasp:dependency-check-gradle:5.2.0'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'
     }
 }

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -36,7 +36,7 @@ tasks.withType(JavaCompile) {
 }
 
 checkstyle {
-    toolVersion = '8.15'
+    toolVersion = '8.22'
     configFile = file("${rootProject.projectDir}/config/checkstyle/checkstyle.xml")
     configProperties["rootDir"] = rootProject.projectDir
     showViolations = false

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -49,6 +49,18 @@ tasks.withType(Checkstyle) {
     }
 }
 
+dependencyCheck {
+    def supFile = "${project.projectDir}/dependency-check-suppressions.xml"
+    if (file(supFile).exists() && !Project.hasProperty('dependencyCheck.suppressions.skip')) {
+        suppressionFiles += supFile
+    }
+    outputDirectory = "${project.buildDir}/reports/dependency-check"
+    formats = ['HTML', 'JUNIT']
+    skipConfigurations = ['mavenDeployer']
+    cveValidForHours = 1
+    failBuildOnCVSS = 0
+}
+
 jacoco {
     toolVersion = "0.8.2"
 }

--- a/web-auto/dependency-check-suppressions.xml
+++ b/web-auto/dependency-check-suppressions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+      file name: spring-boot-autoconfigure-1.4.0.RELEASE.jar
+      Independent of our usage.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-autoconfigure@.*$</packageUrl>
+        <cve>CVE-2017-8046</cve>
+        <cve>CVE-2018-1196</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-boot-1.4.0.RELEASE.jar
+   Same as autoconfigure
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot@.*$</packageUrl>
+        <cve>CVE-2017-8046</cve>
+        <cve>CVE-2018-1196</cve>
+    </suppress>
+</suppressions>

--- a/web/dependency-check-suppressions.xml
+++ b/web/dependency-check-suppressions.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+      file name: xwork-2.0.4.jar
+      This is only used for API interfaces to provide com.microsoft.applicationinsights.web.struts.RequestNameInterceptor.
+      No OGNL parsing; independent of XSS vector.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.opensymphony/xwork@.*$</packageUrl>
+        <cve>CVE-2007-4556</cve>
+        <cve>CVE-2008-6504</cve>
+        <cve>CVE-2011-1772</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: ognl-2.6.11.jar
+   This is only included because it's a dependency of xwork-*.jar.
+   No OGNL parsing used.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/opensymphony/ognl@.*$</packageUrl>
+        <cve>CVE-2016-3093</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-webmvc-3.1.0.RELEASE.jar
+   Required for interfaces to implement com.microsoft.applicationinsights.web.spring.RequestNameHandlerInterceptorAdapter.
+   XSS does not apply. Not related to directory traversal.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
+        <vulnerabilityName>CVE-2014-1904</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-9878</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-web-3.1.0.RELEASE.jar
+   Dependency of spring-webmvc
+   Usage is independent of springs XML parsing.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+        <vulnerabilityName>CVE-2013-4152</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0054</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0225</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-core-3.1.0.RELEASE.jar
+   Dependency of spring-webmvc.
+   Classes from this jar are not used.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+        <cve>CVE-2013-4152</cve>
+        <cve>CVE-2013-6429</cve>
+        <cve>CVE-2013-7315</cve>
+        <cve>CVE-2014-0054</cve>
+        <cve>CVE-2014-0225</cve>
+        <cve>CVE-2014-1904</cve>
+        <vulnerabilityName>CVE-2014-3578</vulnerabilityName>
+        <cve>CVE-2014-3625</cve>
+        <cve>CVE-2016-9878</cve>
+        <cve>CVE-2018-1270</cve>
+        <cve>CVE-2018-1271</cve>
+        <cve>CVE-2018-1272</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: cdi-api-1.1.jar
+   This CVE is JBoss specific. Not explicitly used by our code.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/javax\.enterprise/cdi\-api@.*$</packageUrl>
+        <cve>CVE-2014-8122</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
This will fail the build if it finds any CVEs in dependencies. You can find the reports in `<project>/build/reports/dependency-check-report.html`. The html has descriptions of CVEs and also has buttons which produce snippets for the suppressions file, if needed.

Most of our use of the dependencies flagged are for their interfaces and the CVEs were generally related to runtime issues. I upgraded libraries where I could. I'll roll-back and evaluate again if the smoke tests fail because of the upgrades.
