### PR TITLE
Add logging capture threshold

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -26,7 +26,7 @@ plugins {
 apply from: "$buildScriptsDir/common-java.gradle"
 apply from: "$buildScriptsDir/publishing.gradle"
 
-def instrumentationVersion = '0.14.2'
+def instrumentationVersion = '0.14.3'
 
 def shadowPrefix = 'com.microsoft.applicationinsights.agent.shadow'
 

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/AIAgentXmlLoader.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/AIAgentXmlLoader.java
@@ -119,8 +119,19 @@ class AIAgentXmlLoader {
         jdbcConfiguration.put("captureGetConnection", false);
         jdbcConfiguration.put("explainPlanThresholdMillis", builtInConfiguration.getQueryPlanThresholdInMS());
 
+        // must be one of trace, debug, info, warn, error (which are supported by both log4j and logback)
+        String loggingThreshold = builtInConfiguration.getLoggingThreshold();
+
+        Map<String, Object> log4jConfiguration = new HashMap<>();
+        log4jConfiguration.put("threshold", loggingThreshold);
+
+        Map<String, Object> logbackConfiguration = new HashMap<>();
+        logbackConfiguration.put("threshold", loggingThreshold);
+
         instrumentationConfiguration.put("servlet", servletConfiguration);
         instrumentationConfiguration.put("jdbc", jdbcConfiguration);
+        instrumentationConfiguration.put("log4j", log4jConfiguration);
+        instrumentationConfiguration.put("logback", logbackConfiguration);
 
         return instrumentationConfiguration;
     }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/MainEntryPoint.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/MainEntryPoint.java
@@ -99,7 +99,8 @@ public class MainEntryPoint {
                 AIAgentXmlLoader.getInstrumentationConfig(builtInInstrumentation));
 
         EngineModule.createWithSomeDefaults(instrumentation, tmpDir, Global.getThreadContextThreadLocal(),
-                instrumentationDescriptors, configServiceFactory, new AgentImpl(),
+                instrumentationDescriptors, configServiceFactory, new AgentImpl(), false,
+                Collections.singletonList("com.microsoft.applicationinsights.agent"),
                 Collections.singletonList("com.microsoft.applicationinsights.agent"), agentJarFile);
     }
 }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/BuiltInInstrumentation.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/BuiltInInstrumentation.java
