### PR TITLE
#910 RootIds generated by TelemetryCorrelationUtils can be < 32 chara…

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtils.java
@@ -389,11 +389,7 @@ public class TelemetryCorrelationUtils {
 	}
 
 	private static String generateRootId() {
-		UUID guid = UUID.randomUUID();
-		long least = guid.getLeastSignificantBits();
-    	long most = guid.getMostSignificantBits();
-
-		return Long.toHexString(most) + Long.toHexString(least);
+		return UUID.randomUUID().toString().replace("-", "");
 	}
 
 	private static String generateId(String parentId) {


### PR DESCRIPTION
Fix for #910 
