### PR TITLE
Fix springboot dependencies

### DIFF
--- a/azure-application-insights-spring-boot-starter/build.gradle
+++ b/azure-application-insights-spring-boot-starter/build.gradle
@@ -47,8 +47,7 @@ sourceSets {
 
 def springBootVersion = '1.5.21.RELEASE'
 dependencies {
-    compile(project(path: ':core', configuration: 'shadow'))
-    compile(project(path: ':web', configuration: 'shadow'))
+    compile(project(path: ':web', configuration: 'shadow')) // web includes core
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
 
@@ -69,7 +68,6 @@ dependencies {
 ext.dependenciesPrefix = 'com.microsoft.applicationinsights.boot.dependencies'
 shadowJar {
     dependencies {
-        exclude(project(':core'))
         exclude(project(':web'))
         exclude(project(':ApplicationInsightsInternalLogger'))
     }

--- a/azure-application-insights-spring-boot-starter/build.gradle
+++ b/azure-application-insights-spring-boot-starter/build.gradle
@@ -47,14 +47,16 @@ sourceSets {
 
 def springBootVersion = '1.5.21.RELEASE'
 dependencies {
-    compile(project(':core'))
-    compile(project(':web'))
+    compile(project(path: ':core', configuration: 'shadow'))
+    compile(project(path: ':web', configuration: 'shadow'))
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
+
     compileOnly("org.springframework.boot:spring-boot:$springBootVersion")
     compileOnly("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
     compileOnly("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
     compileOnly("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
+
     testCompile('junit:junit:4.12')
     testCompile("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
     testCompile("org.springframework.boot:spring-boot:$springBootVersion")
@@ -70,43 +72,9 @@ shadowJar {
         exclude(project(':core'))
         exclude(project(':web'))
         exclude(project(':ApplicationInsightsInternalLogger'))
-        exclude(dependency([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.5']))
-        exclude(dependency([group: 'commons-io', name: 'commons-io', version: '2.6']))
-        exclude(dependency([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3']))
-        // Transitive dependencies of httpclient that needs to be excluded seperately as shadow jar doesn't exclude them
-        // automatically.
-        exclude(dependency([group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.6']))
-        exclude(dependency([group: 'org.apache.httpcomponents', name: 'httpcore-nio', version: '4.4.6']))
-        // end excluding transitive dependencies
-
-        exclude(dependency([group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.1.3']))
-        exclude(dependency([group: 'com.google.guava', name: 'guava', version: '26.0-android']))
-        exclude(dependency([group: 'com.google.code.gson', name: 'gson', version: '2.8.2']))
-
-        // exclude gRPC and protobuf dependencies
-        exclude(dependency([group: 'com.google.protobuf', name:'protobuf-java', version:'3.6.1']))
-        exclude(dependency([group: 'io.grpc', name: 'grpc-stub', version: '1.16.1']))
-        exclude(dependency([group: 'io.grpc', name: 'grpc-protobuf', version: '1.16.1']))
-        exclude(dependency([group: 'io.grpc', name: 'grpc-context', version: '1.16.1']))
-        exclude(dependency([group: 'com.google.code.gson', name: 'gson', version: '2.8.2']))
-        exclude(dependency([group: 'com.google.guava', name: 'guava', version: '20.0']))
-        exclude(dependency([group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.2.0']))
-        exclude(dependency([group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2']))
-        exclude(dependency([group: 'io.opencensus', name: 'opencensus-api', version: '0.12.3']))
-        exclude(dependency([group: 'io.opencensus', name: 'opencensus-contrib-grpc-metrics', version: '0.12.3']))
-        exclude(dependency([group: 'io.grpc', name: 'grpc-core', version: '1.16.1']))
-        exclude(dependency([group: 'com.google.protobuf', name: 'protobuf-java', version: '3.6.1']))
-        exclude(dependency([group: 'com.google.api.grpc', name: 'proto-google-common-protos', version: '1.0.0']))
-        exclude(dependency([group: 'io.grpc', name: 'grpc-protobuf-lite', version: '1.16.1']))
-        exclude(dependency([group: 'io.grpc', name: 'grpc-netty-shaded', version: '1.16.1']))
-        exclude(dependency([group: 'org.codehaus.mojo', name: 'animal-sniffer-annotations', version: '1.17']))
-        exclude(dependency([group: 'org.checkerframework', name: 'checker-compat-qual', version: '2.5.2']))
-        exclude(dependency([group: 'com.google.j2objc', name:'j2objc-annotations', version: '1.1']))
-
     }
     archiveClassifier=''
     relocate 'org.apache.commons', "${dependenciesPrefix}.apachecommons"
-    relocate 'com.google', "${dependenciesPrefix}.google"
 }
 
 jar {


### PR DESCRIPTION
This does a few things:
1. Fixes the unnecessary inclusion of xmlpull and xstream in spring boot shadow
2. Uses shadow configuration for core and web so we don't have to manage their dependencies here (related to 1)
3. Removes an unnecessary relocation.
