### PR TITLE
Fix incompatibility with some applications

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -68,6 +68,8 @@ shadowJar() {
     exclude 'META-INF/NOTICE*'
     exclude 'META-INF/services/javax.servlet.ServletContainerInitializer'
 
+    exclude 'module-info.class'
+
     // prevent duplicate files
     exclude 'LICENSE'
     exclude 'NOTICE'


### PR DESCRIPTION
The `module-info.class` file that is present in the agent jar can cause apps that are using older versions of ClassGraph (previously known as FastClasspathScanner) to fail with error:

```
Unknown constant pool tag ... in classfile module-info.class
```

This issue is fixed in later versions of ClassGraph (see https://github.com/classgraph/classgraph/issues/141), but this PR will make Application Insights compatible with older versions of ClassGraph as well.