### PR TITLE
Reduce the logging output for "Backoff has been reset"

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
@@ -129,7 +129,7 @@ public final class TransmissionPolicyManager implements Stoppable, TransmissionH
     public void clearBackoff() {
         policyState.setCurrentState(TransmissionPolicy.UNBLOCKED);
         backoffManager.onDoneSending();
-//        InternalLogger.INSTANCE.info("Backoff has been reset.");
+        InternalLogger.INSTANCE.trace("Backoff has been reset.");
     }
 
     /**


### PR DESCRIPTION
As mentioned in #894 this message floods the console during development. I don't think it should be totally removed (anyway it shouldn't be commented out!), as it can be interesting to know everything went well, when you are debugging.

Fix #894