@@ -32,6 +32,7 @@ public class BuiltInInstrumentation {
     private final boolean jdbcEnabled;
 
     private final boolean loggingEnabled;
+    private final String loggingThreshold;
 
     private final boolean jedisEnabled;
 
@@ -43,6 +44,7 @@ public class BuiltInInstrumentation {
                                   boolean w3cBackCompatEnabled,
                                   boolean jdbcEnabled,
                                   boolean loggingEnabled,
+                                  String loggingThreshold,
                                   boolean jedisEnabled,
                                   long queryPlanThresholdInMS) {
         this.enabled = enabled;
@@ -51,6 +53,7 @@ public class BuiltInInstrumentation {
         this.w3cBackCompatEnabled = w3cBackCompatEnabled;
         this.jdbcEnabled = jdbcEnabled;
         this.loggingEnabled = loggingEnabled;
+        this.loggingThreshold = loggingThreshold;
         this.jedisEnabled = jedisEnabled;
         this.queryPlanThresholdInMS = queryPlanThresholdInMS;
     }
@@ -73,6 +76,10 @@ public class BuiltInInstrumentation {
 
     public boolean isJdbcEnabled() {
         return jdbcEnabled;
+    }
+
+    public String getLoggingThreshold() {
+        return loggingThreshold;
     }
 
     public boolean isLoggingEnabled() {

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/BuiltInInstrumentationBuilder.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/BuiltInInstrumentationBuilder.java
@@ -38,6 +38,7 @@ public class BuiltInInstrumentationBuilder {
     private boolean jdbcEnabled;
 
     private boolean loggingEnabled;
+    private String loggingThreshold;
 
     private boolean jedisEnabled;
 
@@ -54,6 +55,7 @@ public class BuiltInInstrumentationBuilder {
                 w3cBackCompatEnabled && enabled,
                 jdbcEnabled && enabled,
                 loggingEnabled && enabled,
+                loggingThreshold,
                 jedisEnabled && enabled,
                 queryPlanThresholdInMS
         );
@@ -73,8 +75,9 @@ public class BuiltInInstrumentationBuilder {
         this.jdbcEnabled = jdbcEnabled;
     }
 
-    public void setLoggingEnabled(boolean loggingEnabled) {
+    public void setLoggingEnabled(boolean loggingEnabled, String loggingThreshold) {
         this.loggingEnabled = loggingEnabled;
+        this.loggingThreshold = loggingThreshold;
     }
 
     public void setJedisEnabled(boolean jedisEnabled) {

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlAgentConfigurationBuilder.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlAgentConfigurationBuilder.java
@@ -175,8 +175,9 @@ public class XmlAgentConfigurationBuilder {
         builtInConfigurationBuilder.setJdbcEnabled(XmlParserUtils.getEnabled(XmlParserUtils.getFirst(nodes), JDBC_TAG));
 
         nodes = builtInElement.getElementsByTagName(LOGGING_TAG);
-        builtInConfigurationBuilder
-                .setLoggingEnabled(XmlParserUtils.getEnabled(XmlParserUtils.getFirst(nodes), LOGGING_TAG));
+        builtInConfigurationBuilder.setLoggingEnabled(
+                XmlParserUtils.getEnabled(XmlParserUtils.getFirst(nodes), LOGGING_TAG),
+                XmlParserUtils.getStringAttribute(XmlParserUtils.getFirst(nodes), "threshold", "warn"));
 
         nodes = builtInElement.getElementsByTagName(JEDIS_TAG);
         Element element = XmlParserUtils.getFirst(nodes);

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlParserUtils.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlParserUtils.java
@@ -98,6 +98,17 @@ class XmlParserUtils {
         return defaultValue;
     }
 
+    public static String getStringAttribute(Element element, String attributeName, String defaultValue) {
+        if (element == null) {
+            return defaultValue;
+        }
+        String strValue = element.getAttribute(attributeName);
+        if (!Strings.isNullOrEmpty(strValue)) {
+            return strValue;
+        }
+        return defaultValue;
+    }
+
     public static Long getLong(Element element, String elementName) {
         if (element == null) {
             return null;

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlParserUtils.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlParserUtils.java
@@ -45,7 +45,7 @@ class XmlParserUtils {
         return (Element) node;
     }
 
-    public static boolean getEnabled(Element element, String attributeName) {
+    public static boolean getEnabled(Element element, String elementName) {
         if (element == null) {
             return true;
         }
@@ -57,7 +57,7 @@ class XmlParserUtils {
             return true;
         } catch (Exception e) {
             logger.error("Failed to parse attribute '{}' of '{}', default value ({}) will be used.", ENABLED_ATTRIBUTE,
-                    attributeName, true);
+                    elementName, true);
         }
         return true;
     }

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlParserUtils.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlParserUtils.java
@@ -113,7 +113,7 @@ class XmlParserUtils {
             }
             return null;
         } catch (Exception e) {
-            logger.error("Failed to parse attribute '{}' of '{}'", ENABLED_ATTRIBUTE, elementName);
+            logger.error("Failed to parse value of '{}'", elementName);
         }
         return null;
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -109,7 +109,7 @@ archivesBaseName = 'applicationinsights-core'
 
 dependencies {
     compileOnly (project(':agent')) { transitive = false }
-    compileOnly ([group: 'org.glowroot.instrumentation', name: 'instrumentation-api', version: '0.14.2']) { transitive = false }
+    compileOnly ([group: 'org.glowroot.instrumentation', name: 'instrumentation-api', version: '0.14.3']) { transitive = false }
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.5'])
     compile ([group: 'commons-io', name: 'commons-io', version: '2.6' ])

--- a/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -17,44 +17,26 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
     @TargetUri("/traceLog4j1_2")
     public void testTraceLog4j1_2() {
 
-        assertEquals(6, mockedIngestion.getCountForType("MessageData"));
+        assertEquals(3, mockedIngestion.getCountForType("MessageData"));
 
         MessageData md1 = getTelemetryDataForType(0, "MessageData");
-        assertEquals("This is log4j1.2 trace.", md1.getMessage());
-        assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
+        assertEquals("This is log4j1.2 warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
+
 
         MessageData md2 = getTelemetryDataForType(1, "MessageData");
-        assertEquals("This is log4j1.2 debug.", md2.getMessage());
-        assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
+        assertEquals("This is log4j1.2 error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
 
         MessageData md3 = getTelemetryDataForType(2, "MessageData");
-        assertEquals("This is log4j1.2 info.", md3.getMessage());
-        assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
+        assertEquals("This is log4j1.2 fatal.", md3.getMessage());
+        assertEquals(SeverityLevel.Critical, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
-
-        MessageData md4 = getTelemetryDataForType(3, "MessageData");
-        assertEquals("This is log4j1.2 warn.", md4.getMessage());
-        assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
-        assertEquals("Logger", md4.getProperties().get("SourceType"));
-        assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
-
-
-        MessageData md5 = getTelemetryDataForType(4, "MessageData");
-        assertEquals("This is log4j1.2 error.", md5.getMessage());
-        assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
-        assertEquals("Logger", md5.getProperties().get("SourceType"));
-        assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
-
-        MessageData md6 = getTelemetryDataForType(5, "MessageData");
-        assertEquals("This is log4j1.2 fatal.", md6.getMessage());
-        assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
-        assertEquals("Logger", md6.getProperties().get("SourceType"));
-        assertEquals("FATAL", md6.getProperties().get("LoggingLevel"));
+        assertEquals("FATAL", md3.getProperties().get("LoggingLevel"));
     }
 
     @Test

--- a/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -17,44 +17,25 @@ public class TraceLog4j2Test extends AiSmokeTest {
     @Test
     @TargetUri("/traceLog4j2")
     public void testTraceLog4j2() {
-        assertEquals(6, mockedIngestion.getCountForType("MessageData"));
+        assertEquals(3, mockedIngestion.getCountForType("MessageData"));
 
         MessageData md1 = getTelemetryDataForType(0, "MessageData");
-        assertEquals("This is log4j2 trace.", md1.getMessage());
-        assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
+        assertEquals("This is log4j2 warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
 
         MessageData md2 = getTelemetryDataForType(1, "MessageData");
-        assertEquals("This is log4j2 debug.", md2.getMessage());
-        assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
+        assertEquals("This is log4j2 error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
 
         MessageData md3 = getTelemetryDataForType(2, "MessageData");
-        assertEquals("This is log4j2 info.", md3.getMessage());
-        assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
+        assertEquals("This is log4j2 fatal.", md3.getMessage());
+        assertEquals(SeverityLevel.Critical, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
-
-        MessageData md4 = getTelemetryDataForType(3, "MessageData");
-        assertEquals("This is log4j2 warn.", md4.getMessage());
-        assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
-        assertEquals("Logger", md4.getProperties().get("SourceType"));
-        assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
-
-
-        MessageData md5 = getTelemetryDataForType(4, "MessageData");
-        assertEquals("This is log4j2 error.", md5.getMessage());
-        assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
-        assertEquals("Logger", md5.getProperties().get("SourceType"));
-        assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
-
-        MessageData md6 = getTelemetryDataForType(5, "MessageData");
-        assertEquals("This is log4j2 fatal.", md6.getMessage());
-        assertEquals(SeverityLevel.Critical, md6.getSeverityLevel());
-        assertEquals("Logger", md6.getProperties().get("SourceType"));
-        assertEquals("FATAL", md6.getProperties().get("LoggingLevel"));
+        assertEquals("FATAL", md3.getProperties().get("LoggingLevel"));
     }
 
     @Test

--- a/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -25,37 +25,19 @@ public class TraceLogBackTest extends AiSmokeTest {
     @Test
     @TargetUri("/traceLogBack")
     public void testTraceLogBack() {
-        assertEquals(5, mockedIngestion.getCountForType("MessageData"));
+        assertEquals(2, mockedIngestion.getCountForType("MessageData"));
 
         MessageData md1 = getTelemetryDataForType(0, "MessageData");
-        assertEquals("This is logback trace.", md1.getMessage());
-        assertEquals(SeverityLevel.Verbose, md1.getSeverityLevel());
+        assertEquals("This is logback warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("TRACE", md1.getProperties().get("LoggingLevel"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
 
         MessageData md2 = getTelemetryDataForType(1, "MessageData");
-        assertEquals("This is logback debug.", md2.getMessage());
-        assertEquals(SeverityLevel.Verbose, md2.getSeverityLevel());
+        assertEquals("This is logback error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("DEBUG", md2.getProperties().get("LoggingLevel"));
-
-        MessageData md3 = getTelemetryDataForType(2, "MessageData");
-        assertEquals("This is logback info.", md3.getMessage());
-        assertEquals(SeverityLevel.Information, md3.getSeverityLevel());
-        assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("INFO", md3.getProperties().get("LoggingLevel"));
-
-        MessageData md4 = getTelemetryDataForType(3, "MessageData");
-        assertEquals("This is logback warn.", md4.getMessage());
-        assertEquals(SeverityLevel.Warning, md4.getSeverityLevel());
-        assertEquals("Logger", md4.getProperties().get("SourceType"));
-        assertEquals("WARN", md4.getProperties().get("LoggingLevel"));
-
-        MessageData md5 = getTelemetryDataForType(4, "MessageData");
-        assertEquals("This is logback error.", md5.getMessage());
-        assertEquals(SeverityLevel.Error, md5.getSeverityLevel());
-        assertEquals("Logger", md5.getProperties().get("SourceType"));
-        assertEquals("ERROR", md5.getProperties().get("LoggingLevel"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
     }
 
     @Test


### PR DESCRIPTION
This allows configuring a `threshold` to be applied for logging capture in `AI-Agent.xml`, e.g.

```
...
<BuiltIn>
   <Logging threshold="error" />
</BuiltIn>
...
```

The threshold (if specified) must be one of `trace`, `debug`, `info`, `warn`, `error`.

The default threshold applied is `warn`.