### PR TITLE
suppress cves from jackson

### DIFF
--- a/azure-application-insights-spring-boot-starter/dependency-check-suppressions.xml
+++ b/azure-application-insights-spring-boot-starter/dependency-check-suppressions.xml
@@ -19,6 +19,8 @@
         <cve>CVE-2019-12814</cve>
         <cve>CVE-2019-14379</cve>
         <cve>CVE-2019-14439</cve>
+        <cve>CVE-2019-14540</cve>
+        <cve>CVE-2019-16335</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
will fix the "partial failures" in build.

same reasoning as last time: spring has dependency on jackson which is not used in our starter code
