### PR TITLE
Improve startup time

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/common/CommonUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/common/CommonUtils.java
@@ -41,7 +41,7 @@ public class CommonUtils {
   public static String getHostName() {
     try {
       InetAddress addr = InetAddress.getLocalHost();
-      return addr.getCanonicalHostName();
+      return addr.getHostName();
     } catch (UnknownHostException ex) {
       InternalLogger.INSTANCE.warn("Error resolving hostname:%n%s", ExceptionUtils.getStackTrace(ex));
       return null;


### PR DESCRIPTION
In some environments `getCanonicalHostName()` can take several seconds.

I think get `getHostName()` should be fine, since we are calling it on `localhost` anyways (this is what Glowroot uses to capture local host name, see https://github.com/glowroot/glowroot/blob/v0.13.5/agent/core/src/main/java/org/glowroot/agent/init/EnvironmentCreator.java#L66).