### PR TITLE
Stop http debug logging during test

### DIFF
--- a/test/smoke/testApps/SpringBoot1_3Auto/src/smokeTest/resources/logback.xml
+++ b/test/smoke/testApps/SpringBoot1_3Auto/src/smokeTest/resources/logback.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
With http debug logging on, the test log is so huge it's hard to find issues.