### PR TITLE
Fix NullPointerException if agent fails to start

### DIFF
--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/AgentImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/AgentImpl.java
@@ -24,6 +24,7 @@ package com.microsoft.applicationinsights.agentc.internal;
 import java.util.Date;
 
 import com.google.common.base.Strings;
+import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.agentc.internal.model.DistributedTraceContext;
 import com.microsoft.applicationinsights.agentc.internal.model.Global;
 import com.microsoft.applicationinsights.agentc.internal.model.IncomingSpanImpl;
@@ -47,7 +48,9 @@ class AgentImpl implements AgentSPI {
                                       ThreadContextThreadLocal.Holder threadContextHolder, int rootNestingGroupId,
                                       int rootSuppressionKeyId) {
 
-        if (!transactionType.equals("Web") && !transactionType.equals("Background")) {
+        TelemetryClient telemetryClient = Global.getTelemetryClient();
+        if (telemetryClient == null
+                || !transactionType.equals("Web") && !transactionType.equals("Background")) {
             // this is a little more complicated than desired, but part of the contract of startIncomingSpan is that it
             // sets a ThreadContext in the threadContextHolder before returning, and NopThreadSpan makes sure to clear
             // the threadContextHolder at the end of the thread
@@ -67,7 +70,7 @@ class AgentImpl implements AgentSPI {
         String userAgent = getter.get(carrier, "User-Agent");
         requestTelemetry.getContext().getUser().setUserAgent(userAgent);
 
-        String instrumentationKey = Global.getTelemetryClient().getContext().getInstrumentationKey();
+        String instrumentationKey = telemetryClient.getContext().getInstrumentationKey();
         DistributedTraceContext distributedTraceContext;
         if (Global.isOutboundW3CEnabled()) {
             distributedTraceContext =

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/MainEntryPoint.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/MainEntryPoint.java
@@ -77,10 +77,11 @@ public class MainEntryPoint {
             startupLogger = initLogging(instrumentation, agentJarFile);
             addLibJars(instrumentation, agentJarFile);
             instrumentation.addTransformer(new CommonsLogFactoryClassFileTransformer());
+            start(instrumentation, agentJarFile);
+            // add legacy class file transformers after ensuring Global.getTelemetryClient() will not return null
             instrumentation.addTransformer(new LegacyTelemetryClientClassFileTransformer());
             instrumentation.addTransformer(new LegacyDependencyTelemetryClassFileTransformer());
             instrumentation.addTransformer(new LegacyPerformanceCounterClassFileTransformer());
-            start(instrumentation, agentJarFile);
         } catch (ThreadDeath td) {
             throw td;
         } catch (Throwable t) {

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/Global.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/Global.java
@@ -25,8 +25,6 @@ import com.microsoft.applicationinsights.TelemetryClient;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.glowroot.instrumentation.engine.bytecode.api.ThreadContextThreadLocal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 // global state used instead of passing these to various classes (e.g. ThreadContextImpl, SpanImpl) in order
 // to reduce memory footprint
 public class Global {
@@ -68,8 +66,9 @@ public class Global {
         Global.inboundW3CEnabled = inboundW3CEnabled;
     }
 
-    public static TelemetryClient getTelemetryClient() {
-        return checkNotNull(telemetryClient);
+    // this can be null if agent failed during startup
+    public static @Nullable TelemetryClient getTelemetryClient() {
+        return telemetryClient;
     }
 
     public static void setTelemetryClient(TelemetryClient telemetryClient) {

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/IncomingSpanImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/IncomingSpanImpl.java
@@ -178,7 +178,8 @@ public class IncomingSpanImpl implements Span {
 
     private void send() {
         long endTimeMillis = System.currentTimeMillis();
-        TelemetryClient telemetryClient = Global.getTelemetryClient();
+        // telemetry client is not null because it was checked when transaction started in AgentImpl.startIncomingSpan()
+        TelemetryClient telemetryClient = checkNotNull(Global.getTelemetryClient());
         if (exception != null) {
             ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception);
             exceptionTelemetry.getContext().getOperation().setId(getOperationId());

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/LegacySDK.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/LegacySDK.java
@@ -37,6 +37,7 @@ import org.glowroot.instrumentation.engine.bytecode.api.ThreadContextPlus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -141,6 +142,7 @@ public class LegacySDK {
             telemetry.getContext().getOperation().setId(incomingSpan.getOperationId());
             telemetry.getContext().getOperation().setParentId(incomingSpan.getOperationParentId());
         }
-        Global.getTelemetryClient().track(telemetry);
+        // this is not null because legacy instrumentation is not added until it is set
+        checkNotNull(Global.getTelemetryClient()).track(telemetry);
     }
 }

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/LocalSpanImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/LocalSpanImpl.java
@@ -39,6 +39,8 @@ import org.glowroot.instrumentation.engine.impl.NopTransactionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class LocalSpanImpl implements Span {
 
     static final String PREFIX = "__custom,";
@@ -113,7 +115,8 @@ public class LocalSpanImpl implements Span {
         telemetry.setDuration(new Duration(durationMillis));
         telemetry.setSuccess(exception == null);
 
-        TelemetryClient telemetryClient = Global.getTelemetryClient();
+        // telemetry client is not null because it was checked when transaction started in AgentImpl.startIncomingSpan()
+        TelemetryClient telemetryClient = checkNotNull(Global.getTelemetryClient());
         telemetryClient.track(telemetry);
         if (exception != null) {
             ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception);

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/LoggerSpans.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/LoggerSpans.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 
+import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.telemetry.ExceptionTelemetry;
 import com.microsoft.applicationinsights.telemetry.SeverityLevel;
 import com.microsoft.applicationinsights.telemetry.TraceTelemetry;
@@ -34,6 +35,8 @@ import org.glowroot.instrumentation.api.MessageSupplier;
 import org.glowroot.instrumentation.api.internal.ReadableMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 class LoggerSpans {
 
@@ -50,6 +53,9 @@ class LoggerSpans {
 
         String loggerName = (String) detail.get("Logger name");
 
+        // telemetry client is not null because it was checked when transaction started in AgentImpl.startIncomingSpan()
+        TelemetryClient telemetryClient = checkNotNull(Global.getTelemetryClient());
+
         if (throwable == null) {
             TraceTelemetry telemetry = new TraceTelemetry(formattedMessage);
             telemetry.getContext().getOperation().setId(operationId);
@@ -58,7 +64,7 @@ class LoggerSpans {
                 telemetry.setSeverityLevel(severityLevel);
             }
             setProperties(telemetry.getProperties(), timeMillis, level, loggerName, null, formattedMessage);
-            Global.getTelemetryClient().track(telemetry);
+            telemetryClient.track(telemetry);
         } else {
             ExceptionTelemetry telemetry = new ExceptionTelemetry(throwable);
             telemetry.getContext().getOperation().setId(operationId);
@@ -67,7 +73,7 @@ class LoggerSpans {
                 telemetry.setSeverityLevel(severityLevel);
             }
             setProperties(telemetry.getProperties(), timeMillis, level, loggerName, throwable, formattedMessage);
-            Global.getTelemetryClient().track(telemetry);
+            telemetryClient.track(telemetry);
         }
     }
 

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/OutgoingSpanImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/OutgoingSpanImpl.java
@@ -43,6 +43,8 @@ import org.glowroot.instrumentation.engine.impl.NopTransactionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class OutgoingSpanImpl implements Span {
 
     private static final Logger logger = LoggerFactory.getLogger(OutgoingSpanImpl.class);
@@ -125,7 +127,9 @@ public class OutgoingSpanImpl implements Span {
             telemetry.setType(type);
         }
         if (telemetry != null) {
-            TelemetryClient telemetryClient = Global.getTelemetryClient();
+            // telemetry client is not null because it was checked when transaction started in AgentImpl
+            // .startIncomingSpan()
+            TelemetryClient telemetryClient = checkNotNull(Global.getTelemetryClient());
             telemetryClient.track(telemetry);
             if (exception != null) {
                 ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception);

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/QuerySpanImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/QuerySpanImpl.java
@@ -36,6 +36,8 @@ import org.glowroot.instrumentation.api.Setter;
 import org.glowroot.instrumentation.api.Timer;
 import org.glowroot.instrumentation.engine.impl.NopTransactionService;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class QuerySpanImpl implements QuerySpan {
 
     private final String operationId;
@@ -185,7 +187,8 @@ public class QuerySpanImpl implements QuerySpan {
             telemetry.getProperties().put("Query Plan", sb.toString());
         }
 
-        TelemetryClient telemetryClient = Global.getTelemetryClient();
+        // telemetry client is not null because it was checked when transaction started in AgentImpl.startIncomingSpan()
+        TelemetryClient telemetryClient = checkNotNull(Global.getTelemetryClient());
         telemetryClient.track(telemetry);
         if (exception != null) {
             ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(exception);


### PR DESCRIPTION
This fixes application failing with, e.g.

```
[ERROR   ] SRVE0777E: Exception thrown by application class 'com.microsoft.applicationinsights.agentc.shadow.com.google.common.base.Preconditions.checkNotNull:890'
java.lang.NullPointerException
	at com.microsoft.applicationinsights.agentc.shadow.com.google.common.base.Preconditions.checkNotNull(Preconditions.java:890)
	at com.microsoft.applicationinsights.agentc.internal.model.Global.getTelemetryClient(Global.java:72)
	at com.microsoft.applicationinsights.agentc.internal.AgentImpl.startIncomingSpan(AgentImpl.java:70)
	at org.glowroot.instrumentation.engine.impl.OptionalThreadContextImpl.startIncomingSpan(OptionalThreadContextImpl.java:89)
	at org.glowroot.instrumentation.servlet.ServletInstrumentation.onBeforeCommon(ServletInstrumentation.java:437)
	at org.glowroot.instrumentation.servlet.ServletInstrumentation.access$200(ServletInstrumentation.java:52)
	at org.glowroot.instrumentation.servlet.ServletInstrumentation$ServiceAdvice.onBefore(ServletInstrumentation.java:74)
	at com.ibm.websphere.jaxrs.server.IBMRestServlet.service(IBMRestServlet.java)
```