### PR TITLE
Make lists threadsafe #1043

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryConfiguration.java
@@ -30,8 +30,8 @@ import com.microsoft.applicationinsights.extensibility.TelemetryModule;
 import com.microsoft.applicationinsights.extensibility.TelemetryProcessor;
 import com.microsoft.applicationinsights.internal.config.TelemetryConfigurationFactory;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Encapsulates the global telemetry configuration typically loaded from the ApplicationInsights.xml file.
@@ -48,10 +48,10 @@ public final class TelemetryConfiguration {
     private String instrumentationKey;
     private String roleName;
 
-    private final ArrayList<ContextInitializer> contextInitializers = new   ArrayList<ContextInitializer>();
-    private final ArrayList<TelemetryInitializer> telemetryInitializers = new ArrayList<TelemetryInitializer>();
-    private final ArrayList<TelemetryModule> telemetryModules = new ArrayList<TelemetryModule>();
-    private final ArrayList<TelemetryProcessor> telemetryProcessors = new ArrayList<TelemetryProcessor>();
+    private final List<ContextInitializer> contextInitializers =  new  CopyOnWriteArrayList<ContextInitializer>();
+    private final List<TelemetryInitializer> telemetryInitializers = new CopyOnWriteArrayList<TelemetryInitializer>();
+    private final List<TelemetryModule> telemetryModules = new CopyOnWriteArrayList<TelemetryModule>();
+    private final List<TelemetryProcessor> telemetryProcessors = new CopyOnWriteArrayList<TelemetryProcessor>();
 
     private TelemetryChannel channel;
 


### PR DESCRIPTION
Partial Fix for #1043 

This prevents calls to 

```
 telemetryConfig.getTelemetryInitializers().add(new MyTelemetryInitializer());
        telemetryConfig.getContextInitializers().add(new MyContextInitializer());
```

Affecting other users on different threads who may be doing a 

```
com.microsoft.applicationinsights.TelemetryClient.track(TelemetryClient.java:428)
```

As this causes the lists to be enumerated and if changed from another thread while being enumerated you'll get the following exception. 

```
Caused by: java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
	at java.util.ArrayList$Itr.next(ArrayList.java:859)
	at com.microsoft.applicationinsights.TelemetryClient.activateInitializers(TelemetryClient.java:460)
	at com.microsoft.applicationinsights.TelemetryClient.track(TelemetryClient.java:428)
	at com.microsoft.applicationinsights.TelemetryClient.trackDependency(TelemetryClient.java:357)
	at nhs.prescriptions.helpers.TelemetryHelper.executeAndMonitorDependencyCall(TelemetryHelper.java:73)
	at customer.thing.RecogniseTextSend.postBatchReadRequest(RecogniseTextSend.java:203)
	at customer.thing.RecogniseTextSend.submitOrCheckOcrRequest(RecogniseTextSend.java:136)
	at customer.thing.RecogniseTextSend.run(RecogniseTextSend.java:96)
```