### PR TITLE
update test cases classes to be java 7 compatible.

### DIFF
--- a/test/smoke/framework/testCases/src/main/java/com/microsoft/applicationinsights/smoketest/CustomAiTestCases.java
+++ b/test/smoke/framework/testCases/src/main/java/com/microsoft/applicationinsights/smoketest/CustomAiTestCases.java
@@ -27,7 +27,7 @@ public class CustomAiTestCases {
         };
     }
 
-    public Runnable getTrackTrace(final String message, final SeverityLevel severityLevel, Map<String, String> properties) {
+    public Runnable getTrackTrace(final String message, final SeverityLevel severityLevel, final Map<String, String> properties) {
         return new Runnable() {
             @Override
             public void run() {
@@ -36,7 +36,7 @@ public class CustomAiTestCases {
         };
     }
 
-    public Runnable getTrackMetric(final String name, final double value, final int sampleCount, final double min, final double max, Map<String, String> properties) {
+    public Runnable getTrackMetric(final String name, final double value, final int sampleCount, final double min, final double max, final Map<String, String> properties) {
         return new Runnable(){
             @Override
             public void run() {
@@ -63,7 +63,7 @@ public class CustomAiTestCases {
         };
     }
 
-    public Runnable getTrackException(final Exception exception, Map<String, String> properties, Map<String, Double> metrics) {
+    public Runnable getTrackException(final Exception exception, final Map<String, String> properties, final Map<String, Double> metrics) {
         return new Runnable(){
             @Override
             public void run() {

--- a/test/smoke/framework/testCases/src/main/java/com/microsoft/applicationinsights/smoketest/FixedAiTestCases.java
+++ b/test/smoke/framework/testCases/src/main/java/com/microsoft/applicationinsights/smoketest/FixedAiTestCases.java
@@ -12,7 +12,6 @@ import com.microsoft.applicationinsights.telemetry.SeverityLevel;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,17 +29,17 @@ public class FixedAiTestCases {
 
     private Map<String, String> getPropertyMapForMethod(String method) {
         Preconditions.checkNotNull(method);
-        return new HashMap<String, String>() {{
-            put(String.format("Test%sProp1", method), String.format("Test%sP1_Value", method));
-            put(String.format("Test%sProp2", method), String.format("Test%sP2_Value", method));
-        }};
+        final HashMap<String, String> map = new HashMap<>();
+        map.put(String.format("Test%sProp1", method), String.format("Test%sP1_Value", method));
+        map.put(String.format("Test%sProp2", method), String.format("Test%sP2_Value", method));
+        return map;
     }
 
     private Map<String, Double> getMetricMapForMethod(String method) {
-        return new HashMap<String, Double>() {{
-            put(String.format("Test%sMetric1", method), 555.555);
-            put(String.format("Test%sMetric2", method), 666.666);
-        }};
+        final HashMap<String, Double> map = new HashMap<>();
+        map.put(String.format("Test%sMetric1", method), 555.555);
+        map.put(String.format("Test%sMetric2", method), 666.666);
+        return map;
     }
 
     public Runnable getTrackEvent() {
@@ -113,7 +112,7 @@ public class FixedAiTestCases {
     public Runnable getTrackHttpRequest_Success() {
         Random r = new Random(System.currentTimeMillis());
         int code = 200 + r.nextInt(100);
-        return customCases.getTrackHttpRequest("AiTestHttpRequest1", Date.from(Instant.now()), 123L, String.valueOf(code), true);
+        return customCases.getTrackHttpRequest("AiTestHttpRequest1", new Date(), 123L, String.valueOf(code), true);
     }
 
     /**
@@ -123,7 +122,7 @@ public class FixedAiTestCases {
     public Runnable getTrackHttpRequest_Failed() {
         Random r = new Random(System.currentTimeMillis());
         int code = 400 + r.nextInt(200);
-        return customCases.getTrackHttpRequest("AiTestHttpRequest2", Date.from(Instant.now()), 456L, String.valueOf(code), false);
+        return customCases.getTrackHttpRequest("AiTestHttpRequest2", new Date(), 456L, String.valueOf(code), false);
     }
 
     /**
@@ -132,7 +131,7 @@ public class FixedAiTestCases {
      */
     public Runnable getTrackRequest_Full() {
         // name, timestamp, duration, resultCode, success
-        RequestTelemetry rt = new RequestTelemetry("AiTestRequest", Date.from(Instant.now()), 147L, "100", true);
+        RequestTelemetry rt = new RequestTelemetry("AiTestRequest", new Date(), 147L, "100", true);
         // add props
         for (Entry<String, String> entry : getPropertyMapForMethod("Request").entrySet()) {
             rt.getProperties().put(entry.getKey(), entry.getValue());

--- a/test/webapps/PerfTestApp/build.gradle
+++ b/test/webapps/PerfTestApp/build.gradle
@@ -2,26 +2,31 @@ apply plugin: 'war'
 
 def aiSdkVersion = version
 
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+configurations.all {
+    resolutionStrategy {
+        dependencySubstitution {
+            substitute project(':core') with module("com.microsoft.azure:applicationinsights-core:$aiSdkVersion")
+        }
+    }
+}
+
 dependencies {
     compile "com.microsoft.azure:applicationinsights-core:$aiSdkVersion"
-//    compile aiWebJar
     compile 'com.google.guava:guava:20.0'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
 
     compile project(':test:smoke:framework:testCases')
 
     providedCompile 'javax.servlet:javax.servlet-api:3.0.1'
-
-    providedRuntime 'mysql:mysql-connector-java:5.1.44'
-
-    smokeTestCompile 'com.google.guava:guava:23.0'
-    testCompile 'com.google.guava:guava:23.0' // VSCODE intellisense bug workaround
 }
 
-compileJava.sourceCompatibility = 1.7
-compileJava.targetCompatibility = 1.7
-compileSmokeTestJava.sourceCompatibility = 1.8
-compileSmokeTestJava.targetCompatibility = 1.8
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 ext.testAppArtifactDir = war.destinationDirectory
 ext.testAppArtifactFilename = war.archiveFileName.get()


### PR DESCRIPTION
Also fix PerfTestApp build script. After testing the TLS changes, I had to make these changes to get the perftestapp to work.


The resolution strategy ensures the transitive dependencies of `project(':test:smoke:framework:testCases')` are resolved to the local maven repo.
