### PR TITLE
Revert background thread priority change

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/internal/DockerContextPoller.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/internal/DockerContextPoller.java
@@ -43,7 +43,6 @@ public class DockerContextPoller extends Thread {
     public DockerContextPoller(String contextFileDirectory) {
         this(new File(contextFileDirectory + "/" + CONTEXT_FILE_NAME), new DockerContextFactory());
         this.setDaemon(true);
-        this.setPriority(Thread.MIN_PRIORITY);
         this.setName(DockerContextPoller.class.getSimpleName());
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ActiveTransmissionLoader.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ActiveTransmissionLoader.java
@@ -129,7 +129,6 @@ public final class ActiveTransmissionLoader implements TransmissionsLoader {
                 }
             }, String.format(threadNameFmt, i));
             threads[i].setDaemon(true);
-            threads[i].setPriority(Thread.MIN_PRIORITY);
         }}
 
     @Override

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/QuickPulse.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/QuickPulse.java
@@ -110,12 +110,10 @@ public enum QuickPulse implements Stoppable {
 
                     senderThread = new Thread(quickPulseDataSender, QuickPulseDataSender.class.getSimpleName());
                     senderThread.setDaemon(true);
-                    senderThread.setPriority(Thread.MIN_PRIORITY);
                     senderThread.start();
 
                     thread = new Thread(coordinator, DefaultQuickPulseCoordinator.class.getSimpleName());
                     thread.setDaemon(true);
-                    thread.setPriority(Thread.MIN_PRIORITY);
                     thread.start();
 
                     SDKShutdownActivity.INSTANCE.register(this);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/ThreadPoolUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/ThreadPoolUtils.java
@@ -101,7 +101,6 @@ public final class ThreadPoolUtils {
                 Thread thread = new Thread(r);
                 thread.setName(String.format("%s-%d", poolName, threadId.getAndIncrement()));
                 thread.setDaemon(true);
-                thread.setPriority(Thread.MIN_PRIORITY);
                 return thread;
             }
         };


### PR DESCRIPTION
Concerned that it is preventing these threads from running in timely
fashing in some environments. Plus doesn't seem like this made much
difference for cold start time after further testing.