### PR TITLE
TelemetryClientHelper added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 # Version 2.5.0-BETA.5
+- Added `TelemetryClientHelper` for easily wrapping external dependency calls
+
+# Version 2.5.0-BETA.5
 - Fixed `ClassCastException` that could happen when using `HttpURLConnection`
   ([#1053](https://github.com/microsoft/ApplicationInsights-Java/issues/1053))
 

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClientHelper.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClientHelper.java
@@ -1,0 +1,123 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
+
+public final class TelemetryClientHelper {
+
+    private final TelemetryClient telemetryClient;
+
+    public TelemetryClientHelper() {
+        telemetryClient = new TelemetryClient();
+    }
+
+    public TelemetryClientHelper(TelemetryClient client) {
+        telemetryClient = client;
+    }
+
+    public TelemetryClient getTelemetryClient() {
+        return this.telemetryClient;
+    }
+
+    public CloseableHttpResponse monitorHttpDependency(String dependencyName, String commandName,
+            CloseableHttpClient httpClient, HttpUriRequest httpRequest) throws Exception {
+        Instant start = Instant.now();
+        CloseableHttpResponse response = null;
+        HttpContext context = HttpClientContext.create();
+
+        try {
+            response = httpClient.execute(httpRequest, context);
+        } catch (Exception ex) {
+            trackDependencyException(dependencyName, commandName, ex);
+            throw ex;
+        } finally {
+            Instant finish = Instant.now();
+            RemoteDependencyTelemetry dependency = buildTelemetryEvent(response, httpRequest, dependencyName,
+                    commandName, start, finish);
+            telemetryClient.trackDependency(dependency);
+        }
+
+        return response;
+    }
+
+    public <T> T monitorDependency(String dependencyName, String commandName, Callable<T> callable) throws Exception {
+        boolean success = false;
+        Instant start = Instant.now();
+        T result = null;
+
+        try {
+            result = callable.call();
+            success = true;
+        } catch (Exception ex) {
+            trackDependencyException(dependencyName, commandName, ex);
+            throw ex;
+        } finally {
+            Instant finish = Instant.now();
+            com.microsoft.applicationinsights.telemetry.Duration duration = new com.microsoft.applicationinsights.telemetry.Duration(
+                    Duration.between(start, finish).toMillis());
+            telemetryClient.trackDependency(dependencyName, commandName, duration, success);
+        }
+
+        return result;
+    }
+
+    private void trackDependencyException(String dependencyName, String commandName, Exception ex) {
+        Map<String, String> exceptionProperties = new HashMap<>(2);
+        exceptionProperties.put("dependencyName", dependencyName);
+        exceptionProperties.put("commandName", commandName);
+
+        telemetryClient.trackException(ex, exceptionProperties, null);
+    }
+
+    private RemoteDependencyTelemetry buildTelemetryEvent(HttpResponse response, HttpUriRequest httpRequest,
+            String dependencyName, String commandName, Instant start, Instant finish) {
+        com.microsoft.applicationinsights.telemetry.Duration duration = new com.microsoft.applicationinsights.telemetry.Duration(
+                Duration.between(start, finish).toMillis());
+        int statusCode = response == null ? 0 : response.getStatusLine().getStatusCode();
+        boolean success = isSuccess(statusCode);
+
+        RemoteDependencyTelemetry telemetry = new RemoteDependencyTelemetry(dependencyName, commandName, duration,
+                success);
+
+        telemetry.setResultCode(response == null ? "N/A" : response.getStatusLine().toString());
+        telemetry.setType(String.format("HTTP - %s", httpRequest.getMethod()));
+        return telemetry;
+    }
+
+    private boolean isSuccess(int statusCode) {
+        return (statusCode >= 200 && statusCode <= 299);
+    }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientHelperTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/TelemetryClientHelperTests.java
@@ -1,0 +1,227 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import com.microsoft.applicationinsights.telemetry.Duration;
+import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
+
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+
+/**
+ * Tests the interface of the telemetry client.
+ */
+public final class TelemetryClientHelperTests {
+
+    @Mock
+    private TelemetryClient mockTelemetryClient;
+    @Captor
+    private ArgumentCaptor<Map<String, String>> argCaptor;
+    @Captor
+    private ArgumentCaptor<RemoteDependencyTelemetry> telemetryCaptor;
+    @Captor
+    private ArgumentCaptor<Duration> durationCaptor;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void getTelemetryClient_returns_telemetryclient() {
+        TelemetryClientHelper sut = new TelemetryClientHelper(mockTelemetryClient);
+        assertSame(mockTelemetryClient, sut.getTelemetryClient());
+    }
+
+    @Test
+    public void monitorHttpDependencyTracksSuccessfulCall() throws Exception {
+        TelemetryClientHelper sut = new TelemetryClientHelper(mockTelemetryClient);
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        HttpUriRequest mockRequest = mock(HttpUriRequest.class);
+        CloseableHttpResponse mockResponse = buildMockResponse(200);
+
+        when(mockRequest.getMethod()).thenReturn("GET");
+        when(mockClient.execute(eq(mockRequest), any(HttpContext.class))).thenReturn(mockResponse);
+
+        CloseableHttpResponse response = sut.monitorHttpDependency("wibble", "wobble", mockClient, mockRequest);
+
+        assertSame(response, mockResponse);
+
+        verify(mockTelemetryClient).trackDependency(telemetryCaptor.capture());
+
+        assertEquals(true, telemetryCaptor.getValue().getSuccess());
+        assertEquals("wibble", telemetryCaptor.getValue().getName());
+        assertEquals("wobble", telemetryCaptor.getValue().getCommandName());
+        assertEquals("HTTP STATUS - 200", telemetryCaptor.getValue().getResultCode());
+        assertEquals("HTTP - GET", telemetryCaptor.getValue().getType());
+        assertTrue(telemetryCaptor.getValue().getDuration().getMilliseconds() > 0);
+    }
+
+    @Test
+    public void monitorHttpDependencyTracksFailedCall() throws Exception {
+        TelemetryClientHelper sut = new TelemetryClientHelper(mockTelemetryClient);
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        HttpUriRequest mockRequest = mock(HttpUriRequest.class);
+        CloseableHttpResponse mockResponse = buildMockResponse(404);
+
+        when(mockRequest.getMethod()).thenReturn("GET");
+        when(mockClient.execute(eq(mockRequest), any(HttpContext.class))).thenReturn(mockResponse);
+
+        CloseableHttpResponse response = sut.monitorHttpDependency("wibble", "wobble", mockClient, mockRequest);
+
+        assertSame(response, mockResponse);
+
+        verify(mockTelemetryClient).trackDependency(telemetryCaptor.capture());
+
+        assertEquals(false, telemetryCaptor.getValue().getSuccess());
+        assertEquals("wibble", telemetryCaptor.getValue().getName());
+        assertEquals("wobble", telemetryCaptor.getValue().getCommandName());
+        assertEquals("HTTP STATUS - 404", telemetryCaptor.getValue().getResultCode());
+        assertEquals("HTTP - GET", telemetryCaptor.getValue().getType());
+    }
+
+    @Test
+    public void monitorHttpDependencyTracksOnThrownException() throws ClientProtocolException, IOException {
+        TelemetryClientHelper sut = new TelemetryClientHelper(mockTelemetryClient);
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        HttpUriRequest mockRequest = mock(HttpUriRequest.class);
+
+        when(mockClient.execute(eq(mockRequest), any(HttpContext.class))).thenThrow(new ClientProtocolException());
+
+        try {
+            sut.monitorHttpDependency("wibble", "wobble", mockClient, mockRequest);
+        } catch (Exception ex) {
+            // ignore
+        }
+
+        verify(mockTelemetryClient).trackDependency(telemetryCaptor.capture());
+        verify(mockTelemetryClient).trackException(any(Exception.class), argCaptor.capture(),
+                Matchers.<HashMap<String, Double>>any());
+
+        assertEquals("wibble", argCaptor.getValue().get("dependencyName"));
+        assertEquals("wobble", argCaptor.getValue().get("commandName"));
+        assertEquals(false, telemetryCaptor.getValue().getSuccess());
+        assertEquals("N/A", telemetryCaptor.getValue().getResultCode());
+    }
+
+    @Test
+    public void monitorDependencyTracksOnSuccess() throws Exception {
+        TelemetryClientHelper sut = new TelemetryClientHelper(mockTelemetryClient);
+
+        Callable<Integer> callableObj = new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                Thread.sleep(2);
+                return 2 * 2;
+            }
+        };
+
+        int result = sut.monitorDependency("wibble", "wobble", callableObj);
+
+        assertEquals(4, result);
+        verify(mockTelemetryClient).trackDependency(eq("wibble"), eq("wobble"), durationCaptor.capture(), eq(true));
+        assertTrue("Duration should be set", durationCaptor.getValue().getMilliseconds() > 0);
+    }
+
+    @Test
+    public void monitorDependencyTracksOnExceptionThrown() {
+        TelemetryClientHelper sut = new TelemetryClientHelper(mockTelemetryClient);
+
+        Callable<Integer> callableObj = new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                Thread.sleep(2);
+                throw new NullPointerException();
+            }
+        };
+
+        try {
+            sut.monitorDependency("wibble", "wobble", callableObj);
+        } catch (Exception ex) {
+            // ignore
+        }
+
+        verify(mockTelemetryClient).trackDependency(eq("wibble"), eq("wobble"), durationCaptor.capture(), eq(false));
+        verify(mockTelemetryClient).trackException(any(NullPointerException.class), argCaptor.capture(),
+                Matchers.<HashMap<String, Double>>any());
+
+        assertTrue("Duration should be set", durationCaptor.getValue().getMilliseconds() > 0);
+
+        assertEquals("wibble", argCaptor.getValue().get("dependencyName"));
+        assertEquals("wobble", argCaptor.getValue().get("commandName"));
+    }
+
+    private CloseableHttpResponse buildMockResponse(final int statusCode) {
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+
+        when(mockResponse.getStatusLine()).thenReturn(new StatusLine() {
+
+            @Override
+            public int getStatusCode() {
+                return statusCode;
+            }
+
+            @Override
+            public String getReasonPhrase() {
+                return null;
+            }
+
+            @Override
+            public ProtocolVersion getProtocolVersion() {
+                return null;
+            }
+
+            @Override
+            public String toString() {
+                return String.format("HTTP STATUS - %s", Integer.toString(statusCode));
+            }
+        });
+
+        return mockResponse;
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 // Project properties
-version=2.5.0-BETA.5
+version=2.5.0-BETA.6
 group=com.microsoft.azure
 


### PR DESCRIPTION
We found a number of issues using the Java AppInsights SDK with Azure Functions for a recent CSE project regarding dependency tracking and wrote this little extension helper class. Thought it might be worth contributing it back to the master as it made our life a lot easier when calling Http dependencies or wanting to track dependent code packages etc.

For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated
