### PR TITLE
Use tls1.2 by default

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     compile ([group: 'io.grpc', name: 'grpc-protobuf', version: '1.16.1'])
     runtime ([group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.16.1'])
     // update transitive dependency version
-    runtime ([group: 'com.google.guava', name: 'guava', version: '27.1-android'])
+    compile ([group: 'com.google.guava', name: 'guava', version: '27.1-android'])
     testCompile group: 'org.hamcrest', name:'hamcrest-core', version:'1.3'
     testCompile group: 'org.hamcrest', name:'hamcrest-library', version:'1.3'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -44,8 +44,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContexts;
 
-import javax.net.ssl.SSLContext;
-
 /**
  * Created by gupele on 6/4/2015.
  */
@@ -59,13 +57,14 @@ final class ApacheSender43 implements ApacheSender {
                 new Runnable() {
                     @Override
                     public void run() {
-                        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
                         final String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
-                        if (allowedProtocols != null) {
-                            SSLConnectionSocketFactory sf = new SSLConnectionSocketFactory(SSLContexts.createDefault(), allowedProtocols, null, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+                        final PoolingHttpClientConnectionManager cm;
+                        if (allowedProtocols.length == 0) {
+                            cm = new PoolingHttpClientConnectionManager();
+                        } else {
                             cm = new PoolingHttpClientConnectionManager(RegistryBuilder.<ConnectionSocketFactory>create()
+                                    .register("https", new SSLConnectionSocketFactory(SSLContexts.createDefault(), allowedProtocols, null, SSLConnectionSocketFactory.getDefaultHostnameVerifier()))
                                     .register("http", PlainConnectionSocketFactory.getSocketFactory())
-                                    .register("https", sf)
                                     .build());
                         }
                         cm.setMaxTotal(DEFAULT_MAX_TOTAL_CONNECTIONS);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -62,16 +62,7 @@ final class ApacheSender43 implements ApacheSender {
                         PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
                         final String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
                         if (allowedProtocols != null) {
-                            SSLContext sslContext;
-                            try {
-                                sslContext = SSLContexts.custom().useProtocol("TLS").build();
-                            } catch (NoSuchAlgorithmException | KeyManagementException e) {
-                                if (InternalLogger.INSTANCE.isWarnEnabled()) {
-                                    InternalLogger.INSTANCE.warn("Could not configure custom SSL context. Using system default: %s", ExceptionUtils.getStackTrace(e));
-                                }
-                                sslContext = SSLContexts.createSystemDefault();
-                            }
-                            SSLConnectionSocketFactory sf = new SSLConnectionSocketFactory(sslContext, allowedProtocols, null, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+                            SSLConnectionSocketFactory sf = new SSLConnectionSocketFactory(SSLContexts.createDefault(), allowedProtocols, null, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
                             cm = new PoolingHttpClientConnectionManager(RegistryBuilder.<ConnectionSocketFactory>create()
                                     .register("http", PlainConnectionSocketFactory.getSocketFactory())
                                     .register("https", sf)

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -55,15 +55,10 @@ final class ApacheSender43 implements ApacheSender {
                 new Runnable() {
                     @Override
                     public void run() {
-                        final PoolingHttpClientConnectionManager cm;
-                        if (allowedProtocols.length == 0) {
-                            cm = new PoolingHttpClientConnectionManager();
-                        } else {
-                            cm = new PoolingHttpClientConnectionManager(RegistryBuilder.<ConnectionSocketFactory>create()
-                                    .register("https", new SSLConnectionSocketFactory(SSLContexts.createDefault(), allowedProtocols, null, SSLConnectionSocketFactory.getDefaultHostnameVerifier()))
-                                    .register("http", PlainConnectionSocketFactory.getSocketFactory())
-                                    .build());
-                        }
+                        final PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager(RegistryBuilder.<ConnectionSocketFactory>create()
+                                .register("https", new SSLConnectionSocketFactory(SSLContexts.createDefault(), allowedProtocols, null, SSLConnectionSocketFactory.getDefaultHostnameVerifier()))
+                                .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                                .build());
                         cm.setMaxTotal(DEFAULT_MAX_TOTAL_CONNECTIONS);
                         cm.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
                         sender.httpClientRef.compareAndSet(null, HttpClients.custom()

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -22,14 +22,11 @@
 package com.microsoft.applicationinsights.internal.channel.common;
 
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 
 import com.microsoft.applicationinsights.internal.util.SSLOptionsUtil;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
@@ -53,11 +50,11 @@ final class ApacheSender43 implements ApacheSender {
 
     static ApacheSender43 create() {
         final ApacheSender43 sender = new ApacheSender43();
+        final String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
         Thread initThread = new Thread(
                 new Runnable() {
                     @Override
                     public void run() {
-                        final String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
                         final PoolingHttpClientConnectionManager cm;
                         if (allowedProtocols.length == 0) {
                             cm = new PoolingHttpClientConnectionManager();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/NoSupportedProtocolsException.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/NoSupportedProtocolsException.java
@@ -1,0 +1,10 @@
+package com.microsoft.applicationinsights.internal.util;
+
+public class NoSupportedProtocolsException extends RuntimeException {
+    public NoSupportedProtocolsException() {
+    }
+
+    public NoSupportedProtocolsException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/SSLOptionsUtil.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/SSLOptionsUtil.java
@@ -1,0 +1,33 @@
+package com.microsoft.applicationinsights.internal.util;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+public class SSLOptionsUtil {
+
+    public static final String APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY = "applicationinsights.ssl.protocols";
+
+    @Nullable
+    public static String[] getAllowedProtocols() {
+        final String rawProp = System.getProperty(APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY);
+        final String[] defaultValue = {"TLSv1.2"};
+        if (rawProp == null) { // empty means defer to JVM defaults
+            return defaultValue;
+        }
+        String[] customProtocols = Iterables.toArray(Splitter.on(',').trimResults().omitEmptyStrings().split(rawProp), String.class);
+        if (customProtocols.length == 0) {
+            InternalLogger.INSTANCE.info("Found application.ssl.protocols=''; using JVM default SSL protocols for HTTP client");
+            return null;
+        }
+
+        if (InternalLogger.INSTANCE.isInfoEnabled()) {
+            InternalLogger.INSTANCE.info("Found application.ssl.protocols='%s'; HTTP client will allow only these protocols", Arrays.toString(customProtocols));
+        }
+        return customProtocols;
+    }
+
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/SSLOptionsUtil.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/SSLOptionsUtil.java
@@ -1,31 +1,69 @@
 package com.microsoft.applicationinsights.internal.util;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
-import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class SSLOptionsUtil {
 
+    private SSLOptionsUtil() {}
+
     public static final String APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY = "applicationinsights.ssl.protocols";
 
-    @Nullable
+    private static final String[] DEFAULT_PROTOCOLS;
+    static {
+        String[] proposed = new String[] {"TLSv1.3", "TLSv1.2"};
+        DEFAULT_PROTOCOLS = filterSupportedProtocols(Arrays.asList(proposed), false);
+        if (DEFAULT_PROTOCOLS.length == 0 && InternalLogger.INSTANCE.isErrorEnabled()) {
+            InternalLogger.INSTANCE.error("Default protocols are not supported in this JVM: %s. System property '%s' can be used to configure supported SSL protocols.",
+                    Arrays.toString(proposed), APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY);
+        }
+    }
+
+    private static String[] filterSupportedProtocols(Iterable<String> defaultValue, boolean reportErrors) {
+        List<String> supported = new ArrayList<>();
+        for (String protocol : defaultValue) {
+            try {
+                SSLContext.getInstance(protocol);
+                supported.add(protocol);
+            } catch (NoSuchAlgorithmException e) {
+                if (InternalLogger.INSTANCE.isErrorEnabled() && reportErrors) {
+                    InternalLogger.INSTANCE.error("Could not find protocol '%s': %s", protocol, ExceptionUtils.getStackTrace(e));
+                }
+            }
+        }
+        return supported.toArray(new String[0]);
+    }
+
+    /**
+     * <p>Finds the list of supported SSL/TLS protocols. If custom protocols are specified with the system property {@value #APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY}, this overrides the defaults.
+     * An error will be logged if the property contains no supported protocols.</p>
+     *
+     * <p>If no supported protocols are specified, the defaults are used (see static constructor). If no default protocols are available on this JVM, an error is logged.</p>
+     *
+     * @return An array of supported protocols. If there are none found, an empty array.
+     */
     public static String[] getAllowedProtocols() {
         final String rawProp = System.getProperty(APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY);
-        final String[] defaultValue = {"TLSv1.2"};
         if (rawProp == null) { // empty means defer to JVM defaults
-            return defaultValue;
+            return DEFAULT_PROTOCOLS;
         }
-        String[] customProtocols = Iterables.toArray(Splitter.on(',').trimResults().omitEmptyStrings().split(rawProp), String.class);
+        String[] customProtocols = filterSupportedProtocols(Splitter.on(',').trimResults().omitEmptyStrings().split(rawProp), true);
         if (customProtocols.length == 0) {
-            InternalLogger.INSTANCE.info("Found application.ssl.protocols=''; using JVM default SSL protocols for HTTP client");
-            return null;
+            if (InternalLogger.INSTANCE.isErrorEnabled()) {
+                InternalLogger.INSTANCE.error("%s contained no supported protocols; using default: %s", APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY, Arrays.toString(DEFAULT_PROTOCOLS));
+            }
+            return DEFAULT_PROTOCOLS;
         }
 
         if (InternalLogger.INSTANCE.isInfoEnabled()) {
-            InternalLogger.INSTANCE.info("Found application.ssl.protocols='%s'; HTTP client will allow only these protocols", Arrays.toString(customProtocols));
+            InternalLogger.INSTANCE.info("Found %s='%s'; HTTP client will allow only these protocols", APPLICATION_INSIGHTS_SSL_PROTOCOLS_PROPERTY, Arrays.toString(customProtocols));
         }
         return customProtocols;
     }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
@@ -83,16 +83,7 @@ public class CdsProfileFetcher implements AppProfileFetcher {
         final HttpAsyncClientBuilder httpAsyncClientBuilder = HttpAsyncClients.custom().setDefaultRequestConfig(requestConfig);
         String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
         if (allowedProtocols != null) {
-            SSLContext sslContext;
-            try {
-                sslContext = SSLContexts.custom().useProtocol("TLS").build();
-            } catch (NoSuchAlgorithmException | KeyManagementException e) {
-                if (InternalLogger.INSTANCE.isWarnEnabled()) {
-                    InternalLogger.INSTANCE.warn("Could not configure custom SSL context. Using system default: %s", ExceptionUtils.getStackTrace(e));
-                }
-                sslContext = SSLContexts.createSystemDefault();
-            }
-            SSLIOSessionStrategy sslStrat = new SSLIOSessionStrategy(sslContext, allowedProtocols, null, (HostnameVerifier) null);
+            SSLIOSessionStrategy sslStrat = new SSLIOSessionStrategy(SSLContexts.createDefault(), allowedProtocols, null, (HostnameVerifier) null);
             httpAsyncClientBuilder.setSSLStrategy(sslStrat);
         }
         setHttpClient(httpAsyncClientBuilder

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
@@ -25,7 +25,6 @@ import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.shutdown.SDKShutdownActivity;
 import com.microsoft.applicationinsights.internal.util.PeriodicTaskPool;
 import com.microsoft.applicationinsights.internal.util.SSLOptionsUtil;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.ParseException;
 import org.apache.http.client.config.RequestConfig;
@@ -37,13 +36,9 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -81,10 +76,9 @@ public class CdsProfileFetcher implements AppProfileFetcher {
                 .build();
 
         final HttpAsyncClientBuilder httpAsyncClientBuilder = HttpAsyncClients.custom().setDefaultRequestConfig(requestConfig);
-        String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
-        if (allowedProtocols != null) {
-            SSLIOSessionStrategy sslStrat = new SSLIOSessionStrategy(SSLContexts.createDefault(), allowedProtocols, null, (HostnameVerifier) null);
-            httpAsyncClientBuilder.setSSLStrategy(sslStrat);
+        final String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
+        if (allowedProtocols.length > 0) {
+                httpAsyncClientBuilder.setSSLStrategy(new SSLIOSessionStrategy(SSLContexts.createDefault(), allowedProtocols, null, SSLIOSessionStrategy.getDefaultHostnameVerifier()));
         }
         setHttpClient(httpAsyncClientBuilder
                 .useSystemProperties()

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
@@ -30,7 +30,6 @@ import org.apache.http.ParseException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContexts;
@@ -75,12 +74,10 @@ public class CdsProfileFetcher implements AppProfileFetcher {
                 .setConnectionRequestTimeout(5000)
                 .build();
 
-        final HttpAsyncClientBuilder httpAsyncClientBuilder = HttpAsyncClients.custom().setDefaultRequestConfig(requestConfig);
         final String[] allowedProtocols = SSLOptionsUtil.getAllowedProtocols();
-        if (allowedProtocols.length > 0) {
-                httpAsyncClientBuilder.setSSLStrategy(new SSLIOSessionStrategy(SSLContexts.createDefault(), allowedProtocols, null, SSLIOSessionStrategy.getDefaultHostnameVerifier()));
-        }
-        setHttpClient(httpAsyncClientBuilder
+        setHttpClient(HttpAsyncClients.custom()
+                .setDefaultRequestConfig(requestConfig)
+                .setSSLStrategy(new SSLIOSessionStrategy(SSLContexts.createDefault(), allowedProtocols, null, SSLIOSessionStrategy.getDefaultHostnameVerifier()))
                 .useSystemProperties()
                 .build());
 


### PR DESCRIPTION
You can use `applicationinsights.ssl.protocols` to override. Empty value means <strike>let the JVM/Http client decide (i.e. the current behavior).</strike> use defaults: TLSv1.2 or v1.3.