### PR TITLE
Split out sdk version names for better tracking

### DIFF
--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/LocalSpanImpl.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/LocalSpanImpl.java
@@ -101,7 +101,7 @@ public class LocalSpanImpl implements Span {
         }
         sdkBridge.track(telemetry);
         if (exception != null) {
-            sdkBridge.track(new ExceptionTelemetry(exception));
+            sdkBridge.track(new ExceptionTelemetry(exception, telemetry.getSdkName()));
         }
     }
 
@@ -144,7 +144,8 @@ public class LocalSpanImpl implements Span {
             return null;
         }
         RemoteDependencyTelemetry telemetry =
-                new RemoteDependencyTelemetry(startTimeMillis, durationMillis, classType, exception == null);
+                new RemoteDependencyTelemetry(startTimeMillis, durationMillis, classType, exception == null,
+                        "ja-custom");
         telemetry.setName(className.replace('.', '/') + '.' + methodName);
         return telemetry;
     }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/LoggerSpans.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/LoggerSpans.java
@@ -49,7 +49,7 @@ class LoggerSpans {
             setProperties(telemetry.getProperties(), timeMillis, level, loggerName, null, formattedMessage);
             sdkBridge.track(telemetry);
         } else {
-            ExceptionTelemetry telemetry = new ExceptionTelemetry(throwable, level);
+            ExceptionTelemetry telemetry = new ExceptionTelemetry(throwable, "ja-logging", level);
             setProperties(telemetry.getProperties(), timeMillis, level, loggerName, throwable, formattedMessage);
             sdkBridge.track(telemetry);
         }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/OutgoingSpanImpl.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/OutgoingSpanImpl.java
@@ -110,13 +110,13 @@ public class OutgoingSpanImpl implements Span {
             telemetry = toHttpTelemetry();
         } else if (type.equals("Redis")) {
             telemetry = new RemoteDependencyTelemetry(startTimeMillis, System.currentTimeMillis() - startTimeMillis,
-                    type, exception == null);
+                    type, exception == null, "ja-redis");
             telemetry.setName(text);
         }
         if (telemetry != null) {
             sdkBridge.track(telemetry);
             if (exception != null) {
-                sdkBridge.track(new ExceptionTelemetry(exception));
+                sdkBridge.track(new ExceptionTelemetry(exception, telemetry.getSdkName()));
             }
         }
     }
@@ -139,7 +139,7 @@ public class OutgoingSpanImpl implements Span {
 
         RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry(startTimeMillis,
                 System.currentTimeMillis() - startTimeMillis, "Http (tracked component)",
-                result == null || result < 400);
+                result == null || result < 400, "ja-http");
         telemetry.setId(outgoingSpanId);
 
         // from HttpClientMethodVisitor and CoreAgentNotificationsHandler:

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/QuerySpanImpl.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/model/QuerySpanImpl.java
@@ -140,7 +140,7 @@ public class QuerySpanImpl implements QuerySpan {
             return;
         }
         RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry(startTimeMillis, totalMillis, type,
-                exception == null);
+                exception == null, "ja-jdbc");
         telemetry.setName(dest);
         telemetry.setCommandName(text);
 
@@ -174,7 +174,7 @@ public class QuerySpanImpl implements QuerySpan {
 
         sdkBridge.track(telemetry);
         if (exception != null) {
-            sdkBridge.track(new ExceptionTelemetry(exception));
+            sdkBridge.track(new ExceptionTelemetry(exception, telemetry.getSdkName()));
         }
     }
 }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/sdk/SdkBridge.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/sdk/SdkBridge.java
