### PR TITLE
Update logic for logging backoff message

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
@@ -129,7 +129,7 @@ public final class TransmissionPolicyManager implements Stoppable, TransmissionH
     public void clearBackoff() {
         policyState.setCurrentState(TransmissionPolicy.UNBLOCKED);
         backoffManager.onDoneSending();
-//        InternalLogger.INSTANCE.info("Backoff has been reset.");
+        InternalLogger.INSTANCE.trace("Backoff has been reset.");
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
@@ -127,9 +127,10 @@ public final class TransmissionPolicyManager implements Stoppable, TransmissionH
      * Clear the current thread state and and reset the back off counter.
      */
     public void clearBackoff() {
-        policyState.setCurrentState(TransmissionPolicy.UNBLOCKED);
+        if (policyState.setCurrentState(TransmissionPolicy.UNBLOCKED)) {
+            InternalLogger.INSTANCE.trace("Backoff has been reset.");
+        }
         backoffManager.onDoneSending();
-        InternalLogger.INSTANCE.trace("Backoff has been reset.");
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyState.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyState.java
@@ -21,19 +21,21 @@
 
 package com.microsoft.applicationinsights.internal.channel.common;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Created by gupele on 6/29/2015.
  */
 final class TransmissionPolicyState implements TransmissionPolicyStateFetcher, TransmissionPolicyStateSetter {
-    private volatile TransmissionPolicy currentState = TransmissionPolicy.UNBLOCKED;
+    private AtomicReference<TransmissionPolicy> currentState = new AtomicReference<>(TransmissionPolicy.UNBLOCKED);
 
     @Override
     public TransmissionPolicy getCurrentState() {
-        return currentState;
+        return currentState.get();
     }
 
     @Override
-    public void setCurrentState(TransmissionPolicy currentState) {
-        this.currentState = currentState;
+    public boolean setCurrentState(TransmissionPolicy newState) {
+        return this.currentState.getAndSet(newState) != newState;
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyStateSetter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyStateSetter.java
@@ -25,5 +25,10 @@ package com.microsoft.applicationinsights.internal.channel.common;
  * Created by gupele on 6/29/2015.
  */
 interface TransmissionPolicyStateSetter {
-    void setCurrentState(TransmissionPolicy currentState);
+    /**
+     * Sets the current TransmissionPolicy state.
+     * @param newState The new value for current state
+     * @return true if the state changed (newState != currentState); false otherwise.
+     */
+    boolean setCurrentState(TransmissionPolicy newState);
 }


### PR DESCRIPTION
Only log if backoff state changed.
Fix #894 .
Includes changes from #1028