### PR TITLE
Fix registration of custom JMX performance counters

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/JmxXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/JmxXmlElement.java
@@ -21,17 +21,23 @@
 
 package com.microsoft.applicationinsights.internal.config;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
 /**
  * Created by gupele on 3/15/2015.
  */
-@XStreamAlias("Add")
 public class JmxXmlElement {
 
+    @XStreamAsAttribute
     private String displayName;
+
+    @XStreamAsAttribute
     private String objectName;
+
+    @XStreamAsAttribute
     private String attribute;
+
+    @XStreamAsAttribute
     private String type;
 
     public String getDisplayName() {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/PerformanceCountersXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/PerformanceCountersXmlElement.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Created by gupele on 3/15/2015.
@@ -44,17 +45,17 @@ public class PerformanceCountersXmlElement {
     private String plugin;
 
     @XStreamAlias("Jmx")
-    private ArrayList<JmxXmlElement> jmxXmlElements;
+    private JmxWrapperXmlElement jmxWrapper = new JmxWrapperXmlElement();
 
     @XStreamAlias("Windows")
-    private ArrayList<WindowsPerformanceCounterXmlElement> windowsPCs;
+    private WindowsPCWrapperXmlElement windowsPCWrapper = new WindowsPCWrapperXmlElement();
 
     public ArrayList<JmxXmlElement> getJmxXmlElements() {
-        return jmxXmlElements;
+        return jmxWrapper.jmxXmlElements;
     }
 
     public void setJmxXmlElements(ArrayList<JmxXmlElement> jmxXmlElements) {
-        this.jmxXmlElements = jmxXmlElements;
+        jmxWrapper.jmxXmlElements = jmxXmlElements;
     }
 
     public boolean isUseBuiltIn() {
@@ -66,11 +67,11 @@ public class PerformanceCountersXmlElement {
     }
 
     public ArrayList<WindowsPerformanceCounterXmlElement> getWindowsPCs() {
-        return windowsPCs;
+        return windowsPCWrapper.windowsPCs;
     }
 
     public void setWindowsPCs(ArrayList<WindowsPerformanceCounterXmlElement> windowsPCs) {
-        this.windowsPCs = windowsPCs;
+        windowsPCWrapper.windowsPCs = windowsPCs;
     }
 
     public long getCollectionFrequencyInSec() {
@@ -95,5 +96,17 @@ public class PerformanceCountersXmlElement {
 
     public void setPlugin(String plugin) {
         this.plugin = plugin;
+    }
+
+    public static class JmxWrapperXmlElement {
+
+        @XStreamImplicit(itemFieldName = "Add")
+        private ArrayList<JmxXmlElement> jmxXmlElements;
+    }
+
+    public static class WindowsPCWrapperXmlElement {
+
+        @XStreamImplicit(itemFieldName = "Add")
+        private ArrayList<WindowsPerformanceCounterXmlElement> windowsPCs;
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorXmlElement.java
@@ -30,7 +30,6 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 /**
  * Created by gupele on 7/26/2016.
  */
-@XStreamAlias("Processor")
 public class TelemetryProcessorXmlElement {
 
     @XStreamAsAttribute

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorsXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryProcessorsXmlElement.java
@@ -24,6 +24,7 @@ package com.microsoft.applicationinsights.internal.config;
 import java.util.ArrayList;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Created by gupele on 7/26/2016.
@@ -31,24 +32,30 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class TelemetryProcessorsXmlElement {
 
     @XStreamAlias("CustomProcessors")
-    private ArrayList<TelemetryProcessorXmlElement> custom = new ArrayList<>();
+    private TelemetryProcessorWrapperXmlElement customWrapper = new TelemetryProcessorWrapperXmlElement();
 
     @XStreamAlias("BuiltInProcessors")
-    private ArrayList<TelemetryProcessorXmlElement> builtIn = new ArrayList<>();
+    private TelemetryProcessorWrapperXmlElement builtInWrapper = new TelemetryProcessorWrapperXmlElement();
 
     public ArrayList<TelemetryProcessorXmlElement> getBuiltInTelemetryProcessors() {
-        return builtIn;
+        return builtInWrapper.processors;
     }
 
     public void setBuiltInTelemetryProcessors(ArrayList<TelemetryProcessorXmlElement> builtIn) {
-        this.builtIn = builtIn;
+        builtInWrapper.processors = builtIn;
     }
 
     public ArrayList<TelemetryProcessorXmlElement> getCustomTelemetryProcessors() {
-        return custom;
+        return customWrapper.processors;
     }
 
     public void setCustomTelemetryProcessors(ArrayList<TelemetryProcessorXmlElement> custom) {
-        this.custom = custom;
+        customWrapper.processors = custom;
+    }
+
+    public static class TelemetryProcessorWrapperXmlElement {
+
+        @XStreamImplicit(itemFieldName = "Processor")
+        private ArrayList<TelemetryProcessorXmlElement> processors = new ArrayList<>();
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/WindowsPerformanceCounterXmlElement.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/WindowsPerformanceCounterXmlElement.java
@@ -21,13 +21,11 @@
 
 package com.microsoft.applicationinsights.internal.config;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
 /**
  * Created by gupele on 3/30/2015.
  */
-@XStreamAlias("Add")
 public class WindowsPerformanceCounterXmlElement {
 
     @XStreamAsAttribute

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilderTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilderTest.java
@@ -62,5 +62,11 @@ public final class JaxbAppInsightsConfigurationBuilderTest {
         Assert.assertEquals("System Threads", windowsPC.getDisplayName());
         JmxXmlElement jmxXmlElement = config.getPerformance().getJmxXmlElements().get(0);
         Assert.assertEquals("Thread Count", jmxXmlElement.getDisplayName());
+        TelemetryProcessorXmlElement builtInTelemetryProcessor =
+                config.getTelemetryProcessors().getBuiltInTelemetryProcessors().get(0);
+        Assert.assertEquals("FixedRateSamplingTelemetryProcessor", builtInTelemetryProcessor.getType());
+        TelemetryProcessorXmlElement customTelemetryProcessor =
+                config.getTelemetryProcessors().getCustomTelemetryProcessors().get(0);
+        Assert.assertEquals("Test", customTelemetryProcessor.getType());
     }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilderTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/config/JaxbAppInsightsConfigurationBuilderTest.java
@@ -25,6 +25,7 @@ import org.junit.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 
 public final class JaxbAppInsightsConfigurationBuilderTest {
     private final static String EXISTING_CONF_TEST_FILE = "ApplicationInsights2.xml";
@@ -56,6 +57,10 @@ public final class JaxbAppInsightsConfigurationBuilderTest {
         Assert.assertEquals("myrole", config.getRoleName());
         Assert.assertFalse(config.getChannel().getDeveloperMode());
         Assert.assertEquals("mypackage.MyCustomContextInitializer", config.getContextInitializers().getAdds().get(0).getType());
+
+        WindowsPerformanceCounterXmlElement windowsPC = config.getPerformance().getWindowsPCs().get(0);
+        Assert.assertEquals("System Threads", windowsPC.getDisplayName());
+        JmxXmlElement jmxXmlElement = config.getPerformance().getJmxXmlElements().get(0);
+        Assert.assertEquals("Thread Count", jmxXmlElement.getDisplayName());
     }
 }
-

--- a/core/src/test/resources/ApplicationInsights2.xml
+++ b/core/src/test/resources/ApplicationInsights2.xml
@@ -266,6 +266,9 @@
             The structure is the same as BuiltInProcessors.
             See comments above for more information on implementation and configuration.
             -->
+            <Processor type="Test">
+                <Add name="Test" value="Test" />
+            </Processor>
         </CustomProcessors>
     </TelemetryProcessors>
 


### PR DESCRIPTION
Registration of custom JMX performance counters was failing with error:

`Failed to register JMX performance counters: 'java.lang.ClassCastException: com.microsoft.applicationinsights.internal.config.WindowsPerformanceCounterXmlElement cannot be cast to com.microsoft.applicationinsights.internal.config.JmxXmlElement'`