@@ -88,16 +88,19 @@ public interface SdkBridge<T> {
 
         private final Throwable throwable;
 
-        private final @Nullable String level;
+        private final String sdkName;
+
+        private final @Nullable String level; // only used when exception is from logging
 
         private final Map<String, String> properties = new HashMap<>();
 
-        public ExceptionTelemetry(Throwable throwable) {
-            this(throwable, null);
+        public ExceptionTelemetry(Throwable throwable, String sdkName) {
+            this(throwable, null, sdkName);
         }
 
-        public ExceptionTelemetry(Throwable throwable, @Nullable String level) {
+        public ExceptionTelemetry(Throwable throwable, String sdkName, @Nullable String level) {
             this.throwable = throwable;
+            this.sdkName = sdkName;
             this.level = level;
         }
 
@@ -105,7 +108,11 @@ public interface SdkBridge<T> {
             return throwable;
         }
 
-        public  @Nullable String getLevel() {
+        public String getSdkName() {
+            return sdkName;
+        }
+
+        public @Nullable String getLevel() {
             return level;
         }
 
@@ -122,6 +129,8 @@ public interface SdkBridge<T> {
         private final String type;
         private final boolean success;
 
+        private final String sdkName;
+
         private @Nullable String id;
         private @Nullable String name;
         private @Nullable String commandName;
@@ -130,11 +139,13 @@ public interface SdkBridge<T> {
 
         private final Map<String, String> properties = new HashMap<>();
 
-        public RemoteDependencyTelemetry(long timestamp, long durationMillis, String type, boolean success) {
+        public RemoteDependencyTelemetry(long timestamp, long durationMillis, String type, boolean success,
+                                         String sdkName) {
             this.timestamp = timestamp;
             this.durationMillis = durationMillis;
             this.type = type;
             this.success = success;
+            this.sdkName = sdkName;
         }
 
         public long getTimestamp() {
@@ -151,6 +162,10 @@ public interface SdkBridge<T> {
 
         public boolean isSuccess() {
             return success;
+        }
+
+        public String getSdkName() {
+            return sdkName;
         }
 
         public @Nullable String getId() {

--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebMvcAutoConfiguration.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsWebMvcAutoConfiguration.java
@@ -96,7 +96,7 @@ public class ApplicationInsightsWebMvcAutoConfiguration {
     @ConditionalOnMissingBean
     @DependsOn("telemetryConfiguration")
     public WebRequestTrackingFilter webRequestTrackingFilter(@Value("${spring.application.name:application}") String applicationName) {
-        return new WebRequestTrackingFilter(applicationName);
+        return WebRequestTrackingFilter.createForSpringBootStarter(applicationName);
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/agent/AbstractSdkBridge.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/agent/AbstractSdkBridge.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.agent.internal.sdk.SdkBridge;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.Duration;
 import com.microsoft.applicationinsights.telemetry.SeverityLevel;
 
@@ -75,6 +76,9 @@ public abstract class AbstractSdkBridge<T> implements SdkBridge<T> {
 
         telemetry.getProperties().putAll(agentTelemetry.getProperties());
 
+        telemetry.getContext().getInternal()
+                .setSdkVersion(agentTelemetry.getSdkName() + ":" + PropertyHelper.getSdkVersionNumber());
+
         client.track(telemetry);
     }
 
@@ -93,6 +97,9 @@ public abstract class AbstractSdkBridge<T> implements SdkBridge<T> {
 
         telemetry.getProperties().putAll(agentTelemetry.getProperties());
 
+        telemetry.getContext().getInternal()
+                .setSdkVersion("ja-logging:" + PropertyHelper.getSdkVersionNumber());
+
         client.track(telemetry);
     }
 
@@ -110,6 +117,9 @@ public abstract class AbstractSdkBridge<T> implements SdkBridge<T> {
         }
 
         telemetry.getProperties().putAll(agentTelemetry.getProperties());
+
+        telemetry.getContext().getInternal()
+                .setSdkVersion(agentTelemetry.getSdkName() + ":" + PropertyHelper.getSdkVersionNumber());
 
         client.track(telemetry);
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatProvider.java
@@ -5,6 +5,7 @@ import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.shutdown.SDKShutdownActivity;
 import com.microsoft.applicationinsights.internal.shutdown.Stoppable;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.internal.util.ThreadPoolUtils;
 import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +30,8 @@ import java.util.concurrent.TimeUnit;
  * @author Dhaval Doshi
  */
 public class HeartBeatProvider implements HeartBeatProviderInterface, Stoppable {
+
+  private static final String SDK_VERSION = "java-heartbeat:" + PropertyHelper.getSdkVersionNumber();
 
   /**
    * The name of the heartbeat metric.
@@ -236,6 +239,7 @@ public class HeartBeatProvider implements HeartBeatProviderInterface, Stoppable 
 
     MetricTelemetry telemetry = gatherData();
     telemetry.getContext().getOperation().setSyntheticSource(HEARTBEAT_SYNTHETIC_METRIC_NAME);
+    telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
     telemetryClient.trackMetric(telemetry);
     InternalLogger.INSTANCE.trace("No of heartbeats sent, %s", ++heartbeatsSent);
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractUnixPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractUnixPerformanceCounter.java
@@ -28,6 +28,7 @@ import com.microsoft.applicationinsights.internal.system.SystemInformation;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 
 /**
  * A base class for Unix performance counters who uses the '/proc/' filesystem for their work.
@@ -35,6 +36,9 @@ import com.google.common.base.Strings;
  * Created by gupele on 3/8/2015.
  */
 abstract class AbstractUnixPerformanceCounter extends AbstractPerformanceCounter {
+
+    protected static final String SDK_VERSION = "java-metric-unix:" + PropertyHelper.getSdkVersionNumber();
+
     private final File processFile;
     private final String path;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractWindowsPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractWindowsPerformanceCounter.java
@@ -1,11 +1,14 @@
 package com.microsoft.applicationinsights.internal.perfcounter;
 
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 
 /**
  * Created by gupele on 4/29/2015.
  */
 public abstract class AbstractWindowsPerformanceCounter implements PerformanceCounter {
+
+    protected static final String SDK_VERSION = "java-metric-windows:" + PropertyHelper.getSdkVersionNumber();
 
     protected void reportError(double value, String displayName) {
         if (!InternalLogger.INSTANCE.isErrorEnabled()) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxMetricPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxMetricPerformanceCounter.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.jmx.JmxAttributeData;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 
 /**
@@ -35,6 +36,8 @@ import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
  */
 public final class JmxMetricPerformanceCounter extends AbstractJmxPerformanceCounter {
 
+    private static final String SDK_VERSION = "java-metric-jmx:" + PropertyHelper.getSdkVersionNumber();
+
     public JmxMetricPerformanceCounter(String id, String objectName, Collection<JmxAttributeData> attributes) {
         super(id, objectName, attributes);
     }
@@ -43,11 +46,12 @@ public final class JmxMetricPerformanceCounter extends AbstractJmxPerformanceCou
     protected void send(TelemetryClient telemetryClient, String displayName, double value) {
         InternalLogger.INSTANCE.trace("Metric JMX: %s, %s", displayName, value);
 
-    MetricTelemetry telemetry = new MetricTelemetry();
-    telemetry.markAsCustomPerfCounter();
+        MetricTelemetry telemetry = new MetricTelemetry();
+        telemetry.markAsCustomPerfCounter();
         telemetry.setName(displayName);
         telemetry.setValue(value);
         telemetry.getProperties().put("CustomPerfCounter", "true");
+        telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
         telemetryClient.track(telemetry);
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessCpuPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessCpuPerformanceCounter.java
@@ -24,6 +24,7 @@ package com.microsoft.applicationinsights.internal.perfcounter;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.system.SystemInformation;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.PerformanceCounterTelemetry;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -34,6 +35,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  * Created by gupele on 3/3/2015.
  */
 final class ProcessCpuPerformanceCounter extends AbstractPerformanceCounter {
+
+    private static final String SDK_VERSION = "java-metric-jvm:" + PropertyHelper.getSdkVersionNumber();
 
     private CpuPerformanceCounterCalculator cpuPerformanceCounterCalculator;
 
@@ -77,6 +80,8 @@ final class ProcessCpuPerformanceCounter extends AbstractPerformanceCounter {
                 Constants.CPU_PC_COUNTER_NAME,
                 SystemInformation.INSTANCE.getProcessId(),
                 processCpuUsage);
+        telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
+
         telemetryClient.track(telemetry);
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessMemoryPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessMemoryPerformanceCounter.java
@@ -28,6 +28,7 @@ import java.lang.management.MemoryUsage;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.system.SystemInformation;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.PerformanceCounterTelemetry;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
 
@@ -37,6 +38,8 @@ import com.microsoft.applicationinsights.telemetry.Telemetry;
  * Created by gupele on 3/3/2015.
  */
 final class ProcessMemoryPerformanceCounter extends AbstractPerformanceCounter {
+
+    private static final String SDK_VERSION = "java-metric-jvm:" + PropertyHelper.getSdkVersionNumber();
 
     public ProcessMemoryPerformanceCounter() {
     }
@@ -62,6 +65,7 @@ final class ProcessMemoryPerformanceCounter extends AbstractPerformanceCounter {
                 Constants.PROCESS_MEM_PC_COUNTER_NAME,
                 SystemInformation.INSTANCE.getProcessId(),
                 memoryBytes);
+        telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
 
         telemetryClient.track(telemetry);
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOPerformanceCounter.java
@@ -27,6 +27,7 @@ import java.io.FileReader;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.system.SystemInformation;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.PerformanceCounterTelemetry;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -78,6 +79,7 @@ final class UnixProcessIOPerformanceCounter extends AbstractUnixPerformanceCount
                     Constants.PROCESS_IO_PC_COUNTER_NAME,
                     SystemInformation.INSTANCE.getProcessId(),
                     value);
+            telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
 
             telemetryClient.track(telemetry);
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
@@ -86,6 +86,7 @@ final class UnixTotalCpuPerformanceCounter extends AbstractUnixPerformanceCounte
                     Constants.CPU_PC_COUNTER_NAME,
                     Constants.INSTANCE_NAME_TOTAL,
                     totalCpuUsage);
+            telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
 
             telemetryClient.track(telemetry);
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalMemoryPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalMemoryPerformanceCounter.java
@@ -60,6 +60,7 @@ final class UnixTotalMemoryPerformanceCounter extends AbstractUnixPerformanceCou
                 Constants.TOTAL_MEMORY_PC_COUNTER_NAME,
                 "",
                 totalAvailableMemory);
+        telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
 
         telemetryClient.track(telemetry);
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsMetric.java
@@ -59,6 +59,7 @@ public final class WindowsPerformanceCounterAsMetric extends AbstractWindowsPerf
 
         // indicate that this is used for performance counters, not custom metrics.
         telemetry.markAsCustomPerfCounter();
+        telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
 
         register(pcsData);
         if (keyToDisplayName.isEmpty()) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsPC.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/WindowsPerformanceCounterAsPC.java
@@ -100,6 +100,7 @@ public final class WindowsPerformanceCounterAsPC extends AbstractWindowsPerforma
 
     private void send(TelemetryClient telemetryClient, double value, WindowsPerformanceCounterData data) {
         PerformanceCounterTelemetry telemetry = new PerformanceCounterTelemetry(data.categoryName, data.counterName, data.instanceName, value);
+        telemetry.getContext().getInternal().setSdkVersion(SDK_VERSION);
         telemetryClient.track(telemetry);
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/DeadLockDetectorPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/DeadLockDetectorPerformanceCounter.java
@@ -33,6 +33,7 @@ import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.perfcounter.PerformanceCounter;
 import com.microsoft.applicationinsights.internal.util.LocalStringsUtils;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 import com.microsoft.applicationinsights.telemetry.TraceTelemetry;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -53,6 +54,8 @@ public final class DeadLockDetectorPerformanceCounter implements PerformanceCoun
     private final static String SEPERATOR = " | ";
     private final static String METRIC_NAME = "Suspected Deadlocked Threads";
     private final static int MAX_STACK_TRACE = 3;
+
+    private static final String SDK_VERSION = "java-deadlock:" + PropertyHelper.getSdkVersionNumber();
 
     private final ThreadMXBean threadBean;
 
@@ -98,6 +101,7 @@ public final class DeadLockDetectorPerformanceCounter implements PerformanceCoun
 
                 TraceTelemetry trace = new TraceTelemetry(String.format("%s%s", "Suspected deadlocked threads: ", sb.toString()));
                 trace.getContext().getOperation().setId(uuid);
+                trace.getContext().getInternal().setSdkVersion(SDK_VERSION);
                 telemetryClient.track(trace);
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/GCPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/GCPerformanceCounter.java
@@ -27,6 +27,7 @@ import java.lang.management.ManagementFactory;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.perfcounter.PerformanceCounter;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 
 /**
@@ -35,10 +36,13 @@ import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
  * Created by gupele on 8/8/2016.
  */
 public final class GCPerformanceCounter implements PerformanceCounter {
+
     public final static String NAME = "GC";
 
     private static final String GC_TOTAL_COUNT = "GC Total Count";
     private static final String GC_TOTAL_TIME = "GC Total Time";
+
+    private static final String SDK_VERSION = "java-metric-jvm:" + PropertyHelper.getSdkVersionNumber();
 
     private long currentTotalCount = 0;
     private long currentTotalTime = 0;
@@ -81,6 +85,8 @@ public final class GCPerformanceCounter implements PerformanceCounter {
 
             mtTotalCount.markAsCustomPerfCounter();
             mtTotalCount.markAsCustomPerfCounter();
+
+            mtTotalCount.getContext().getInternal().setSdkVersion(SDK_VERSION);
 
             telemetryClient.track(mtTotalCount);
             telemetryClient.track(mtTotalTime);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/JvmHeapMemoryUsedPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/JvmHeapMemoryUsedPerformanceCounter.java
@@ -27,6 +27,7 @@ import java.lang.management.MemoryUsage;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.perfcounter.PerformanceCounter;
+import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 
 /**
@@ -36,11 +37,13 @@ import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
  */
 public class JvmHeapMemoryUsedPerformanceCounter implements PerformanceCounter {
 
-    public final static String NAME = "MemoryUsage";
+    public static final String NAME = "MemoryUsage";
 
-        private final static String HEAP_MEM_USED = "Heap Memory Used (MB)";
+    private static final String HEAP_MEM_USED = "Heap Memory Used (MB)";
 
-    private final long Megabyte = 1024 * 1024;
+    private static final long MEGABYTE = 1024 * 1024;
+
+    private static final String SDK_VERSION = "java-metric-memory:" + PropertyHelper.getSdkVersionNumber();
 
     private final MemoryMXBean memory;
 
@@ -65,9 +68,10 @@ public class JvmHeapMemoryUsedPerformanceCounter implements PerformanceCounter {
     private void reportHeap(MemoryMXBean memory, TelemetryClient telemetryClient) {
         MemoryUsage mhu = memory.getHeapMemoryUsage();
         if (mhu != null) {
-            long currentHeapUsed = mhu.getUsed() / Megabyte;
+            long currentHeapUsed = mhu.getUsed() / MEGABYTE;
             MetricTelemetry memoryHeapUsage = new MetricTelemetry(HEAP_MEM_USED, currentHeapUsed);
             memoryHeapUsage.markAsCustomPerfCounter();
+            memoryHeapUsage.getContext().getInternal().setSdkVersion(SDK_VERSION);
             telemetryClient.track(memoryHeapUsage);
         }
     }

--- a/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/ApplicationInsightsAppender.java
+++ b/logging/log4j1_2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v1_2/ApplicationInsightsAppender.java
@@ -102,7 +102,7 @@ public class ApplicationInsightsAppender extends AppenderSkeleton {
         super.activateOptions();
 
         try {
-            this.telemetryClientProxy = new LogTelemetryClientProxy(this.instrumentationKey);
+            this.telemetryClientProxy = LogTelemetryClientProxy.createForLog4j1_2(this.instrumentationKey);
             this.isInitialized = true;
         } catch (Exception e) {
             // Appender failure must not fail the running application.

--- a/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppender.java
+++ b/logging/log4j2/appenderSrc/main/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppender.java
@@ -111,7 +111,7 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         super(name, null, null);
 
         try {
-            telemetryClientProxy = new LogTelemetryClientProxy(instrumentationKey);
+            telemetryClientProxy = LogTelemetryClientProxy.createForLog4j2(instrumentationKey);
             this.isInitialized = true;
         } catch (Exception e) {
             // Appender failure must not fail the running application.
@@ -134,7 +134,7 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         super(name, filter, layout, ignoreExceptions);
 
         try {
-            telemetryClientProxy = new LogTelemetryClientProxy(instrumentationKey);
+            telemetryClientProxy = LogTelemetryClientProxy.createForLog4j2(instrumentationKey);
             this.isInitialized = true;
         } catch (Exception e) {
             // Appender failure must not fail the running application.

--- a/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/ApplicationInsightsAppender.java
+++ b/logging/logback/appenderSrc/main/java/com/microsoft/applicationinsights/logback/ApplicationInsightsAppender.java
@@ -80,7 +80,7 @@ public class ApplicationInsightsAppender extends AppenderBase<ILoggingEvent> {
         super.start();
 
         try {
-            logTelemetryClientProxy = new LogTelemetryClientProxy(instrumentationKey);
+            logTelemetryClientProxy = LogTelemetryClientProxy.createForLogback(instrumentationKey);
             this.isInitialized = true;
         } catch (Exception e) {
             // Appender failure must not fail the running application.

--- a/test/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
+++ b/test/fakeIngestion/servlet/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServlet.java
@@ -136,6 +136,12 @@ public class MockedAppInsightsIngestionServlet extends HttpServlet {
         }
     }
 
+    public Collection<Envelope> getItems() {
+        synchronized (multimapLock) {
+            return type2envelope.values();
+        }
+    }
+
     public void awaitAnyItems(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
         waitForItems(Predicates.<Envelope>alwaysTrue(), 1, timeout, timeUnit);
     }

--- a/test/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
+++ b/test/fakeIngestion/standalone/src/main/java/com/microsoft/applicationinsights/test/fakeingestion/MockedAppInsightsIngestionServer.java
@@ -15,6 +15,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.Assert.assertTrue;
+
 public class MockedAppInsightsIngestionServer {
     public static final int DEFAULT_PORT = 60606;
 
@@ -89,6 +91,15 @@ public class MockedAppInsightsIngestionServer {
     public <T extends Domain> T getBaseDataForType(int index, String type) {
         Data<T> data = (Data<T>) getItemsEnvelopeDataType(type).get(index).getData();
         return data.getBaseData();
+    }
+
+    public Envelope getEnvelopeForBaseData(Domain data) {
+        for (Envelope envelope : servlet.getItems()) {
+            if (((Data<?>) envelope.getData()).getBaseData() == data) {
+                return envelope;
+            }
+        }
+        throw new IllegalStateException("Could not find envelope for data: " + data);
     }
 
     public void awaitAnyItems(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {

--- a/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/RequestDataMatchers.java
+++ b/test/smoke/framework/utils/src/main/java/com/microsoft/applicationinsights/smoketest/matchers/RequestDataMatchers.java
@@ -45,7 +45,7 @@ public class RequestDataMatchers {
     }
 
     public static Matcher<RequestData> hasUrl(String url) {
-        return new FeatureMatcher<RequestData, String>(equalTo(url), "ReqeustData with url", "url") {
+        return new FeatureMatcher<RequestData, String>(equalTo(url), "RequestData with url", "url") {
             @Override
             protected String featureValueOf(RequestData actual) {
                 return actual.getUrl();

--- a/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SampleTestWithDependencyContainer.java
+++ b/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SampleTestWithDependencyContainer.java
@@ -1,7 +1,12 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import org.junit.*;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
 @UseAgent
@@ -17,5 +22,15 @@ public class SampleTestWithDependencyContainer extends AiSmokeTest {
 
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
         assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
+        RequestData d = getTelemetryDataForType(0, "RequestData");
+        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        validateSdkName(d, "java-web-manual");
+        validateSdkName(rdd, "ja-redis");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/FixedRateSampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/FixedRateSamplingTest.java
+++ b/test/smoke/testApps/FixedRateSampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/FixedRateSamplingTest.java
@@ -1,6 +1,10 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.EventData;
+import com.microsoft.applicationinsights.internal.schemav2.MessageData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import org.junit.*;
 
 import static org.hamcrest.Matchers.*;
@@ -12,6 +16,8 @@ public class FixedRateSamplingTest extends AiSmokeTest {
     public void testFixedRateSamplingInExcludedTypes() {
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
         assertEquals(100.0, getSampleRate("RequestData", 0), Math.ulp(50.0));
+        RequestData rd = getTelemetryDataForType(0, "RequestData");
+        validateSdkName(rd, "java-web-manual");
     }
 
     @Test
@@ -20,6 +26,8 @@ public class FixedRateSamplingTest extends AiSmokeTest {
         int count = mockedIngestion.getCountForType("EventData");
         assertThat(count, both(greaterThanOrEqualTo(40)).and(lessThanOrEqualTo(60)));
         assertEquals(50.0, getSampleRate("EventData", 0), Math.ulp(50.0));
+        EventData ed = getTelemetryDataForType(0, "EventData");
+        validateSdkName(ed, "java");
     }
 
     @Test
@@ -27,6 +35,8 @@ public class FixedRateSamplingTest extends AiSmokeTest {
     public void testFixedRateSamplingNotInExcludedTypes() {
         assertEquals(1, mockedIngestion.getCountForType("MessageData"));
         assertEquals(100.0, getSampleRate("MessageData", 0), Math.ulp(50.0));
+        MessageData md = getTelemetryDataForType(0, "MessageData");
+        validateSdkName(md, "java");
     }
 
     protected double getSampleRate(String type, int index) {
@@ -34,4 +44,9 @@ public class FixedRateSamplingTest extends AiSmokeTest {
         return envelope.getSampleRate();
     }
 
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
+    }
 }

--- a/test/smoke/testApps/HeartBeat/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/HeartBeatTest.java
+++ b/test/smoke/testApps/HeartBeat/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/HeartBeatTest.java
@@ -1,7 +1,10 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -10,6 +13,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.MetricData;
 
@@ -29,6 +33,10 @@ public class HeartBeatTest extends AiSmokeTest {
         assertNotNull(data.getProperties().get("osVersion"));
         assertNotNull(data.getProperties().get("processSessionId"));
 
+        String sdkVersion = data.getProperties().get("sdkVersion");
+        assertThat(sdkVersion, startsWith("java:"));
+
+        validateSdkName(data, "java-heartbeat");
     }
 
     private static Predicate<Envelope> getMetricPredicate(String name) {
@@ -48,4 +56,9 @@ public class HeartBeatTest extends AiSmokeTest {
         };
     }
 
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
+    }
 }

--- a/test/smoke/testApps/SpringBoot1_3Auto/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringBootAutoTest.java
+++ b/test/smoke/testApps/SpringBoot1_3Auto/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringBootAutoTest.java
@@ -1,7 +1,11 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import org.junit.*;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
 public class SpringBootAutoTest extends AiSmokeTest {
@@ -13,5 +17,13 @@ public class SpringBootAutoTest extends AiSmokeTest {
         assertTrue("mocked ingestion has 0 items", mockedIngestion.getItemCount() > 0);
 
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        RequestData d = getTelemetryDataForType(0, "RequestData");
+        validateSdkName(d, "java-web-auto");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/SpringBootAuto/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringBootAutoTest.java
+++ b/test/smoke/testApps/SpringBootAuto/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringBootAutoTest.java
@@ -1,7 +1,11 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import org.junit.*;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
 public class SpringBootAutoTest extends AiSmokeTest {
@@ -13,5 +17,13 @@ public class SpringBootAutoTest extends AiSmokeTest {
         assertTrue("mocked ingestion has 0 items", mockedIngestion.getItemCount() > 0);
 
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        RequestData d = getTelemetryDataForType(0, "RequestData");
+        validateSdkName(d, "java-web-auto");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/CustomInstrumentationTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/CustomInstrumentationTest.java
@@ -2,6 +2,9 @@ package com.springbootstartertest.smoketest;
 
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
@@ -11,8 +14,10 @@ import com.microsoft.applicationinsights.smoketest.TargetUri;
 import com.microsoft.applicationinsights.smoketest.UseAgent;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @UseAgent("CustomInstrumentation")
@@ -27,6 +32,7 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject.one");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+        validateSdkName(rdd, "ja-custom");
     }
 
     @Test
@@ -38,6 +44,7 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject.two");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+        validateSdkName(rdd, "ja-custom");
     }
 
     @Test
@@ -54,6 +61,7 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         List<ExceptionDetails> exceptions = exceptionData.getExceptions();
         assertEquals(exceptions.size(), 1);
         assertEquals(exceptions.get(0).getMessage(), "Three");
+        validateSdkName(rdd, "ja-custom");
     }
 
     @Test
@@ -65,6 +73,7 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject$NestedObject.four");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+        validateSdkName(rdd, "ja-custom");
     }
 
     @Test
@@ -95,21 +104,25 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(fiveRdd.getName(), "com/springbootstartertest/controller/TargetObject.five");
         assertEquals(fiveRdd.getType(), "OTHER");
         assertEquals(fiveRdd.getSuccess(), true);
+        validateSdkName(fiveRdd, "ja-custom");
 
         assertNotNull(sixRdd);
         assertEquals(sixRdd.getName(), "com/springbootstartertest/controller/TargetObject.six");
         assertEquals(sixRdd.getType(), "OTHER");
         assertEquals(sixRdd.getSuccess(), true);
+        validateSdkName(sixRdd, "ja-custom");
 
         assertNotNull(oneRdd);
         assertEquals(oneRdd.getName(), "com/springbootstartertest/controller/TargetObject.one");
         assertEquals(oneRdd.getType(), "OTHER");
         assertEquals(oneRdd.getSuccess(), true);
+        validateSdkName(oneRdd, "ja-custom");
 
         assertNotNull(twoRdd);
         assertEquals(twoRdd.getName(), "com/springbootstartertest/controller/TargetObject.two");
         assertEquals(twoRdd.getType(), "OTHER");
         assertEquals(twoRdd.getSuccess(), true);
+        validateSdkName(twoRdd, "ja-custom");
     }
 
     @Test
@@ -121,6 +134,7 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject.seven");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+        validateSdkName(rdd, "ja-custom");
     }
 
     @Test
@@ -134,10 +148,12 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(rdd1.getName(), "com/springbootstartertest/controller/TargetObject.eight");
         assertEquals(rdd1.getType(), "OTHER");
         assertEquals(rdd1.getSuccess(), true);
+        validateSdkName(rdd1, "ja-custom");
 
         assertEquals(rdd2.getName(), "com/springbootstartertest/controller/TargetObject.eight");
         assertEquals(rdd2.getType(), "OTHER");
         assertEquals(rdd2.getSuccess(), true);
+        validateSdkName(rdd2, "ja-custom");
     }
 
     @Test
@@ -163,10 +179,17 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(nineRdd.getName(), "com/springbootstartertest/controller/TargetObject.nine");
         assertEquals(nineRdd.getType(), "OTHER");
         assertEquals(nineRdd.getSuccess(), true);
+        validateSdkName(nineRdd, "ja-custom");
 
         assertNotNull(httpRdd);
         String requestOperationId = d.getId();
         String rddId = httpRdd.getId();
         assertTrue(rddId.contains(requestOperationId));
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/JdbcSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/JdbcSmokeTest.java
@@ -1,12 +1,19 @@
 package com.springbootstartertest.smoketest;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
-import com.microsoft.applicationinsights.internal.schemav2.RequestData;
-import com.microsoft.applicationinsights.smoketest.*;
+import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
+import com.microsoft.applicationinsights.smoketest.DependencyContainer;
+import com.microsoft.applicationinsights.smoketest.TargetUri;
+import com.microsoft.applicationinsights.smoketest.UseAgent;
+import com.microsoft.applicationinsights.smoketest.WithDependencyContainers;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @UseAgent
@@ -38,6 +45,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertEquals("jdbc:hsqldb:mem:test", rdd.getName());
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -50,6 +58,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertEquals("jdbc:hsqldb:mem:test", rdd.getName());
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -63,6 +72,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertEquals("insert into abc (xyz) values (?)", rdd.getData());
         assertEquals(" [Batch of 3]", rdd.getProperties().get("Args"));
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -77,6 +87,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
                 " insert into abc (xyz) values ('v')", rdd.getData());
         assertEquals(" [Batch]", rdd.getProperties().get("Args"));
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -100,6 +111,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:mysql://"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -123,6 +135,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:mysql://"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -135,6 +148,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:postgresql://"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -147,6 +161,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:postgresql://"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -159,6 +174,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:sqlserver://"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Test
@@ -171,6 +187,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:sqlserver://"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Ignore("FIXME: need custom container with oracle db")
@@ -184,6 +201,7 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:oracle:thin:@"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
     }
 
     @Ignore("FIXME: need custom container with oracle db")
@@ -197,5 +215,12 @@ public class JdbcSmokeTest extends AiSmokeTest {
         assertTrue(rdd.getName().startsWith("jdbc:oracle:thin:@"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+        validateSdkName(rdd, "ja-jdbc");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -3,6 +3,8 @@ package com.springbootstartertest.smoketest;
 import java.util.List;
 import java.util.Map;
 
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.EventData;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
@@ -17,6 +19,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
 @UseAgent
@@ -80,6 +83,7 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         String requestOperationId = d.getId();
         assertTrue(requestOperationId.contains(exceptionEnvelope.getTags().
                 getOrDefault("ai.operation.id", null)));
+        validateSdkName(d, "java-web-sbs");
     }
 
     @Test
@@ -92,6 +96,8 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         String requestOperationId = d.getId();
         String rddId = rdd.getId();
         assertTrue(rddId.contains(requestOperationId));
+        validateSdkName(d, "java-web-sbs");
+        validateSdkName(rdd, "ja-http");
     }
 
     @Test
@@ -104,6 +110,8 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         String requestOperationId = d.getId();
         String rddId = rdd.getId();
         assertTrue(rddId.contains(requestOperationId));
+        validateSdkName(d, "java-web-sbs");
+        validateSdkName(rdd, "ja-http");
     }
 
     @Test
@@ -116,6 +124,8 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         String requestOperationId = d.getId();
         String rddId = rdd.getId();
         assertTrue(rddId.contains(requestOperationId));
+        validateSdkName(d, "java-web-sbs");
+        validateSdkName(rdd, "ja-http");
     }
 
     @Test
@@ -128,6 +138,8 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         String requestOperationId = d.getId();
         String rddId = rdd.getId();
         assertTrue(rddId.contains(requestOperationId));
+        validateSdkName(d, "java-web-sbs");
+        validateSdkName(rdd, "ja-http");
     }
 
     @Test
@@ -140,5 +152,13 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         String requestOperationId = d.getId();
         String rddId = rdd.getId();
         assertTrue(rddId.contains(requestOperationId));
+        validateSdkName(d, "java-web-sbs");
+        validateSdkName(rdd, "ja-http");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -1,10 +1,15 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Comparator;
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
@@ -41,37 +46,42 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("Log4j", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "java-log4j1");
 
         MessageData md2 = logs.get(0);
         assertEquals("This is log4j1.2 debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("Log4j", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        validateSdkName(md2, "java-log4j1");
 
         MessageData md3 = logs.get(2);
         assertEquals("This is log4j1.2 info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("Log4j", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
+        validateSdkName(md3, "java-log4j1");
 
         MessageData md4 = logs.get(3);
         assertEquals("This is log4j1.2 warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("Log4j", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
-
+        validateSdkName(md4, "java-log4j1");
 
         MessageData md5 = logs.get(4);
         assertEquals("This is log4j1.2 error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("Log4j", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
+        validateSdkName(md5, "java-log4j1");
 
         MessageData md6 = logs.get(5);
         assertEquals("This is log4j1.2 fatal.", md6.getMessage());
         assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
         assertEquals("Log4j", md6.getProperties().get("SourceType"));
         assertEquals("FATAL", md6.getProperties().get("LoggingLevel"));
+        validateSdkName(md6, "java-log4j1");
     }
 
     @Test
@@ -88,5 +98,12 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
         assertEquals("This is an exception!", ed1.getProperties().get("Logger Message"));
         assertEquals("Log4j", ed1.getProperties().get("SourceType"));
         assertEquals("ERROR", ed1.getProperties().get("LoggingLevel"));
+        validateSdkName(ed1, "java-log4j1");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -1,9 +1,14 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
@@ -24,37 +29,42 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "ja-logging");
 
         MessageData md2 = getTelemetryDataForType(1, "MessageData");
         assertEquals("This is log4j1.2 debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        validateSdkName(md2, "ja-logging");
 
         MessageData md3 = getTelemetryDataForType(2, "MessageData");
         assertEquals("This is log4j1.2 info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
+        validateSdkName(md3, "ja-logging");
 
         MessageData md4 = getTelemetryDataForType(3, "MessageData");
         assertEquals("This is log4j1.2 warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("Logger", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
-
+        validateSdkName(md4, "ja-logging");
 
         MessageData md5 = getTelemetryDataForType(4, "MessageData");
         assertEquals("This is log4j1.2 error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("Logger", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
+        validateSdkName(md5, "ja-logging");
 
         MessageData md6 = getTelemetryDataForType(5, "MessageData");
         assertEquals("This is log4j1.2 fatal.", md6.getMessage());
         assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
         assertEquals("Logger", md6.getProperties().get("SourceType"));
         assertEquals("FATAL", md6.getProperties().get("LoggingLevel"));
+        validateSdkName(md6, "ja-logging");
     }
 
     @Test
@@ -71,5 +81,12 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
         assertEquals("This is an exception!", ed1.getProperties().get("Logger Message"));
         assertEquals("Logger", ed1.getProperties().get("SourceType"));
         assertEquals("ERROR", ed1.getProperties().get("LoggingLevel"));
+        validateSdkName(ed1, "ja-logging");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -1,10 +1,15 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Comparator;
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
@@ -37,37 +42,42 @@ public class TraceLog4j2Test extends AiSmokeTest {
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("Log4j", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "java-log4j2");
 
         MessageData md2 = logs.get(0);
         assertEquals("This is log4j2 debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("Log4j", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        validateSdkName(md2, "java-log4j2");
 
         MessageData md3 = logs.get(2);
         assertEquals("This is log4j2 info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("Log4j", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
+        validateSdkName(md3, "java-log4j2");
 
         MessageData md4 = logs.get(3);
         assertEquals("This is log4j2 warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("Log4j", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
-
+        validateSdkName(md4, "java-log4j2");
 
         MessageData md5 = logs.get(4);
         assertEquals("This is log4j2 error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("Log4j", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
+        validateSdkName(md5, "java-log4j2");
 
         MessageData md6 = logs.get(5);
         assertEquals("This is log4j2 fatal.", md6.getMessage());
         assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
         assertEquals("Log4j", md6.getProperties().get("SourceType"));
         assertEquals("FATAL", md6.getProperties().get("LoggingLevel"));
+        validateSdkName(md6, "java-log4j2");
     }
 
     @Test
@@ -84,5 +94,12 @@ public class TraceLog4j2Test extends AiSmokeTest {
         assertEquals("This is an exception!", ed1.getProperties().get("Logger Message"));
         assertEquals("Log4j", ed1.getProperties().get("SourceType"));
         assertEquals("ERROR", ed1.getProperties().get("LoggingLevel"));
+        validateSdkName(ed1, "java-log4j2");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -1,9 +1,14 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
@@ -24,37 +29,42 @@ public class TraceLog4j2Test extends AiSmokeTest {
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "ja-logging");
 
         MessageData md2 = getTelemetryDataForType(1, "MessageData");
         assertEquals("This is log4j2 debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        validateSdkName(md2, "ja-logging");
 
         MessageData md3 = getTelemetryDataForType(2, "MessageData");
         assertEquals("This is log4j2 info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
+        validateSdkName(md3, "ja-logging");
 
         MessageData md4 = getTelemetryDataForType(3, "MessageData");
         assertEquals("This is log4j2 warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("Logger", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
-
+        validateSdkName(md4, "ja-logging");
 
         MessageData md5 = getTelemetryDataForType(4, "MessageData");
         assertEquals("This is log4j2 error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("Logger", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
+        validateSdkName(md5, "ja-logging");
 
         MessageData md6 = getTelemetryDataForType(5, "MessageData");
         assertEquals("This is log4j2 fatal.", md6.getMessage());
         assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
         assertEquals("Logger", md6.getProperties().get("SourceType"));
         assertEquals("FATAL", md6.getProperties().get("LoggingLevel"));
+        validateSdkName(md6, "ja-logging");
     }
 
     @Test
@@ -71,5 +81,12 @@ public class TraceLog4j2Test extends AiSmokeTest {
         assertEquals("This is an exception!", ed1.getProperties().get("Logger Message"));
         assertEquals("Logger", ed1.getProperties().get("SourceType"));
         assertEquals("ERROR", ed1.getProperties().get("LoggingLevel"));
+        validateSdkName(ed1, "ja-logging");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -1,10 +1,15 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Comparator;
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
@@ -46,30 +51,35 @@ public class TraceLogBackTest extends AiSmokeTest {
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("LOGBack", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "java-logback");
 
         MessageData md2 = logs.get(0);
         assertEquals("This is logback debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("LOGBack", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "java-logback");
 
         MessageData md3 = logs.get(2);
         assertEquals("This is logback info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("LOGBack", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "java-logback");
 
         MessageData md4 = logs.get(3);
         assertEquals("This is logback warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("LOGBack", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "java-logback");
 
         MessageData md5 = logs.get(4);
         assertEquals("This is logback error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("LOGBack", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "java-logback");
     }
 
     @Test
@@ -86,5 +96,12 @@ public class TraceLogBackTest extends AiSmokeTest {
         assertEquals("This is an exception!", ed1.getProperties().get("Logger Message"));
         assertEquals("LOGBack", ed1.getProperties().get("SourceType"));
         assertEquals("ERROR", ed1.getProperties().get("LoggingLevel"));
+        validateSdkName(ed1, "java-logback");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -1,9 +1,14 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.MessageData;
@@ -32,30 +37,35 @@ public class TraceLogBackTest extends AiSmokeTest {
         assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
         assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        validateSdkName(md1, "ja-logging");
 
         MessageData md2 = getTelemetryDataForType(1, "MessageData");
         assertEquals("This is logback debug.", md2.getMessage());
         assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
         assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        validateSdkName(md2, "ja-logging");
 
         MessageData md3 = getTelemetryDataForType(2, "MessageData");
         assertEquals("This is logback info.", md3.getMessage());
         assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
         assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
+        validateSdkName(md3, "ja-logging");
 
         MessageData md4 = getTelemetryDataForType(3, "MessageData");
         assertEquals("This is logback warn.", md4.getMessage());
         assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
         assertEquals("Logger", md4.getProperties().get("SourceType"));
         assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
+        validateSdkName(md4, "ja-logging");
 
         MessageData md5 = getTelemetryDataForType(4, "MessageData");
         assertEquals("This is logback error.", md5.getMessage());
         assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
         assertEquals("Logger", md5.getProperties().get("SourceType"));
         assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
+        validateSdkName(md5, "ja-logging");
     }
 
     @Test
@@ -72,5 +82,12 @@ public class TraceLogBackTest extends AiSmokeTest {
         assertEquals("This is an exception!", ed1.getProperties().get("Logger Message"));
         assertEquals("Logger", ed1.getProperties().get("SourceType"));
         assertEquals("ERROR", ed1.getProperties().get("LoggingLevel"));
+        validateSdkName(ed1, "ja-logging");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/test/smoke/testApps/WebAuto/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebAutoTest.java
+++ b/test/smoke/testApps/WebAuto/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebAutoTest.java
@@ -1,7 +1,11 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import com.microsoft.applicationinsights.internal.schemav2.Domain;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import org.junit.*;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
 public class WebAutoTest extends AiSmokeTest {
@@ -13,5 +17,13 @@ public class WebAutoTest extends AiSmokeTest {
         assertTrue("mocked ingestion has 0 items", mockedIngestion.getItemCount() > 0);
 
         assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        RequestData d = getTelemetryDataForType(0, "RequestData");
+        validateSdkName(d, "java-web-auto");
+    }
+
+    private void validateSdkName(Domain data, String sdkName) {
+        Envelope envelope = mockedIngestion.getEnvelopeForBaseData(data);
+        String sdkVersion = envelope.getTags().get("ai.internal.sdkVersion");
+        assertThat(sdkVersion, startsWith(sdkName + ":"));
     }
 }

--- a/web-auto/src/main/java/com/microsoft/applicationinsights/web/internal/auto/AIServletContainerInitializer.java
+++ b/web-auto/src/main/java/com/microsoft/applicationinsights/web/internal/auto/AIServletContainerInitializer.java
@@ -34,7 +34,7 @@ public class AIServletContainerInitializer implements ServletContainerInitialize
     @Override
     public void onStartup(Set<Class<?>> c, ServletContext ctx) {
         FilterRegistration.Dynamic filterRegistration =
-                ctx.addFilter(WebFilterName.NAME, new WebRequestTrackingFilter());
+                ctx.addFilter(WebFilterName.NAME, WebRequestTrackingFilter.createForWebAuto());
         if (filterRegistration != null) {
             filterRegistration.addMappingForUrlPatterns(null, false, "/*");
         }

--- a/web-auto/src/main/java/com/microsoft/applicationinsights/web/internal/auto/SpringBoot13AndPriorAutoConfiguration.java
+++ b/web-auto/src/main/java/com/microsoft/applicationinsights/web/internal/auto/SpringBoot13AndPriorAutoConfiguration.java
@@ -37,7 +37,7 @@ public class SpringBoot13AndPriorAutoConfiguration {
     public FilterRegistrationBean filterRegistrationBean() throws Exception {
         FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean();
         filterRegistrationBean.setName(WebFilterName.NAME);
-        filterRegistrationBean.setFilter(new WebRequestTrackingFilter());
+        filterRegistrationBean.setFilter(WebRequestTrackingFilter.createForWebAuto());
         filterRegistrationBean.addUrlPatterns("/*");
         filterRegistrationBean.setOrder(Integer.MIN_VALUE);
         return filterRegistrationBean;

--- a/web-auto/src/main/java/com/microsoft/applicationinsights/web/internal/auto/SpringBootAutoConfiguration.java
+++ b/web-auto/src/main/java/com/microsoft/applicationinsights/web/internal/auto/SpringBootAutoConfiguration.java
@@ -37,7 +37,7 @@ public class SpringBootAutoConfiguration {
     public FilterRegistrationBean filterRegistrationBean() {
         FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean();
         filterRegistrationBean.setName(WebFilterName.NAME);
-        filterRegistrationBean.setFilter(new WebRequestTrackingFilter());
+        filterRegistrationBean.setFilter(WebRequestTrackingFilter.createForWebAuto());
         filterRegistrationBean.addUrlPatterns("/*");
         filterRegistrationBean.setOrder(Integer.MIN_VALUE);
         return filterRegistrationBean;

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
@@ -43,18 +43,27 @@ public final class HttpServerHandler {
      */
     private final List<ThreadLocalCleaner> cleaners;
 
-    /**
-     * Creates a new instance of {@link HttpServerHandler}
-     *
-     * @param extractor The {@code HttpExtractor} used to extract information from request and repsonse
-     * @param webModulesContainer The {@code WebModulesContainer} used to hold
-     *        {@link com.microsoft.applicationinsights.web.extensibility.modules.WebTelemetryModule}
-     * @param telemetryClient The {@code TelemetryClient} used to send telemetry
-     */
+    private final String sdkVersion;
+
     public HttpServerHandler(HttpExtractor extractor,
-        WebModulesContainer webModulesContainer,
-        List<ThreadLocalCleaner> cleaners,
-        /* Nullable */ TelemetryClient telemetryClient) {
+                             WebModulesContainer webModulesContainer,
+                             List<ThreadLocalCleaner> cleaners,
+                             TelemetryClient telemetryClient) {
+        this(extractor, webModulesContainer, cleaners, telemetryClient, null);
+    }
+        /**
+         * Creates a new instance of {@link HttpServerHandler}
+         *
+         * @param extractor The {@code HttpExtractor} used to extract information from request and repsonse
+         * @param webModulesContainer The {@code WebModulesContainer} used to hold
+         *        {@link com.microsoft.applicationinsights.web.extensibility.modules.WebTelemetryModule}
+         * @param telemetryClient The {@code TelemetryClient} used to send telemetry
+         */
+    public HttpServerHandler(HttpExtractor extractor,
+                             WebModulesContainer webModulesContainer,
+                             List<ThreadLocalCleaner> cleaners,
+                             TelemetryClient telemetryClient,
+                             String sdkVersion) {
         Validate.notNull(extractor, "extractor");
         Validate.notNull(webModulesContainer, "WebModuleContainer");
         Validate.notNull(cleaners, "ThreadLocalCleaners");
@@ -62,6 +71,7 @@ public final class HttpServerHandler {
         this.webModulesContainer = webModulesContainer;
         this.cleaners = cleaners;
         this.telemetryClient = telemetryClient;
+        this.sdkVersion = sdkVersion;
     }
 
     /**
@@ -112,6 +122,9 @@ public final class HttpServerHandler {
         int resultCode = extractor.getStatusCode(response);
         requestTelemetry.setSuccess(resultCode < 400);
         requestTelemetry.setResponseCode(Integer.toString(resultCode));
+        if (sdkVersion != null) {
+            requestTelemetry.getContext().getInternal().setSdkVersion(sdkVersion);
+        }
         if (ThreadContext.getRequestTelemetryContext() == null) {
             // e.g. when called from AIHttpServletListener
             ThreadContext.setRequestTelemetryContext(context);


### PR DESCRIPTION
See #889 (does not address everything, so not marking it for close).

* Requests
  * java-web-auto:2.5.0
  * java-web-manual:2.5.0
  * java-web-sbs:2.5.0   (sbs = spring boot starter)
* Remote dependencies
  * ja-jdbc:2.5.0    (ja = java agent)
  * ja-http:2.5.0
  * ja-redis:2.5.0
  * ja-custom:2.5.0   (custom instrumentation defined in AI-Agent.xml)
* Traces
  * java-log4j1:2.5.0  (are underscores allowed, e.g. java-log4j1_2:2.5.0?)
  * java-log4j2:2.5.0
  * java-logback:2.5.0
  * ja-logging:2.5.0
  * java-deadlock:2.5.0   (deadlock detection)
* Exceptions
  * any of the above (except java-deadlock)
* Performance counters
  * java-metric-jvm:2.5.0    (built-in jvm metrics, e.g. GC, Memory)
  * java-metric-linux:2.5.0
  * java-metric-windows:2.5.0
  * java-metric-jmx:2.5.0   (custom jmx metrics)
* Metrics
  * java-heartbeat:2.5.0
* Any telemetry sent programmatically via SDK
  * java:2.5.0

Still to be done later (not in this PR):

* CollectD
  * java-collectd:2.5.0
* Micrometer
  * java-micrometer:2.5.0
* Break out "ja-http" further:
  * ja-http-apache3:2.5.0
  * ja-http-apache4:2.5.0
  * ja-http-ok2:2.5.0
  * ja-http-ok3:2.5.0
  * ja-http-url:2.5.0
* Break out "ja-logging" further:
  * ja-log4j1:2.5.0  (are underscores allowed, e.g. java-log4j1_2:2.5.0?)
  * ja-log4j2:2.5.0
  * ja-logback:2.5.0
