### PR TITLE
use the xpp3 parser

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -115,10 +115,7 @@ dependencies {
     compile ([group: 'commons-io', name: 'commons-io', version: '2.6' ])
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
     compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
-    compile ([group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.11.1']) {
-        exclude group: 'xmlpull', module: 'xmlpull'
-        exclude group: 'xpp3', module: 'xpp3_min'
-    }
+    compile ([group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.11.1'])
     compile ([group: 'com.google.code.gson', name: 'gson', version: '2.8.2'])
     compile ([group: 'com.google.protobuf', name:'protobuf-java', version:'3.6.1'])
     compile ([group: 'io.grpc', name: 'grpc-stub', version: '1.16.1'])

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilder.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilder.java
@@ -29,7 +29,7 @@ import javax.xml.stream.XMLStreamReader;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
-import com.thoughtworks.xstream.io.xml.StaxDriver;
+import com.thoughtworks.xstream.io.xml.Xpp3Driver;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
@@ -49,7 +49,7 @@ class JaxbAppInsightsConfigurationBuilder implements AppInsightsConfigurationBui
         }
 
         try {
-            XStream xstream = new XStream(new PureJavaReflectionProvider(), new StaxDriver());
+            XStream xstream = new XStream(new PureJavaReflectionProvider(), new Xpp3Driver());
 
             xstream.ignoreUnknownElements(); // backwards compatible with jaxb behavior
 


### PR DESCRIPTION
To avoid this: https://x-stream.github.io/CVE-2016-3674.html

core.jar size:
* w/ stax driver: 16.8 MB (17,651,728 bytes) [xpp jars excluded]
* w/ xpp3 driver: 16.8 MB (17,677,957 bytes)