### PR TITLE
W3C distributed tracing

### DIFF
--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/AgentImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/AgentImpl.java
@@ -23,13 +23,11 @@ package com.microsoft.applicationinsights.agentc.internal;
 
 import java.util.Date;
 
-import com.google.common.base.Strings;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.agentc.internal.model.DistributedTraceContext;
 import com.microsoft.applicationinsights.agentc.internal.model.Global;
 import com.microsoft.applicationinsights.agentc.internal.model.IncomingSpanImpl;
 import com.microsoft.applicationinsights.agentc.internal.model.NopThreadSpan;
-import com.microsoft.applicationinsights.agentc.internal.model.TelemetryCorrelationUtilsCore;
 import com.microsoft.applicationinsights.agentc.internal.model.ThreadContextImpl;
 import com.microsoft.applicationinsights.agentc.internal.model.TraceContextCorrelationCore;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
@@ -71,16 +69,9 @@ class AgentImpl implements AgentSPI {
         requestTelemetry.getContext().getUser().setUserAgent(userAgent);
 
         String instrumentationKey = telemetryClient.getContext().getInstrumentationKey();
-        DistributedTraceContext distributedTraceContext;
-        if (Global.isOutboundW3CEnabled()) {
-            distributedTraceContext =
-                    TraceContextCorrelationCore.resolveCorrelationForRequest(carrier, getter, requestTelemetry);
-            TraceContextCorrelationCore.resolveRequestSource(carrier, getter, requestTelemetry, instrumentationKey);
-        } else {
-            distributedTraceContext =
-                    TelemetryCorrelationUtilsCore.resolveCorrelationForRequest(carrier, getter, requestTelemetry);
-            TelemetryCorrelationUtilsCore.resolveRequestSource(carrier, getter, requestTelemetry, instrumentationKey);
-        }
+        DistributedTraceContext distributedTraceContext =
+                TraceContextCorrelationCore.resolveCorrelationForRequest(carrier, getter, requestTelemetry);
+        TraceContextCorrelationCore.resolveRequestSource(carrier, getter, requestTelemetry, instrumentationKey);
         if (requestTelemetry.getContext().getOperation().getParentId() == null) {
             requestTelemetry.getContext().getOperation().setParentId(requestTelemetry.getId());
         }

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/Configuration.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/Configuration.java
@@ -45,8 +45,8 @@ public class Configuration {
 
     public static class DistributedTracing {
 
-        public boolean w3cEnabled = true;
-        public boolean w3cBackCompatEnabled = true;
+        public boolean outboundEnabled = true; // this can be disabled if downstream services reject extra headers
+        public boolean requestIdCompatEnabled = true;
     }
 
     public static class LiveMetrics {

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/Configuration.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/Configuration.java
@@ -45,7 +45,7 @@ public class Configuration {
 
     public static class DistributedTracing {
 
-        public boolean w3cEnabled;
+        public boolean w3cEnabled = true;
         public boolean w3cBackCompatEnabled = true;
     }
 

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/MainEntryPoint.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/MainEntryPoint.java
@@ -55,7 +55,6 @@ import com.microsoft.applicationinsights.telemetry.PageViewTelemetry;
 import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.telemetry.TraceTelemetry;
-import com.microsoft.applicationinsights.web.internal.correlation.TraceContextCorrelationCore;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.glowroot.instrumentation.engine.config.InstrumentationDescriptor;
 import org.glowroot.instrumentation.engine.config.InstrumentationDescriptors;
@@ -145,11 +144,8 @@ public class MainEntryPoint {
 
         Configuration config = ConfigurationBuilder.create(agentJarPath);
 
-        Global.setOutboundW3CEnabled(config.distributedTracing.w3cEnabled);
-        Global.setInboundW3CEnabled(config.distributedTracing.w3cEnabled);
-
-        Global.setOutboundW3CBackCompatEnabled(config.distributedTracing.w3cBackCompatEnabled);
-        TraceContextCorrelationCore.setIsW3CBackCompatEnabled(config.distributedTracing.w3cBackCompatEnabled);
+        Global.setDistributedTracingOutboundEnabled(config.distributedTracing.outboundEnabled);
+        Global.setDistributedTracingRequestIdCompatEnabled(config.distributedTracing.requestIdCompatEnabled);
 
         ApplicationInsightsXmlConfiguration xmlConfiguration = new ApplicationInsightsXmlConfiguration();
 

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/AsyncOutgoingSpanImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/AsyncOutgoingSpanImpl.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.agentc.internal.model;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.glowroot.instrumentation.api.AsyncSpan;
 import org.glowroot.instrumentation.api.MessageSupplier;
 import org.glowroot.instrumentation.api.Timer;
@@ -28,8 +29,8 @@ import org.glowroot.instrumentation.engine.impl.NopTransactionService;
 
 class AsyncOutgoingSpanImpl extends OutgoingSpanImpl implements AsyncSpan {
 
-    public AsyncOutgoingSpanImpl(String operationParentId, String operationId, String outgoingSpanId, String type,
-                                 String text, long startTimeMillis, MessageSupplier messageSupplier) {
+    public AsyncOutgoingSpanImpl(String operationParentId, String operationId, @Nullable String outgoingSpanId,
+                                 String type, String text, long startTimeMillis, MessageSupplier messageSupplier) {
         super(operationId, operationParentId, outgoingSpanId, type, text, startTimeMillis, messageSupplier);
     }
 

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/DistributedTraceContext.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/DistributedTraceContext.java
@@ -70,9 +70,9 @@ public class DistributedTraceContext {
     }
 
     // w3c format
+    @Nullable
     String retrieveTracestate() {
-        Preconditions.checkNotNull(tracestate);
-        return tracestate.toString();
+        return tracestate == null ? null : tracestate.toString();
     }
 
     // ApplicationInsights format

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/Global.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/Global.java
@@ -29,11 +29,8 @@ import org.glowroot.instrumentation.engine.bytecode.api.ThreadContextThreadLocal
 // to reduce memory footprint
 public class Global {
 
-    private static boolean outboundW3CEnabled;
-    private static boolean outboundW3CBackCompatEnabled;
-
-    // note: inboundW3CBackCompatEnabled is stored in TraceContextCorrelationCore
-    private static boolean inboundW3CEnabled;
+    private static boolean distributedTracingOutboundEnabled;
+    private static boolean distributedTracingRequestIdCompatEnabled;
 
     private static volatile @Nullable TelemetryClient telemetryClient;
 
@@ -42,28 +39,20 @@ public class Global {
     private Global() {
     }
 
-    public static boolean isOutboundW3CEnabled() {
-        return outboundW3CEnabled;
+    public static boolean isDistributedTracingOutboundEnabled() {
+        return distributedTracingOutboundEnabled;
     }
 
-    public static void setOutboundW3CEnabled(boolean outboundW3CEnabled) {
-        Global.outboundW3CEnabled = outboundW3CEnabled;
+    public static void setDistributedTracingOutboundEnabled(boolean distributedTracingOutboundEnabled) {
+        Global.distributedTracingOutboundEnabled = distributedTracingOutboundEnabled;
     }
 
-    public static boolean isOutboundW3CBackCompatEnabled() {
-        return outboundW3CBackCompatEnabled;
+    public static boolean isDistributedTracingRequestIdCompatEnabled() {
+        return distributedTracingRequestIdCompatEnabled;
     }
 
-    public static void setOutboundW3CBackCompatEnabled(boolean outboundW3CBackCompatEnabled) {
-        Global.outboundW3CBackCompatEnabled = outboundW3CBackCompatEnabled;
-    }
-
-    public static boolean isInboundW3CEnabled() {
-        return inboundW3CEnabled;
-    }
-
-    public static void setInboundW3CEnabled(boolean inboundW3CEnabled) {
-        Global.inboundW3CEnabled = inboundW3CEnabled;
+    public static void setDistributedTracingRequestIdCompatEnabled(boolean distributedTracingRequestIdCompatEnabled) {
+        Global.distributedTracingRequestIdCompatEnabled = distributedTracingRequestIdCompatEnabled;
     }
 
     // this can be null if agent failed during startup

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/IncomingSpanImpl.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/IncomingSpanImpl.java
@@ -155,13 +155,8 @@ public class IncomingSpanImpl implements Span {
     @Override
     @Deprecated
     public <R> void propagateToResponse(R response, Setter<R> setter) {
-        if (Global.isInboundW3CEnabled()) {
-            // TODO eliminate wrapper object instantiation
-            TraceContextCorrelationCore.resolveCorrelationForResponse(response, setter);
-        } else {
-            // TODO eliminate wrapper object instantiation
-            TelemetryCorrelationUtilsCore.resolveCorrelationForResponse(response, setter);
-        }
+        // TODO eliminate wrapper object instantiation
+        TraceContextCorrelationCore.resolveCorrelationForResponse(response, setter);
     }
 
     @Override

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/TraceContextCorrelationCore.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/model/TraceContextCorrelationCore.java
@@ -13,10 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A class that is responsible for performing correlation based on W3C protocol.
- * This is a clean implementation of W3C protocol and doesn't have the backward
- * compatibility with AI-RequestId protocol.
- *
  * @author Dhaval Doshi
  */
 public class TraceContextCorrelationCore {
@@ -28,12 +24,6 @@ public class TraceContextCorrelationCore {
     private static final String REQUEST_CONTEXT_HEADER_NAME = "Request-Context";
     private static final String AZURE_TRACEPARENT_COMPONENT_INITIAL = "az";
     private static final String REQUEST_CONTEXT_HEADER_APPID_KEY = "appId";
-
-    /**
-     * Switch to enable W3C Backward compatibility with Legacy AI Correlation.
-     * By default this is turned ON.
-     */
-    private static boolean isW3CBackCompatEnabled = true;
 
     private TraceContextCorrelationCore() {
     }
@@ -124,7 +114,7 @@ public class TraceContextCorrelationCore {
         if (incomingTraceparent == null) {
 
             // If BackCompat mode is enabled, read the Request-Id Header
-            if (isW3CBackCompatEnabled) {
+            if (Global.isDistributedTracingRequestIdCompatEnabled()) {
                 processedTraceparent = processLegacyCorrelation(request, requestHeaderGetter, requestTelemetry);
             }
 
@@ -262,7 +252,7 @@ public class TraceContextCorrelationCore {
 
             String tracestate = requestHeaderGetter.get(request, TRACESTATE_HEADER_NAME);
             if (Strings.isNullOrEmpty(tracestate)) {
-                if (isW3CBackCompatEnabled) {
+                if (Global.isDistributedTracingRequestIdCompatEnabled()) {
                     String requestContext = requestHeaderGetter.get(request, REQUEST_CONTEXT_HEADER_NAME);
                     if (requestContext != null) {
                         logger.trace("Tracestate absent, In backward compatibility mode, will try to resolve " +

--- a/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/ConfigurationTest.java
+++ b/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/ConfigurationTest.java
@@ -27,8 +27,8 @@ public class ConfigurationTest {
         assertEquals("InstrumentationKey=00000000-0000-0000-0000-000000000000", configuration.connectionString);
         assertEquals("Something Good", configuration.roleName);
         assertEquals("xyz123", configuration.roleInstance);
-        assertEquals(true, configuration.distributedTracing.w3cEnabled);
-        assertEquals(false, configuration.distributedTracing.w3cBackCompatEnabled);
+        assertEquals(false, configuration.distributedTracing.outboundEnabled);
+        assertEquals(false, configuration.distributedTracing.requestIdCompatEnabled);
         assertEquals(false, configuration.liveMetrics.enabled);
         assertEquals(ImmutableMap.of("k8s.pod.name", "amazing-product", "k8s.pod.namespace", "product-ns"),
                 configuration.telemetryContext);
@@ -53,8 +53,7 @@ public class ConfigurationTest {
         assertEquals(null, configuration.connectionString);
         assertEquals(null, configuration.roleName);
         assertEquals(null, configuration.roleInstance);
-        assertEquals(false, configuration.distributedTracing.w3cEnabled);
-        assertEquals(true, configuration.distributedTracing.w3cBackCompatEnabled);
+        assertEquals(true, configuration.distributedTracing.requestIdCompatEnabled);
         assertEquals(true, configuration.liveMetrics.enabled);
         assertEquals(0, configuration.telemetryContext.size());
         assertEquals(0, configuration.jmxMetrics.size());

--- a/agent-codeless/src/test/resources/ApplicationInsights.json
+++ b/agent-codeless/src/test/resources/ApplicationInsights.json
@@ -3,8 +3,8 @@
   "roleName": "Something Good",
   "roleInstance": "xyz123",
   "distributedTracing": {
-    "w3cEnabled": true,
-    "w3cBackCompatEnabled": false
+    "outboundEnabled": false,
+    "requestIdCompatEnabled": false
   },
   "liveMetrics": {
     "enabled": false

--- a/core/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationCore.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelationCore.java
@@ -510,7 +510,7 @@ public class TraceContextCorrelationCore {
         return "|" + traceparentArr[1] + "." + traceparentArr[2] + ".";
     }
 
-    public static void setIsW3CBackCompatEnabled(boolean isW3CBackCompatEnabled) {
+    public static void setIsRequestIdCompatEnabled(boolean isW3CBackCompatEnabled) {
         TraceContextCorrelationCore.isW3CBackCompatEnabled = isW3CBackCompatEnabled;
         InternalLogger.INSTANCE.trace(String.format("W3C Backport mode enabled on Incoming side %s",
             isW3CBackCompatEnabled));

--- a/test/smoke/testApps/HttpClients/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/HttpClientSmokeTest.java
+++ b/test/smoke/testApps/HttpClients/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/HttpClientSmokeTest.java
@@ -12,6 +12,8 @@ import com.microsoft.applicationinsights.smoketest.UseAgent;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @UseAgent
@@ -23,13 +25,16 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
         List<Envelope> rddList = mockedIngestion.waitForItems("RemoteDependencyData", 1);
 
-        RequestData rd = (RequestData) ((Data) rdList.get(0).getData()).getBaseData();
-        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddList.get(0).getData()).getBaseData();
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
         assertEquals("GET /", rdd.getName());
         assertEquals("www.bing.com:-1 | www.bing.com", rdd.getTarget());
-        assertTrue(rdd.getId().contains(rd.getId()));
+        assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
     @Test
@@ -38,13 +43,16 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
         List<Envelope> rddList = mockedIngestion.waitForItems("RemoteDependencyData", 1);
 
-        RequestData rd = (RequestData) ((Data) rdList.get(0).getData()).getBaseData();
-        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddList.get(0).getData()).getBaseData();
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
         assertEquals("GET /", rdd.getName());
         assertEquals("www.bing.com:-1 | www.bing.com", rdd.getTarget());
-        assertTrue(rdd.getId().contains(rd.getId()));
+        assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
     @Test
@@ -53,13 +61,16 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
         List<Envelope> rddList = mockedIngestion.waitForItems("RemoteDependencyData", 1);
 
-        RequestData rd = (RequestData) ((Data) rdList.get(0).getData()).getBaseData();
-        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddList.get(0).getData()).getBaseData();
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
         assertEquals("GET /", rdd.getName());
         assertEquals("www.bing.com:-1 | www.bing.com", rdd.getTarget());
-        assertTrue(rdd.getId().contains(rd.getId()));
+        assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
     @Test
@@ -68,13 +79,16 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
         List<Envelope> rddList = mockedIngestion.waitForItems("RemoteDependencyData", 1);
 
-        RequestData rd = (RequestData) ((Data) rdList.get(0).getData()).getBaseData();
-        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddList.get(0).getData()).getBaseData();
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
         assertEquals("GET /", rdd.getName());
         assertEquals("www.bing.com:-1 | www.bing.com", rdd.getTarget());
-        assertTrue(rdd.getId().contains(rd.getId()));
+        assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
     @Test
@@ -83,13 +97,16 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
         List<Envelope> rddList = mockedIngestion.waitForItems("RemoteDependencyData", 1);
 
-        RequestData rd = (RequestData) ((Data) rdList.get(0).getData()).getBaseData();
-        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddList.get(0).getData()).getBaseData();
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
         assertEquals("GET /", rdd.getName());
         assertEquals("www.bing.com:-1 | www.bing.com", rdd.getTarget());
-        assertTrue(rdd.getId().contains(rd.getId()));
+        assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
     @Test
@@ -98,12 +115,24 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
         List<Envelope> rddList = mockedIngestion.waitForItems("RemoteDependencyData", 1);
 
-        RequestData rd = (RequestData) ((Data) rdList.get(0).getData()).getBaseData();
-        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddList.get(0).getData()).getBaseData();
+        Envelope rdEnvelope = rdList.get(0);
+        Envelope rddEnvelope = rddList.get(0);
+
+        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
         assertEquals("GET /", rdd.getName());
         assertEquals("www.bing.com:-1 | www.bing.com", rdd.getTarget());
-        assertTrue(rdd.getId().contains(rd.getId()));
+        assertParentChild(rd, rdEnvelope, rddEnvelope);
+    }
+
+    private static void assertParentChild(RequestData rd, Envelope rdEnvelope, Envelope rddEnvelope) {
+        String operationId = rdEnvelope.getTags().get("ai.operation.id");
+
+        assertNotNull(operationId);
+
+        assertEquals(operationId, rddEnvelope.getTags().get("ai.operation.id"));
+        assertEquals(rd.getId(), rddEnvelope.getTags().get("ai.operation.parentId"));
     }
 }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -93,7 +93,7 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         }
         assertThat(code, greaterThanOrEqualTo(500));
 
-        assertSameOperationId(rdEnvelope, edEnvelope);
+        assertParentChild(rd, rdEnvelope, edEnvelope);
     }
 
     @Test
@@ -115,18 +115,15 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         assertEquals("GET /", rdd.getName());
         assertEquals("www.bing.com:-1 | www.bing.com", rdd.getTarget());
 
-        assertTrue(rdd.getId().contains(d.getId()));
-        assertSameOperationId(rdEnvelope, rddEnvelope);
+        assertParentChild(d, rdEnvelope, rddEnvelope);
     }
 
-    private static void assertSameOperationId(Envelope rdEnvelope, Envelope rddEnvelope) {
+    private static void assertParentChild(RequestData rd, Envelope rdEnvelope, Envelope rddEnvelope) {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
-        String operationParentId = rdEnvelope.getTags().get("ai.operation.parentId");
 
         assertNotNull(operationId);
-        assertNotNull(operationParentId);
 
         assertEquals(operationId, rddEnvelope.getTags().get("ai.operation.id"));
-        assertEquals(operationParentId, rddEnvelope.getTags().get("ai.operation.parentId"));
+        assertEquals(rd.getId(), rddEnvelope.getTags().get("ai.operation.parentId"));
     }
 }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/TraceContextCorrelation.java
@@ -95,6 +95,6 @@ public class TraceContextCorrelation {
     }
 
     public static void setIsW3CBackCompatEnabled(boolean isW3CBackCompatEnabled) {
-        TraceContextCorrelationCore.setIsW3CBackCompatEnabled(isW3CBackCompatEnabled);
+        TraceContextCorrelationCore.setIsRequestIdCompatEnabled(isW3CBackCompatEnabled);
     }
 }


### PR DESCRIPTION
We should always use W3C distributed tracing. `requestIdBackCompat` config will still handle legacy distributed tracing. And there should be a way to disable outbound distributed tracing headers in case they impact downstream services.