### PR TITLE
Validate remote dependency operation id

### DIFF
--- a/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SampleTestWithDependencyContainer.java
+++ b/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SampleTestWithDependencyContainer.java
@@ -1,21 +1,48 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import org.junit.*;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 @UseAgent
 @WithDependencyContainers(@DependencyContainer(value="redis", portMapping="6379"))
 public class SampleTestWithDependencyContainer extends AiSmokeTest {
 
-    // TODO FIXME this is a sample test for dependencies. it shouldn't count towards test coverage
     @Test
     @TargetUri("/index.jsp")
-    public void doCalcSendsRequestDataAndMetricData() throws Exception {
-        assertTrue("mocked ingestion has no data", mockedIngestion.hasData());
-        assertTrue("mocked ingestion has 0 items", mockedIngestion.getItemCount() > 0);
+    public void doCalcSendsRequestDataAndMetricData() {
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
 
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
+        assertEquals("Redis", rdd.getType());
+        assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
+    }
+
+    private static void assertSameOperationId(Envelope rdEnvelope, Envelope rddEnvelope) {
+        String operationId = rdEnvelope.getTags().get("ai.operation.id");
+        String operationParentId = rdEnvelope.getTags().get("ai.operation.parentId");
+
+        assertNotNull(operationId);
+        assertNotNull(operationParentId);
+
+        assertEquals(operationId, rddEnvelope.getTags().get("ai.operation.id"));
+        assertEquals(operationParentId, rddEnvelope.getTags().get("ai.operation.parentId"));
     }
 }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/CustomInstrumentationTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/CustomInstrumentationTest.java
@@ -2,6 +2,8 @@ package com.springbootstartertest.smoketest;
 
 import java.util.List;
 
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
@@ -11,9 +13,10 @@ import com.microsoft.applicationinsights.smoketest.TargetUri;
 import com.microsoft.applicationinsights.smoketest.UseAgent;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 @UseAgent("CustomInstrumentation")
 public class CustomInstrumentationTest extends AiSmokeTest {
@@ -21,73 +24,131 @@ public class CustomInstrumentationTest extends AiSmokeTest {
     @Test
     @TargetUri("/customInstrumentationOne")
     public void customInstrumentationOne() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject.one");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/customInstrumentationTwo")
     public void customInstrumentationTwo() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject.two");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/customInstrumentationThree")
     public void customInstrumentationThree() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+        List<Envelope> edList = mockedIngestion.getItemsEnvelopeDataType("ExceptionData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+        assertThat(edList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+        Envelope edEnvelope = edList.get(0);
+
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+        ExceptionData ed = (ExceptionData) ((Data) edEnvelope.getData()).getBaseData();
+
         assertEquals(1, mockedIngestion.getCountForType("ExceptionData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject.three");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), false);
-        ExceptionData exceptionData = getTelemetryDataForType(0, "ExceptionData");
-        List<ExceptionDetails> exceptions = exceptionData.getExceptions();
+
+        List<ExceptionDetails> exceptions = ed.getExceptions();
         assertEquals(exceptions.size(), 1);
         assertEquals(exceptions.get(0).getMessage(), "Three");
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
+        assertSameOperationId(edEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/customInstrumentationFour")
     public void customInstrumentationFour() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject$NestedObject.four");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/customInstrumentationFive")
     public void customInstrumentationFive() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(4, mockedIngestion.getCountForType("RemoteDependencyData"));
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        assertThat(rdList, hasSize(1));
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+        assertThat(rddList, hasSize(4));
+        Envelope fiveEnvelope = null;
+        Envelope sixEnvelope = null;
+        Envelope oneEnvelope = null;
+        Envelope twoEnvelope = null;
         RemoteDependencyData fiveRdd = null;
         RemoteDependencyData sixRdd = null;
         RemoteDependencyData oneRdd = null;
         RemoteDependencyData twoRdd = null;
-        List<RemoteDependencyData> rdds = mockedIngestion.getTelemetryDataByType("RemoteDependencyData");
-        for (RemoteDependencyData rdd : rdds) {
-            if (rdd.getName().endsWith(".five")) {
-                fiveRdd = rdd;
-            } else if (rdd.getName().endsWith(".six")) {
-                sixRdd = rdd;
-            } else if (rdd.getName().endsWith(".one")) {
-                oneRdd = rdd;
-            } else if (rdd.getName().endsWith(".two")) {
-                twoRdd = rdd;
+        for (Envelope loopEnvelope : rddList) {
+            RemoteDependencyData loopData = (RemoteDependencyData) ((Data) loopEnvelope.getData()).getBaseData();
+            if (loopData.getName().endsWith(".five")) {
+                fiveEnvelope = loopEnvelope;
+                fiveRdd = loopData;
+            } else if (loopData.getName().endsWith(".six")) {
+                sixEnvelope = loopEnvelope;
+                sixRdd = loopData;
+            } else if (loopData.getName().endsWith(".one")) {
+                oneEnvelope = loopEnvelope;
+                oneRdd = loopData;
+            } else if (loopData.getName().endsWith(".two")) {
+                twoEnvelope = loopEnvelope;
+                twoRdd = loopData;
             } else {
-                throw new IllegalStateException("Unexpected remote dependency: " + rdd.getName());
+                throw new IllegalStateException("Unexpected remote dependency: " + loopData.getName());
             }
         }
 
@@ -95,67 +156,99 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(fiveRdd.getName(), "com/springbootstartertest/controller/TargetObject.five");
         assertEquals(fiveRdd.getType(), "OTHER");
         assertEquals(fiveRdd.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, fiveEnvelope);
 
         assertNotNull(sixRdd);
         assertEquals(sixRdd.getName(), "com/springbootstartertest/controller/TargetObject.six");
         assertEquals(sixRdd.getType(), "OTHER");
         assertEquals(sixRdd.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, sixEnvelope);
 
         assertNotNull(oneRdd);
         assertEquals(oneRdd.getName(), "com/springbootstartertest/controller/TargetObject.one");
         assertEquals(oneRdd.getType(), "OTHER");
         assertEquals(oneRdd.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, oneEnvelope);
 
         assertNotNull(twoRdd);
         assertEquals(twoRdd.getName(), "com/springbootstartertest/controller/TargetObject.two");
         assertEquals(twoRdd.getType(), "OTHER");
         assertEquals(twoRdd.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, twoEnvelope);
     }
 
     @Test
     @TargetUri("/customInstrumentationSeven")
     public void customInstrumentationSeven() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals(rdd.getName(), "com/springbootstartertest/controller/TargetObject.seven");
         assertEquals(rdd.getType(), "OTHER");
         assertEquals(rdd.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/customInstrumentationEight")
     public void customInstrumentationEight() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(2, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd1 = getTelemetryDataForType(0, "RemoteDependencyData");
-        RemoteDependencyData rdd2 = getTelemetryDataForType(1, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(2));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope1 = rddList.get(0);
+        Envelope rddEnvelope2 = rddList.get(1);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd1 = (RemoteDependencyData) ((Data) rddEnvelope1.getData()).getBaseData();
+        RemoteDependencyData rdd2 = (RemoteDependencyData) ((Data) rddEnvelope2.getData()).getBaseData();
 
         assertEquals(rdd1.getName(), "com/springbootstartertest/controller/TargetObject.eight");
         assertEquals(rdd1.getType(), "OTHER");
         assertEquals(rdd1.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, rddEnvelope1);
 
         assertEquals(rdd2.getName(), "com/springbootstartertest/controller/TargetObject.eight");
         assertEquals(rdd2.getType(), "OTHER");
         assertEquals(rdd2.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, rddEnvelope2);
     }
 
     @Test
     @TargetUri("/customInstrumentationNine")
     public void customInstrumentationNine() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(2, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RequestData d = getTelemetryDataForType(0, "RequestData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        assertThat(rdList, hasSize(1));
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+        assertThat(rddList, hasSize(2));
+        Envelope nineEnvelope = null;
+        Envelope httpEnvelope = null;
         RemoteDependencyData nineRdd = null;
         RemoteDependencyData httpRdd = null;
-        List<RemoteDependencyData> rdds = mockedIngestion.getTelemetryDataByType("RemoteDependencyData");
-        for (RemoteDependencyData rdd : rdds) {
-            if (rdd.getType().equals("OTHER")) {
-                nineRdd = rdd;
-            } else if (rdd.getType().equals("Http (tracked component)")) {
-                httpRdd = rdd;
+        for (Envelope loopEnvelope : rddList) {
+            RemoteDependencyData loopData = (RemoteDependencyData) ((Data) loopEnvelope.getData()).getBaseData();
+            if (loopData.getType().equals("OTHER")) {
+                nineEnvelope = loopEnvelope;
+                nineRdd = loopData;
+            } else if (loopData.getType().equals("Http (tracked component)")) {
+                httpEnvelope = loopEnvelope;
+                httpRdd = loopData;
             } else {
-                throw new IllegalStateException("Unexpected remote dependency type: " + rdd.getType());
+                throw new IllegalStateException("Unexpected remote dependency type: " + loopData.getType());
             }
         }
 
@@ -163,10 +256,20 @@ public class CustomInstrumentationTest extends AiSmokeTest {
         assertEquals(nineRdd.getName(), "com/springbootstartertest/controller/TargetObject.nine");
         assertEquals(nineRdd.getType(), "OTHER");
         assertEquals(nineRdd.getSuccess(), true);
+        assertSameOperationId(rdEnvelope, nineEnvelope);
 
         assertNotNull(httpRdd);
-        String requestOperationId = d.getId();
-        String rddId = httpRdd.getId();
-        assertTrue(rddId.contains(requestOperationId));
+        assertSameOperationId(rdEnvelope, httpEnvelope);
+    }
+
+    private static void assertSameOperationId(Envelope rdEnvelope, Envelope rddEnvelope) {
+        String operationId = rdEnvelope.getTags().get("ai.operation.id");
+        String operationParentId = rdEnvelope.getTags().get("ai.operation.parentId");
+
+        assertNotNull(operationId);
+        assertNotNull(operationParentId);
+
+        assertEquals(operationId, rddEnvelope.getTags().get("ai.operation.id"));
+        assertEquals(operationParentId, rddEnvelope.getTags().get("ai.operation.parentId"));
     }
 }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/JdbcSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/JdbcSmokeTest.java
@@ -1,12 +1,19 @@
 package com.springbootstartertest.smoketest;
 
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.smoketest.*;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @UseAgent
@@ -31,171 +38,304 @@ public class JdbcSmokeTest extends AiSmokeTest {
     @Test
     @TargetUri("/jdbc/hsqldbPreparedStatement")
     public void hsqldbPreparedStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertEquals("jdbc:hsqldb:mem:test", rdd.getName());
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/hsqldbStatement")
     public void hsqldbStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertEquals("jdbc:hsqldb:mem:test", rdd.getName());
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/hsqldbBatchPreparedStatement")
     public void hsqldbBatchPreparedStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertEquals("jdbc:hsqldb:mem:test", rdd.getName());
         assertEquals("insert into abc (xyz) values (?)", rdd.getData());
         assertEquals(" [Batch of 3]", rdd.getProperties().get("Args"));
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/hsqldbBatchStatement")
     public void hsqldbBatchStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertEquals("jdbc:hsqldb:mem:test", rdd.getName());
         assertEquals("insert into abc (xyz) values ('t'); insert into abc (xyz) values ('u');" +
                 " insert into abc (xyz) values ('v')", rdd.getData());
         assertEquals(" [Batch]", rdd.getProperties().get("Args"));
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/mysqlPreparedStatement")
     public void mysqlPreparedStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        assertThat(rdList, hasSize(1));
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+        Envelope rddEnvelope = null;
         // the old agent captured several internal queries, e.g. "SHOW WARNINGS"
-        int total = mockedIngestion.getCountForType("RemoteDependencyData");
-        assertTrue(total > 0);
-        RemoteDependencyData rdd = null;
-        boolean found = false;
-        for (int i = 0; i < total; i++) {
-            rdd = getTelemetryDataForType(i, "RemoteDependencyData");
-            if (rdd.getData().equals("select * from abc where xyz = ?")) {
-                found = true;
+        for (Envelope loopEnvelope : rddList) {
+            RemoteDependencyData loopData = (RemoteDependencyData) ((Data) loopEnvelope.getData()).getBaseData();
+            if (loopData.getData().equals("select * from abc where xyz = ?")) {
+                rddEnvelope = loopEnvelope;
                 break;
             }
         }
-        assertTrue(found);
+        assertNotNull(rddEnvelope);
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:mysql://"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/mysqlStatement")
     public void mysqlStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        assertThat(rdList, hasSize(1));
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+        Envelope rddEnvelope = null;
         // the old agent captured several internal queries, e.g. "SHOW WARNINGS"
-        int total = mockedIngestion.getCountForType("RemoteDependencyData");
-        assertTrue(total > 0);
-        RemoteDependencyData rdd = null;
-        boolean found = false;
-        for (int i = 0; i < total; i++) {
-            rdd = getTelemetryDataForType(i, "RemoteDependencyData");
-            if (rdd.getData().equals("select * from abc")) {
-                found = true;
+        for (Envelope loopEnvelope : rddList) {
+            RemoteDependencyData loopData = (RemoteDependencyData) ((Data) loopEnvelope.getData()).getBaseData();
+            if (loopData.getData().equals("select * from abc")) {
+                rddEnvelope = loopEnvelope;
                 break;
             }
         }
-        assertTrue(found);
+        assertNotNull(rddEnvelope);
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:mysql://"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/postgresPreparedStatement")
     public void postgresPreparedStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:postgresql://"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/postgresStatement")
     public void postgresStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:postgresql://"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/sqlServerPreparedStatement")
     public void sqlServerPreparedStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:sqlserver://"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Test
     @TargetUri("/jdbc/sqlServerStatement")
     public void sqlServerStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:sqlserver://"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Ignore("FIXME: need custom container with oracle db")
     @Test
     @TargetUri("/jdbc/oraclePreparedStatement")
     public void oraclePreparedStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:oracle:thin:@"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
     }
 
     @Ignore("FIXME: need custom container with oracle db")
     @Test
     @TargetUri("/jdbc/oracleStatement")
     public void oracleStatement() {
-        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(1, mockedIngestion.getCountForType("RemoteDependencyData"));
-        RemoteDependencyData rdd = getTelemetryDataForType(0, "RemoteDependencyData");
+        List<Envelope> rdList = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> rddList = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+
+        assertThat(rdList, hasSize(1));
+        assertThat(rddList, hasSize(1));
+
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+
         assertEquals("SQL", rdd.getType());
         assertTrue(rdd.getName().startsWith("jdbc:oracle:thin:@"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getSuccess());
+
+        assertSameOperationId(rdEnvelope, rddEnvelope);
+    }
+
+    private static void assertSameOperationId(Envelope rdEnvelope, Envelope rddEnvelope) {
+        String operationId = rdEnvelope.getTags().get("ai.operation.id");
+        String operationParentId = rdEnvelope.getTags().get("ai.operation.parentId");
+
+        assertNotNull(operationId);
+        assertNotNull(operationParentId);
+
+        assertEquals(operationId, rddEnvelope.getTags().get("ai.operation.id"));
+        assertEquals(operationParentId, rddEnvelope.getTags().get("ai.operation.parentId"));
     }
 }


### PR DESCRIPTION
The `codeless` branch was not setting remote dependency operation ids, so added these tests, and seem worth adding to master.