### PR TITLE
Add spotbugs to build and fix the failures

### DIFF
--- a/ApplicationInsightsInternalLogger/spotbugs.exclude.xml
+++ b/ApplicationInsightsInternalLogger/spotbugs.exclude.xml
@@ -9,4 +9,23 @@
         <Class name="com.microsoft.applicationinsights.internal.logger.DefaultLogFileProxy" />
         <Method name="initialize" />
     </Match>
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+        <!-- All of these are related to the log file output. -->
+        <!-- Ignore. File path does not come from anonymous or untrusted sources. -->
+        <Or>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.logger.DefaultLogFileProxy" />
+                <Method name="&lt;init&gt;" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.logger.FileLoggerOutput" />
+                <Method name="initialize" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.logger.LocalFileSystemUtils" />
+                <Method name="getTempDir" />
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/ApplicationInsightsInternalLogger/spotbugs.exclude.xml
+++ b/ApplicationInsightsInternalLogger/spotbugs.exclude.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd https://github.com/spotbugs/filter/3.0.0 ">
+    <Match>
+        <Bug pattern="DM_DEFAULT_ENCODING" />
+        <!-- Ignore. Default encoding is intended. -->
+        <Class name="com.microsoft.applicationinsights.internal.logger.DefaultLogFileProxy" />
+        <Method name="initialize" />
+    </Match>
+</FindBugsFilter>

--- a/agent/spotbugs.exclude.xml
+++ b/agent/spotbugs.exclude.xml
@@ -10,4 +10,11 @@
         <Method name="premain" />
         <Field name="startupLogger" />
     </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+        <!-- Ignore. I wasn't able to confirm that this is not Nullable. -->
+        <Class name="com.microsoft.applicationinsights.agent.internal.config.builder.XmlAgentConfigurationBuilder" />
+        <Method name="parseConfigurationFile" />
+        <Local name="classTags" />
+    </Match>
 </FindBugsFilter>

--- a/agent/spotbugs.exclude.xml
+++ b/agent/spotbugs.exclude.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd https://github.com/spotbugs/filter/3.0.0 ">
+    <Match>
+        <Bug pattern="NP_NULL_ON_SOME_PATH" />
+        <!-- Ignore. I see no reason to change this. It's odd this flagged the second dereference and not the first. -->
+        <Class name="com.microsoft.applicationinsights.agent.internal.MainEntryPoint" />
+        <Method name="premain" />
+        <Field name="startupLogger" />
+    </Match>
+</FindBugsFilter>

--- a/agent/spotbugs.exclude.xml
+++ b/agent/spotbugs.exclude.xml
@@ -32,4 +32,10 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="XXE_DOCUMENT" />
+        <!-- False Positive. This feature is set in createDocumentBuidler() -->
+        <Class name="com.microsoft.applicationinsights.agent.internal.config.builder.XmlAgentConfigurationBuilder" />
+        <Method name="getTopTag" />
+    </Match>
 </FindBugsFilter>

--- a/agent/spotbugs.exclude.xml
+++ b/agent/spotbugs.exclude.xml
@@ -17,4 +17,19 @@
         <Method name="parseConfigurationFile" />
         <Local name="classTags" />
     </Match>
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+        <Or>
+            <And>
+                <!-- False Positive. Path is not from an external source. -->
+                <Class name="com.microsoft.applicationinsights.agent.internal.Premain"/>
+                <Method name="getAgentJarFile"/>
+            </And>
+            <And>
+                <!-- False Positive. File name is hard coded and immutable -->
+                <Class name="com.microsoft.applicationinsights.agent.internal.config.builder.XmlAgentConfigurationBuilder"/>
+                <Method name="parseConfigurationFile"/>
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlAgentConfigurationBuilder.java
+++ b/agent/src/main/java/com/microsoft/applicationinsights/agent/internal/config/builder/XmlAgentConfigurationBuilder.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -238,8 +239,8 @@ public class XmlAgentConfigurationBuilder {
     }
 
     private Element getTopTag(File configurationFile) throws ParserConfigurationException, IOException, SAXException {
-        DocumentBuilder builder = createDocumentBuilder();
         try (final FileInputStream fis = new FileInputStream(configurationFile)) {
+            DocumentBuilder builder = createDocumentBuilder();
             Document doc = builder.parse(fis);
             doc.getDocumentElement().normalize();
 
@@ -261,6 +262,7 @@ public class XmlAgentConfigurationBuilder {
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         // mitigates CWE-611: https://cwe.mitre.org/data/definitions/611.html
         dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        dbFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         dbFactory.setXIncludeAware(false);
         dbFactory.setExpandEntityReferences(false);
         return dbFactory.newDocumentBuilder();

--- a/azure-application-insights-spring-boot-starter/build.gradle
+++ b/azure-application-insights-spring-boot-starter/build.gradle
@@ -45,16 +45,18 @@ sourceSets {
     }
 }
 
+apply from: "$buildScriptsDir/provided-configuration.gradle"
+
 def springBootVersion = '1.5.21.RELEASE'
 dependencies {
     compile(project(path: ':web', configuration: 'shadow')) // web includes core
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
 
-    compileOnly("org.springframework.boot:spring-boot:$springBootVersion")
-    compileOnly("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
-    compileOnly("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
-    compileOnly("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
+    provided("org.springframework.boot:spring-boot:$springBootVersion")
+    provided("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion")
+    provided("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+    provided("org.springframework.boot:spring-boot-configuration-processor:$springBootVersion")
 
     testCompile('junit:junit:4.12')
     testCompile("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
@@ -94,7 +96,7 @@ whenPomConfigured = { p ->
             !(dep.groupId in ['org.apache.http', 'eu.infomas', 'org.apache.commons', 'commons-io',
                               'com.google.guava', 'com.google.code.gson', 'org.apache.httpcomponents',
                               'io.grpc', 'com.google.protobuf'])}
-    p.dependencies += project.configurations.compileOnly.allDependencies
+    p.dependencies += project.configurations.provided.allDependencies
             .findAll { it.group != 'com.microsoft.azure' }
             .collect {
                 def d = p.dependencies[0].class.newInstance() // related to https://issues.gradle.org/browse/GRADLE-1497

--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,15 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
         classpath 'org.owasp:dependency-check-gradle:5.2.2'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'
+        classpath 'com.github.spotbugs:spotbugs-gradle-plugin:3.0.0'
     }
 }
 

--- a/collectd/build.gradle
+++ b/collectd/build.gradle
@@ -45,9 +45,11 @@ if (!collectDLibPath.exists()) {
 
 archivesBaseName = 'applicationinsights-collectd'
 
+apply from: "$buildScriptsDir/provided-configuration.gradle"
+
 dependencies {
     compile project(':core')
-    compileOnly files(collectDLibPath)
+    provided files(collectDLibPath)
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile files(collectDLibPath)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,9 +61,11 @@ import com.microsoft.applicationinsights.build.tasks.PropsFileGen
 
 archivesBaseName = 'applicationinsights-core'
 
+apply from: "$buildScriptsDir/provided-configuration.gradle"
+
 dependencies {
-    compileOnly (project(':agent')) { transitive = false }
-    compileOnly ([group: 'org.glowroot.instrumentation', name: 'instrumentation-api', version: '0.14.9']) { transitive = false }
+    optional (project(':agent')) { transitive = false }
+    optional ([group: 'org.glowroot.instrumentation', name: 'instrumentation-api', version: '0.14.9']) { transitive = false }
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'eu.infomas', name: 'annotation-detector', version: '3.0.5'])
     compile ([group: 'commons-io', name: 'commons-io', version: '2.6' ])

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -21,4 +21,13 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="JLM_JSR166_UTILCONCURRENT_MONITORENTER" />
+        <!-- False Positive. Using wait/notify. -->
+        <Or>
+            <Class name="com.microsoft.applicationinsights.internal.channel.common.ApacheSender43" />
+            <Class name="com.microsoft.applicationinsights.internal.channel.common.ApacheSender43$1" />
+        </Or>
+        <Field name="httpClientRef" />
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -36,4 +36,44 @@
         <Class name="com.microsoft.applicationinsights.internal.util.MapUtil" />
         <Method name="getBoolValueOrNull" />
     </Match>
+    <Match>
+        <Bug pattern="DM_DEFAULT_ENCODING" />
+        <!-- The default encoding is suitable for these purposes. -->
+        <Or>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.GzipTelemetrySerializer" />
+                <Method name="compress" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.PartialSuccessHandler" />
+                <Method name="generateOriginalItems" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.perfcounter.UnixProcessIOPerformanceCounter" />
+                <Method name="getCurrentIOForCurrentProcess" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.perfcounter.UnixTotalCpuPerformanceCounter" />
+                <Method name="getLineOfData" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.perfcounter.UnixTotalMemoryPerformanceCounter" />
+                <Method name="getTotalAvailableMemory" />
+            </And>
+
+            <!-- the following instances could specify encoding if needed by the server -->
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.quickpulse.DefaultQuickPulsePingSender" />
+                <Method name="buildPingEntity" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.GzipTelemetrySerializer" />
+                <Method name="&lt;init&gt;" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.quickpulse.DefaultQuickPulseDataFetcher" />
+                <Method name="buildPostEntity" />
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -76,4 +76,22 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2" /> <!-- external references in -->
+        <!-- The external references is disposed after passed to object. -->
+        <Or>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.NonBlockingDispatcher" />
+                <Method name="&lt;init&gt;" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.Transmission" />
+                <Method name="&lt;init&gt;" />
+            </And>
+            <And><!-- this use is acceptable -->
+                <Class name="com.microsoft.applicationinsights.telemetry.BaseTelemetry" />
+                <Field name="timestamp" />
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -116,4 +116,42 @@
             <Class name="com.microsoft.applicationinsights.internal.quickpulse.QuickPulseDataCollector" />
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+        <Or>
+            <And>
+                <!-- This file path is not exposed or modifiable from external sources (transmission save files from failed sends). -->
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.TransmissionFileSystemOutput"/>
+                <Or>
+                    <Method name="&lt;init&gt;"/>
+                    <Method name="createTemporaryFile"/>
+                </Or>
+            </And>
+            <And>
+                <!-- The configuration file path is only read from trusted sources. -->
+                <Class name="com.microsoft.applicationinsights.internal.config.ConfigurationFileLocator"/>
+                <Or>
+                    <Method name="getConfigurationAbsolutePath"/>
+                    <Method name="getConfigurationFile"/>
+                    <Method name="getConfigurationFromLibraryLocation"/> <!-- the jar file path; same reasoning -->
+                    <Method name="normalizeUrlToFile"/>
+                </Or>
+            </And>
+            <And>
+                <!-- This path is read from trusted sources (file containing *ix process stats). -->
+                <Class name="com.microsoft.applicationinsights.internal.perfcounter.AbstractUnixPerformanceCounter"/>
+                <Method name="&lt;init&gt;"/>
+            </And>
+            <And>
+                <!-- The DLL extraction path is read from trusted sources. -->
+                <Class name="com.microsoft.applicationinsights.internal.perfcounter.JniPCConnector"/>
+                <Method name="buildDllLocalPath"/>
+            </And>
+            <And>
+                <!-- The paths here are either immutable or read from trusted sources -->
+                <Class name="com.microsoft.applicationinsights.internal.util.LocalFileSystemUtils" />
+                <Method name="getTempDir" />
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -184,4 +184,12 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <!-- These rules are fine to skip. -->
+        <Or>
+            <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD" />
+            <Bug pattern="SF_SWITCH_NO_DEFAULT" />
+            <Bug pattern="NM_METHOD_NAMING_CONVENTION" />
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -30,4 +30,10 @@
         </Or>
         <Field name="httpClientRef" />
     </Match>
+    <Match>
+        <Bug pattern="NP_BOOLEAN_RETURN_NULL" />
+        <!-- The method name is pretty clear -->
+        <Class name="com.microsoft.applicationinsights.internal.util.MapUtil" />
+        <Method name="getBoolValueOrNull" />
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -108,4 +108,12 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="ME_ENUM_FIELD_SETTER" />
+        <!-- Singleton enum pattern. By design. -->
+        <Or>
+            <Class name="com.microsoft.applicationinsights.internal.perfcounter.PerformanceCounterContainer" />
+            <Class name="com.microsoft.applicationinsights.internal.quickpulse.QuickPulseDataCollector" />
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -154,4 +154,34 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+        <Or>
+            <And>
+                <!-- The return value of Condition.await is irrelevant in this instance. -->
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.SenderThreadLocalBackOffData" />
+                <Method name="backOff" />
+            </And>
+            <And>
+                <!-- Return value is irrelevant; no plans to refactor to Runnable. -->
+                <Class name="com.microsoft.applicationinsights.internal.heartbeat.HeartBeatProvider" />
+                <Method name="initialize" />
+            </And>
+            <And>
+                <!-- Return value of mkdir is not helpful here. The next conditional checks if the target folder exists and is accessible. -->
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.TransmissionFileSystemOutput" />
+                <Method name="&lt;init&gt;"/>
+            </And>
+            <And>
+                <!-- Return value of mkdirs is not helpful here. The next conditional checks if the target folder exists and is accessible. -->
+                <Class name="com.microsoft.applicationinsights.internal.perfcounter.JniPCConnector" />
+                <Method name="buildDllLocalPath" />
+            </And>
+            <And>
+                <!-- Callers are responsible for checking if this directory was created. -->
+                <Class name="com.microsoft.applicationinsights.internal.util.LocalFileSystemUtils" />
+                <Method name="getTempDir" params="" returns="java.io.File" />
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd https://github.com/spotbugs/filter/3.0.0 ">
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM" />
+        <!-- These random numbers are not used for cryptography. Predictable pseudorandom is sufficient. -->
+        <Or>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.channel.sampling.SamplingScoreGenerator" />
+                <Method name="&lt;clinit&gt;" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.channel.samplingV2.SamplingScoreGeneratorV2" />
+                <Method name="&lt;clinit&gt;" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.internal.util.LocalStringsUtils" />
+                <Method name="generateRandomIntegerId" />
+            </And>
+        </Or>
+    </Match>
+</FindBugsFilter>

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -94,4 +94,18 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP" /><!-- internal references out -->
+        <Or>
+            <And>
+                <!-- Not exposed to public API. -->
+                <Class name="com.microsoft.applicationinsights.internal.channel.common.Transmission" />
+                <Field name="content" />
+            </And>
+            <And><!-- this use is acceptable -->
+                <Class name="com.microsoft.applicationinsights.telemetry.BaseTelemetry" />
+                <Field name="timestamp" />
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/core/src/main/java/com/microsoft/applicationinsights/channel/concrete/TelemetryChannelBase.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/channel/concrete/TelemetryChannelBase.java
@@ -379,15 +379,13 @@ public abstract class TelemetryChannelBase<T> implements TelemetryChannel {
     protected LimitsEnforcer createDefaultMaxTelemetryBufferCapacityEnforcer(Integer currentValue) {
         return LimitsEnforcer.createWithClosestLimitOnError(
                 MAX_TELEMETRY_BUFFER_CAPACITY_NAME, MIN_MAX_TELEMETRY_BUFFER_CAPACITY,
-                MAX_MAX_TELEMETRY_BUFFER_CAPACITY, DEFAULT_MAX_TELEMETRY_BUFFER_CAPACITY,
-                        currentValue == null ? DEFAULT_MAX_TELEMETRY_BUFFER_CAPACITY : currentValue);
+                MAX_MAX_TELEMETRY_BUFFER_CAPACITY, DEFAULT_MAX_TELEMETRY_BUFFER_CAPACITY, currentValue);
     }
 
     protected LimitsEnforcer createDefaultSendIntervalInSecondsEnforcer(Integer currentValue) {
         return LimitsEnforcer.createWithClosestLimitOnError(
                 FLUSH_BUFFER_TIMEOUT_IN_SECONDS_NAME, MIN_FLUSH_BUFFER_TIMEOUT_IN_SECONDS,
-                MAX_FLUSH_BUFFER_TIMEOUT_IN_SECONDS, DEFAULT_FLUSH_BUFFER_TIMEOUT_IN_SECONDS,
-                        currentValue == null ? DEFAULT_FLUSH_BUFFER_TIMEOUT_IN_SECONDS : currentValue);
+                MAX_FLUSH_BUFFER_TIMEOUT_IN_SECONDS, DEFAULT_FLUSH_BUFFER_TIMEOUT_IN_SECONDS, currentValue);
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/DockerContextInitializer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/extensibility/initializer/docker/DockerContextInitializer.java
@@ -49,7 +49,7 @@ public class DockerContextInitializer implements TelemetryInitializer {
 
     private FileFactory fileFactory;
     private DockerContextPoller dockerContextPoller;
-    private boolean sdkInfoFileWritten = false;
+    private volatile boolean sdkInfoFileWritten = false;
 
     protected DockerContextInitializer(FileFactory fileFactory, DockerContextPoller dockerContextPoller) {
         this.fileFactory = fileFactory;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/BackendResponse.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/BackendResponse.java
@@ -12,7 +12,7 @@ class BackendResponse {
     int itemsAccepted;
     Error[] errors;
 
-    class Error {
+    static class Error {
         public int index;
         public int statusCode;
         public String message;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/SenderThreadsBackOffManager.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/SenderThreadsBackOffManager.java
@@ -82,7 +82,7 @@ final class SenderThreadsBackOffManager extends ThreadLocal<SenderThreadLocalBac
     }
 
     @Override
-    protected SenderThreadLocalBackOffData initialValue() {
+    protected synchronized SenderThreadLocalBackOffData initialValue() {
         senderThreadLocalData = new SenderThreadLocalBackOffData(backOffTimeoutsInMilliseconds, threadsSecondsDifference.incrementAndGet() * 1000L);
         registerSenderData(senderThreadLocalData);
         return senderThreadLocalData;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/AdaptiveTelemetrySampler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/AdaptiveTelemetrySampler.java
@@ -88,7 +88,7 @@ public final class AdaptiveTelemetrySampler implements Stoppable, TelemetrySampl
                 suggestedSamplingPercentage = minSamplingPercentage;
             }
 
-            boolean samplingPercentageChangeNeeded = suggestedSamplingPercentage != currentSamplingPercentage;
+            boolean samplingPercentageChangeNeeded = Math.abs(suggestedSamplingPercentage - currentSamplingPercentage) > Math.ulp(suggestedSamplingPercentage); // suggestedSamplingPercentage != currentSamplingPercentage === abs(s - c) > epsilon
             if (samplingPercentageChangeNeeded) {
                 Date currentDate = new Date();
                 long duration = currentDate.getTime() - lastChangedDate.getTime();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/AdaptiveTelemetrySampler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/AdaptiveTelemetrySampler.java
@@ -237,7 +237,7 @@ public final class AdaptiveTelemetrySampler implements Stoppable, TelemetrySampl
     private int getIntValueOrDefault(String name, String valueAsString, int defaultValue, int minValue, int maxValue) {
         int result = defaultValue;
         try {
-            int value = Integer.valueOf(valueAsString);
+            int value = Integer.parseInt(valueAsString);
             if (value > 0) {
                 result = value;
             }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/SamplingScoreGenerator.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/sampling/SamplingScoreGenerator.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Created by gupele on 11/2/2016.
@@ -55,15 +56,21 @@ final class SamplingScoreGenerator {
     }
 
     private static int getSamplingHashCode(String input) {
-        if (input == null) {
+        if (StringUtils.isEmpty(input)) {
             return 0;
         }
 
-        while (input.length() < 8) {
-            input = input + input;
-        }
-
         int hash = 5381;
+
+        if (input.length() < 8) {
+            if (input.length() < 3) { // 1, 2 should repeat 8 or 4 times
+                input = StringUtils.repeat(input, 8/input.length());
+            } else if (input.length() == 3) {
+                input = StringUtils.repeat(input, 4);
+            } else {
+                input = StringUtils.repeat(input, 2);
+            }
+        }
 
         char[] asChars = input.toCharArray();
         for (int i = 0; i < asChars.length; i++) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/FixedRateSamplingTelemetryProcessor.java
@@ -170,7 +170,7 @@ public final class FixedRateSamplingTelemetryProcessor implements TelemetryProce
 
                 if (SamplingScoreGeneratorV2.getSamplingScore(telemetry) >= sp) {
 
-                    InternalLogger.INSTANCE.info("Item %s sampled out", telemetry.getClass().getSimpleName());
+                    InternalLogger.INSTANCE.trace("Item %s sampled out", telemetry.getClass().getSimpleName());
                     return false;
                 }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/samplingV2/SamplingScoreGeneratorV2.java
@@ -18,25 +18,26 @@ public class SamplingScoreGeneratorV2 {
      * This method takes the telemetry and returns the hash of the operation id if it is present already
      * or uses the random number generator to generate the sampling score.
      * @param telemetry
-     * @return
+     * @return [0.0, 1.0)
      */
     public static double getSamplingScore(Telemetry telemetry) {
 
-        double samplingScore = 0.0;
+        double samplingScore;
 
         if (!StringUtils.isEmpty(telemetry.getContext().getOperation().getId())) {
             samplingScore =  ((double) getSamplingHashCode(telemetry.getContext().getOperation().getId()) / Integer.MAX_VALUE);
+        } else {
+            samplingScore =  random.nextDouble(); // [0,1)
         }
 
-        else {
-            long val = Math.abs(random.nextLong());
-            samplingScore =  ((double)Math.abs(val)/ Long.MAX_VALUE);
-        }
-
-        return samplingScore * 100;
+        return samplingScore * 100.0; // always < 100.0
     }
 
-     static int getSamplingHashCode(String input) {
+    /**
+     * @param input
+     * @return [0, Integer.MAX_VALUE)
+     */
+    static int getSamplingHashCode(String input) {
         if (StringUtils.isEmpty(input)) {
             return 0;
         }
@@ -52,6 +53,9 @@ public class SamplingScoreGeneratorV2 {
             hash = ((hash << 5) + hash) + (int) inputBuilder.charAt(i);
         }
 
-        return hash == Integer.MIN_VALUE ? Integer.MAX_VALUE : Math.abs(hash);
+        if (hash == Integer.MIN_VALUE || hash == Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE - 1;
+        }
+        return Math.abs(hash);
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/Java7SaferXStream.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/Java7SaferXStream.java
@@ -31,6 +31,8 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.text.DecimalFormatSymbols;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -397,7 +399,15 @@ public class Java7SaferXStream {
      */
     public Java7SaferXStream(
             ReflectionProvider reflectionProvider, Mapper mapper, HierarchicalStreamDriver driver) {
-        this(reflectionProvider, driver, new CompositeClassLoader(), mapper);
+        this(reflectionProvider,
+                driver,
+                AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                    @Override
+                    public ClassLoader run() {
+                        return new CompositeClassLoader();
+                    }
+                }),
+                mapper);
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/DefaultHeartBeatPropertyProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/DefaultHeartBeatPropertyProvider.java
@@ -112,10 +112,6 @@ public class DefaultHeartBeatPropertyProvider implements HeartBeatPayloadProvide
    * @param defaultFields collection to hold default properties.
    */
   private void initializeDefaultFields(Set<String> defaultFields) {
-
-    if (defaultFields == null) {
-      defaultFields = new HashSet<>();
-    }
     defaultFields.add(JRE_VERSION);
     defaultFields.add(SDK_VERSION);
     defaultFields.add(OS_VERSION);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/DefaultHeartBeatPropertyProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/DefaultHeartBeatPropertyProvider.java
@@ -37,15 +37,15 @@ public class DefaultHeartBeatPropertyProvider implements HeartBeatPayloadProvide
   /**
    * Name of this provider.
    */
-  private final String name = "Default";
+  private static final String name = "Default";
 
-  private final String JRE_VERSION = "jreVersion";
+  private static final String JRE_VERSION = "jreVersion";
 
-  private final String SDK_VERSION = "sdkVersion";
+  private static final String SDK_VERSION = "sdkVersion";
 
-  private final String OS_VERSION = "osVersion";
+  private static final String OS_VERSION = "osVersion";
 
-  private final String PROCESS_SESSION_ID = "processSessionId";
+  private static final String PROCESS_SESSION_ID = "processSessionId";
 
   public DefaultHeartBeatPropertyProvider() {
     defaultFields = new HashSet<>();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
@@ -57,7 +57,7 @@ public class HeartBeatModule implements TelemetryModule {
         switch (entry.getKey()) {
           case "HeartBeatInterval":
             try {
-              setHeartBeatInterval(Long.valueOf(entry.getValue()));
+              setHeartBeatInterval(Long.parseLong(entry.getValue()));
               break;
             } catch (Exception e) {
               InternalLogger.INSTANCE.trace("Exception while adding Heartbeat interval,"

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
@@ -59,37 +59,38 @@ public class HeartBeatModule implements TelemetryModule {
             try {
               setHeartBeatInterval(Long.parseLong(entry.getValue()));
             } catch (Exception e) {
-              InternalLogger.INSTANCE.trace("Exception while adding Heartbeat interval,"
-                  + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
+              if (InternalLogger.INSTANCE.isTraceEnabled()) {
+                InternalLogger.INSTANCE.trace("Exception while adding Heartbeat interval: %s", ExceptionUtils.getStackTrace(e));
+              }
             }
             break;
           case "isHeartBeatEnabled":
             try {
               setHeartBeatEnabled(Boolean.parseBoolean(entry.getValue()));
-            }
-            catch (Exception e) {
-              InternalLogger.INSTANCE.trace("Exception while adding enabling/disabling heartbeat,"
-                  + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
+            } catch (Exception e) {
+              if (InternalLogger.INSTANCE.isTraceEnabled()) {
+                InternalLogger.INSTANCE.trace("Exception while adding enabling/disabling heartbeat: %s", ExceptionUtils.getStackTrace(e));
+              }
             }
             break;
           case "ExcludedHeartBeatPropertiesProvider":
             try {
               List<String> excludedHeartBeatPropertiesProviderList = parseStringToList(entry.getValue());
               setExcludedHeartBeatPropertiesProvider(excludedHeartBeatPropertiesProviderList);
-            }
-            catch (Exception e) {
-              InternalLogger.INSTANCE.trace("Exception while adding Excluded Heartbeat providers,"
-                  + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
+            } catch (Exception e) {
+              if (InternalLogger.INSTANCE.isTraceEnabled()) {
+                InternalLogger.INSTANCE.trace("Exception while adding Excluded Heartbeat providers: %s", ExceptionUtils.getStackTrace(e));
+              }
             }
             break;
           case "ExcludedHeartBeatProperties":
             try {
               List<String> excludedHeartBeatPropertiesList = parseStringToList(entry.getValue());
               setExcludedHeartBeatProperties(excludedHeartBeatPropertiesList);
-            }
-            catch (Exception e) {
-              InternalLogger.INSTANCE.trace("Exception while adding excluded heartbeat properties,"
-                  + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
+            } catch (Exception e) {
+              if (InternalLogger.INSTANCE.isTraceEnabled()) {
+                InternalLogger.INSTANCE.trace("Exception while adding excluded heartbeat properties: %s", ExceptionUtils.getStackTrace(e));
+              }
             }
             break;
           default:

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/HeartBeatModule.java
@@ -58,40 +58,40 @@ public class HeartBeatModule implements TelemetryModule {
           case "HeartBeatInterval":
             try {
               setHeartBeatInterval(Long.parseLong(entry.getValue()));
-              break;
             } catch (Exception e) {
               InternalLogger.INSTANCE.trace("Exception while adding Heartbeat interval,"
                   + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
             }
+            break;
           case "isHeartBeatEnabled":
             try {
               setHeartBeatEnabled(Boolean.parseBoolean(entry.getValue()));
-              break;
             }
             catch (Exception e) {
               InternalLogger.INSTANCE.trace("Exception while adding enabling/disabling heartbeat,"
                   + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
             }
+            break;
           case "ExcludedHeartBeatPropertiesProvider":
             try {
               List<String> excludedHeartBeatPropertiesProviderList = parseStringToList(entry.getValue());
               setExcludedHeartBeatPropertiesProvider(excludedHeartBeatPropertiesProviderList);
-              break;
             }
             catch (Exception e) {
               InternalLogger.INSTANCE.trace("Exception while adding Excluded Heartbeat providers,"
                   + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
             }
+            break;
           case "ExcludedHeartBeatProperties":
             try {
               List<String> excludedHeartBeatPropertiesList = parseStringToList(entry.getValue());
               setExcludedHeartBeatProperties(excludedHeartBeatPropertiesList);
-              break;
             }
             catch (Exception e) {
               InternalLogger.INSTANCE.trace("Exception while adding excluded heartbeat properties,"
                   + " Stack trace is: %s", ExceptionUtils.getStackTrace(e));
             }
+            break;
           default:
             InternalLogger.INSTANCE.trace("Encountered unknown parameter, no action will be performed");
             break;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsHeartbeatProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsHeartbeatProvider.java
@@ -24,7 +24,7 @@ public class WebAppsHeartbeatProvider implements HeartBeatPayloadProviderInterfa
   /**
    * Name of the provider
    */
-  private final String name = "webapps";
+  private static final String name = "webapps";
 
   /**
    * Collection holding default properties for this default provider.
@@ -36,11 +36,11 @@ public class WebAppsHeartbeatProvider implements HeartBeatPayloadProviderInterfa
    */
   private Map<String, String> environmentMap;
 
-  private final String WEBSITE_SITE_NAME = "appSrv_SiteName";
+  private static final String WEBSITE_SITE_NAME = "appSrv_SiteName";
 
-  private final String WEBSITE_HOSTNAME = "appSrv_wsHost";
+  private static final String WEBSITE_HOSTNAME = "appSrv_wsHost";
 
-  private final String WEBSITE_HOME_STAMPNAME = "appSrv_wsStamp";
+  private static final String WEBSITE_HOME_STAMPNAME = "appSrv_wsStamp";
 
 
   /**

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsHeartbeatProvider.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/heartbeat/WebAppsHeartbeatProvider.java
@@ -122,10 +122,6 @@ public class WebAppsHeartbeatProvider implements HeartBeatPayloadProviderInterfa
    * @param defaultFields
    */
   private void initializeDefaultFields(Set<String> defaultFields) {
-    if (defaultFields == null) {
-      defaultFields = new HashSet<>();
-    }
-
     defaultFields.add(WEBSITE_SITE_NAME);
     defaultFields.add(WEBSITE_HOSTNAME);
     defaultFields.add(WEBSITE_HOME_STAMPNAME);

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/GCPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/GCPerformanceCounter.java
@@ -52,7 +52,7 @@ public final class GCPerformanceCounter implements PerformanceCounter {
     public void report(TelemetryClient telemetryClient) {
         synchronized (this) {
             List<GarbageCollectorMXBean> gcs = ManagementFactory.getGarbageCollectorMXBeans();
-            if (gcs == null) {
+            if (gcs.isEmpty()) {
                 return;
             }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/JvmHeapMemoryUsedPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/JvmHeapMemoryUsedPerformanceCounter.java
@@ -40,7 +40,7 @@ public class JvmHeapMemoryUsedPerformanceCounter implements PerformanceCounter {
 
         private final static String HEAP_MEM_USED = "Heap Memory Used (MB)";
 
-    private final long Megabyte = 1024 * 1024;
+    private static final long Megabyte = 1024 * 1024;
 
     private final MemoryMXBean memory;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/processor/PageViewTelemetryFilter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/processor/PageViewTelemetryFilter.java
@@ -92,7 +92,7 @@ public final class PageViewTelemetryFilter implements TelemetryProcessor {
 
     public void setDurationThresholdInMS(String durationThresholdInMS) throws NumberFormatException {
         try {
-            this.durationThresholdInMS = Long.valueOf(durationThresholdInMS);
+            this.durationThresholdInMS = Long.parseLong(durationThresholdInMS);
             InternalLogger.INSTANCE.trace("PageViewTelemetryFilter: successfully set DurationThresholdInMS to %s", durationThresholdInMS);
         } catch (NumberFormatException e) {
             InternalLogger.INSTANCE.error("PageViewTelemetryFilter: failed to set DurationThresholdInMS:%s Exception : %s ",

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/processor/RequestTelemetryFilter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/processor/RequestTelemetryFilter.java
@@ -47,7 +47,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
  */
 @BuiltInProcessor("RequestTelemetryFilter")
 public final class RequestTelemetryFilter implements TelemetryProcessor {
-    private final class FromTo {
+    private static final class FromTo {
         public final int from;
         public final int to;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/processor/RequestTelemetryFilter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/processor/RequestTelemetryFilter.java
@@ -83,7 +83,7 @@ public final class RequestTelemetryFilter implements TelemetryProcessor {
                 return false;
             }
 
-            int asInt = Integer.valueOf(responseCode);
+            int asInt = Integer.parseInt(responseCode);
             for (FromTo fromTo : ignoredResponseCodeRange) {
                 if (fromTo.from <= asInt && fromTo.to >= asInt) {
                     return false;
@@ -105,7 +105,7 @@ public final class RequestTelemetryFilter implements TelemetryProcessor {
 
     public void setMinimumDurationInMS(String minimumDurationInMS) throws Throwable {
         try {
-            this.minimumDurationInMS = Long.valueOf(minimumDurationInMS);
+            this.minimumDurationInMS = Long.parseLong(minimumDurationInMS);
             InternalLogger.INSTANCE.trace("RequestTelemetryFilter: successfully set MinimumDurationInMS = %d", this.minimumDurationInMS);
         } catch (ThreadDeath td) {
             throw td;
@@ -145,8 +145,8 @@ public final class RequestTelemetryFilter implements TelemetryProcessor {
                     if (LocalStringsUtils.isNullOrEmpty(fromTo.get(0)) || LocalStringsUtils.isNullOrEmpty(fromTo.get(1))) {
                         continue;
                     }
-                    int f = Integer.valueOf(fromTo.get(0));
-                    int t = Integer.valueOf(fromTo.get(1));
+                    int f = Integer.parseInt(fromTo.get(0));
+                    int t = Integer.parseInt(fromTo.get(1));
                     ignoredResponseCodeRange.add(new FromTo(f, t));
                 }
                 hasBlocked = !exactBadResponseCodes.isEmpty() || !ignoredResponseCodeRange.isEmpty();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataFetcher.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataFetcher.java
@@ -148,11 +148,8 @@ final class DefaultQuickPulseDataFetcher implements QuickPulseDataFetcher {
         String comma = includeComma ? "," : "";
         sb.append(String.format("{\"Name\": \"%s\",\"Value\": %s,\"Weight\": %s}%s", metricName, metricValue, metricWeight, comma));
     }
+
     private void formatSingleMetric(StringBuilder sb, String metricName, long metricValue, int metricWeight, Boolean includeComma) {
-        String comma = includeComma ? "," : "";
-        sb.append(String.format("{\"Name\": \"%s\",\"Value\": %s,\"Weight\": %s}%s", metricName, metricValue, metricWeight, comma));
-    }
-    private void formatSingleMetric(StringBuilder sb, String metricName, int metricValue, int metricWeight, Boolean includeComma) {
         String comma = includeComma ? "," : "";
         sb.append(String.format("{\"Name\": \"%s\",\"Value\": %s,\"Weight\": %s}%s", metricName, metricValue, metricWeight, comma));
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/QuickPulseDataCollector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/QuickPulseDataCollector.java
@@ -195,7 +195,7 @@ public enum QuickPulseDataCollector {
         }
     }
 
-    private String getInstrumentationKey() {
+    private synchronized String getInstrumentationKey() {
         if (config != null) {
             return config.getInstrumentationKey();
         } else {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/PerformanceCounterData.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/PerformanceCounterData.java
@@ -44,7 +44,7 @@ public final class PerformanceCounterData extends Domain {
      */
     private static final String PERFORMANCE_COUNTER_BASE_TYPE = "PerformanceCounterData";
 
-    private final int ver = 2;
+    private static final int ver = 2;
     private String categoryName;
     private String counterName;
     private String instanceName;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/SessionStateData.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/SessionStateData.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 @Deprecated
 public final class SessionStateData extends Domain {
 
-    private final int ver = 2;
+    private static final int ver = 2;
 
     private SessionState state;
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/LocalFileSystemUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/LocalFileSystemUtils.java
@@ -67,8 +67,7 @@ public class LocalFileSystemUtils {
             tempDirectory = candidate.getAbsolutePath();
         }
 
-        final File result = new File(tempDirectory);
-        return result;
+        return new File(tempDirectory);
     }
 
     /**

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/JsonTelemetryDataSerializer.java
@@ -292,8 +292,6 @@ public final class JsonTelemetryDataSerializer {
 
     private <T> void write(T item) throws IOException {
         if (item instanceof JsonSerializable) {
-            StringWriter stringWriter = new StringWriter();
-
             String jsonStringToAppend = createJsonFor((JsonSerializable)item);
             if (Strings.isNullOrEmpty(jsonStringToAppend)) {
                 return;

--- a/gradle/common-java.gradle
+++ b/gradle/common-java.gradle
@@ -29,6 +29,7 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'checkstyle'
 apply plugin: 'org.owasp.dependencycheck'
+apply plugin: 'com.github.spotbugs'
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
@@ -43,6 +44,24 @@ checkstyle {
     configFile = file("${rootProject.projectDir}/config/checkstyle/checkstyle.xml")
     configProperties["rootDir"] = rootProject.projectDir
     showViolations = false
+}
+
+spotbugs {
+    effort = 'max'
+    reportLevel = 'medium'
+    ignoreFailures = false
+    sourceSets = [sourceSets.main]
+}
+
+tasks.withType(JavaCompile) {
+    dependencies {
+        // See https://find-sec-bugs.github.io/bugs.htm for bug pattern definitions
+        spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.9.0'
+    }
+    def spotbugsExcludeFile = file("$projectDir/spotbugs.exclude.xml")
+    if (spotbugsExcludeFile.exists()) {
+        spotbugs.excludeFilter = spotbugsExcludeFile
+    }
 }
 
 tasks.withType(Checkstyle) {

--- a/gradle/provided-configuration.gradle
+++ b/gradle/provided-configuration.gradle
@@ -1,0 +1,7 @@
+configurations {
+    optional
+    provided
+    compileOnly.extendsFrom provided, optional
+}
+
+spotbugsMain.classpath = configurations.provided + configurations.optional + sourceSets.main.runtimeClasspath

--- a/web-auto/build.gradle
+++ b/web-auto/build.gradle
@@ -25,15 +25,16 @@ plugins {
 
 apply from: "$buildScriptsDir/common-java.gradle"
 apply from: "$buildScriptsDir/publishing.gradle"
+apply from: "$buildScriptsDir/provided-configuration.gradle"
 
 archivesBaseName = 'applicationinsights-web-auto'
 
 dependencies {
     compile(project(':web')) { transitive = false }
-    compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
-    compileOnly group: 'org.springframework', name: 'spring-context', version: '4.3.24.RELEASE'
-    compileOnly group: 'org.springframework.boot', name: 'spring-boot', version: '1.4.0.RELEASE'
-    compileOnly group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '1.4.0.RELEASE'
+    provided group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
+    optional group: 'org.springframework', name: 'spring-context', version: '4.3.24.RELEASE'
+    optional group: 'org.springframework.boot', name: 'spring-boot', version: '1.4.0.RELEASE'
+    optional group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '1.4.0.RELEASE'
 }
 
 shadowJar {

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -28,17 +28,19 @@ apply from: "$buildScriptsDir/publishing.gradle"
 
 archivesBaseName = 'applicationinsights-web'
 
+apply from: "$buildScriptsDir/provided-configuration.gradle"
+
 dependencies {
-    compileOnly (project(':agent')) { transitive = false }
+    optional (project(':agent')) { transitive = false }
     compile (project(':core')) { transitive = false }
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
     compile ([group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'])
     compile ([group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.1.3'])
-    compileOnly 'org.apache.struts.xwork:xwork-core:2.3.37' // Struts 2
-    compileOnly 'org.springframework:spring-webmvc:3.1.0.RELEASE'
-    compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
-    compileOnly group: 'javax.enterprise', name: 'cdi-api', version: '1.1' // Java EE
+    optional 'org.apache.struts.xwork:xwork-core:2.3.37' // Struts 2
+    optional 'org.springframework:spring-webmvc:3.1.0.RELEASE'
+    provided group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
+    provided group: 'javax.enterprise', name: 'cdi-api', version: '1.1' // Java EE
     testCompile (project(':agent')) { transitive = false }
     testCompile 'org.apache.struts.xwork:xwork-core:2.3.37'
     testCompile 'org.springframework:spring-webmvc:3.1.0.RELEASE'
@@ -75,7 +77,7 @@ projectPomName = project.msftAppInsights + " Java SDK Web Module"
 projectPomDescription = "This is the web module of " + project.msftAppInsightsJavaSdk
 
 whenPomConfigured = { p ->
-    p.dependencies = project.configurations.compileOnly.allDependencies
+    p.dependencies = project.configurations.provided.allDependencies
             .findAll { it.group != 'com.microsoft.azure' }
             .collect {
                 def d = p.dependencies[0].class.newInstance() // related to https://issues.gradle.org/browse/GRADLE-1497
@@ -84,7 +86,7 @@ whenPomConfigured = { p ->
                 d.version = it.version
                 d.scope = 'provided'
                 d.type = null
-                if (it.name == 'xwork' || it.name == 'spring-webmvc') d.optional = 'true'
+                if (project.configurations.optional.allDependencies.contains(it)) d.optional = 'true'
                 d
             }
 }

--- a/web/spotbugs.exclude.xml
+++ b/web/spotbugs.exclude.xml
@@ -26,4 +26,10 @@
             </And>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="HTTP_PARAMETER_POLLUTION" />
+        <!-- Input is from trusted sources and not used as parameter values -->
+        <Class name="com.microsoft.applicationinsights.web.internal.correlation.CdsProfileFetcher" />
+        <Method name="createFetchTask" />
+    </Match>
 </FindBugsFilter>

--- a/web/spotbugs.exclude.xml
+++ b/web/spotbugs.exclude.xml
@@ -12,4 +12,18 @@
             <Method name="setStatus" />
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="PREDICTABLE_RANDOM" />
+        <!-- Not used for cryptography. ThreadLocalRandom is sufficient. -->
+        <Or>
+            <And>
+                <Class name="com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils" />
+                <Method name="generateSuffix" />
+            </And>
+            <And>
+                <Class name="com.microsoft.applicationinsights.web.internal.correlation.tracecontext.Traceparent" />
+                <Method name="randomHex" />
+            </And>
+        </Or>
+    </Match>
 </FindBugsFilter>

--- a/web/spotbugs.exclude.xml
+++ b/web/spotbugs.exclude.xml
@@ -32,4 +32,11 @@
         <Class name="com.microsoft.applicationinsights.web.internal.correlation.CdsProfileFetcher" />
         <Method name="createFetchTask" />
     </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP"/>
+        <!-- This usage is sufficient for our purposes. Conversion to long would be cumbersome; it's in the request pipeline, so I'm hesitant to copy on read. -->
+        <Class name="com.microsoft.applicationinsights.web.internal.cookies.UserCookie" />
+        <Method name="getAcquisitionDate" />
+        <Field name="acquisitionDate" />
+    </Match>
 </FindBugsFilter>

--- a/web/spotbugs.exclude.xml
+++ b/web/spotbugs.exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd https://github.com/spotbugs/filter/3.0.0 ">
+    <Match>
+        <Bug pattern="XSS_SERVLET" />
+        <!-- False Positive. Wrapper for response. -->
+        <Class name="com.microsoft.applicationinsights.web.internal.ApplicationInsightsHttpResponseWrapper" />
+        <Or>
+            <Method name="sendError" />
+            <Method name="setStatus" />
+        </Or>
+    </Match>
+</FindBugsFilter>

--- a/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/initializers/WebOperationIdTelemetryInitializer.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/extensibility/initializers/WebOperationIdTelemetryInitializer.java
@@ -69,9 +69,9 @@ public class WebOperationIdTelemetryInitializer extends WebTelemetryInitializerB
 
         // add correlation context to properties
         Map<String, String> correlationContextMap = telemetryContext.getCorrelationContext().getMappings();
-        for (String key : correlationContextMap.keySet()) {
-            if (telemetry.getProperties().get(key) == null) {
-                telemetry.getProperties().put(key, correlationContextMap.get(key));
+        for (Map.Entry<String, String> entry : correlationContextMap.entrySet()) {
+            if (telemetry.getProperties().get(entry.getKey()) == null) {
+                telemetry.getProperties().put(entry.getKey(), entry.getValue());
             }
         }
     }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -84,7 +84,6 @@ public final class WebRequestTrackingFilter implements Filter {
     private final List<ThreadLocalCleaner> cleaners = new LinkedList<ThreadLocalCleaner>();
     private String appName;
     private static final String AGENT_LOCATOR_INTERFACE_NAME = "com.microsoft.applicationinsights.agent.internal.coresync.AgentNotificationsHandler";
-    private String filterName = FILTER_NAME;
 
     /**
      * Constant for marking already processed request
@@ -203,9 +202,6 @@ public final class WebRequestTrackingFilter implements Filter {
             } else {
                 InternalLogger.INSTANCE.info("Agent is not running");
                 agentBridge = AgentBridgeFactory.create();
-            }
-            if (StringUtils.isNotEmpty(config.getFilterName())) {
-                this.filterName = config.getFilterName();
             }
             long end = System.currentTimeMillis();
             InternalLogger.INSTANCE.trace("Initialized Application Insights Filter in %.3fms", (end - start));

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
@@ -133,7 +133,11 @@ public class CdsProfileFetcher implements AppProfileFetcher, ApplicationIdResolv
         // if no task currently exists for this ikey, then let's create one.
         if (currentTask == null) {
             currentTask = createFetchTask(instrumentationKey, configuration);
-            this.tasks.putIfAbsent(instrumentationKey, currentTask);
+            Future<HttpResponse> mapValue = this.tasks.putIfAbsent(instrumentationKey, currentTask);
+            // it's possible for another thread to create a fetch task
+            if (mapValue != null) { // if there is already a mapping, then let's discard the new one and check if the existing task has completed.
+                currentTask = mapValue;
+            }
         }
 
         // check if task is still pending

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/tracecontext/Tracestate.java
@@ -1,6 +1,7 @@
 package com.microsoft.applicationinsights.web.internal.correlation.tracecontext;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -125,15 +126,15 @@ public class Tracestate {
     private String toInternalString() {
         boolean isFirst = true;
         StringBuilder stringBuilder = new StringBuilder(512);
-        for (String key : internalList.keySet()) {
+        for (Map.Entry<String, String> entry : internalList.entrySet()) {
             if (isFirst) {
                 isFirst = false;
             } else {
                 stringBuilder.append(",");
             }
-            stringBuilder.append(key);
+            stringBuilder.append(entry.getKey());
             stringBuilder.append("=");
-            stringBuilder.append(internalList.get(key));
+            stringBuilder.append(entry.getValue());
         }
         return stringBuilder.toString();
     }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
@@ -140,8 +140,9 @@ public final class HttpServerHandler {
      */
     public void handleException(Exception e) {
         try {
-            InternalLogger.INSTANCE.trace("Unhandled exception while processing request: %s",
-                ExceptionUtils.getStackTrace(e));
+            if (InternalLogger.INSTANCE.isTraceEnabled()) {
+                InternalLogger.INSTANCE.trace("Unhandled exception while processing request: %s", ExceptionUtils.getStackTrace(e));
+            }
             if (telemetryClient != null) {
                 telemetryClient.trackException(e);
             }

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/httputils/HttpServerHandler.java
@@ -146,7 +146,9 @@ public final class HttpServerHandler {
                 telemetryClient.trackException(e);
             }
         } catch (Exception ex) {
-            // swallow AI Exception
+            if (InternalLogger.INSTANCE.isErrorEnabled()) {
+                InternalLogger.INSTANCE.error("Error occurred tracking exception: " + ExceptionUtils.getStackTrace(ex));
+            }
         }
     }
 


### PR DESCRIPTION
## Adding Spotbugs
This adds the spotbugs plugin to the build as part of the `check` step (`build=assemble check`). It  also adds the find-sec-bugs plugin.

I pushed another branch called [tmp/spotbugs_configured](https://github.com/microsoft/ApplicationInsights-Java/tree/tmp/spotbugs_configured). This has spotbugs added to the build, but before any fixes. Use this if you want to run the build and see all the failures. Once we merge this, I'm going to delete that branch as well.

Currently, the plugin is configured to fail the build if any failures are found. We can make it configurable if you think we need to. The only use I can think of is to get a complete list of bugs (it's fail-fast). So, if you want that, change line 47 to `ignoreFailures = true`:
https://github.com/microsoft/ApplicationInsights-Java/blob/6c3f41df0f93a81e08191c8855fcee38d3c31672/gradle/common-java.gradle#L44-L49

It's based on FindBugs. If there are any FindBugs plugins that you know of, we can try to add them.

## Using Spotbugs
### Run
It runs automatically with `check` or `build`.
To run it alone:
```
gradlew spotbugsMain
```
It creates a few different tasks, one for each source set. It's configured to only care about `main`.

### Results
The results are in `<project>/build/reports/spotbugs/main.xml`. You can use a FindBugs plugin in your IDE and import these.

You can generate an html report, if you want to. I wasn't a fan of the html.

### Docs
* [Spotbugs](https://spotbugs.readthedocs.io/en/latest/introduction.html)
  * [bug descriptions](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html)
* [Find-sec-bugs](http://find-sec-bugs.github.io/)
  * [descriptions](http://find-sec-bugs.github.io/bugs.htm)


## Changes to dependency configurations
To get spotbugs to scan properly, it needed the `complieOnly` dependencies specified on its classpath. After much trial and error, I ended up with the current configuration which adds the `provided` and `optional` dependency configurations to builds where they are "needed." It turns out they're actually not needed, but I like them. I think `provided` is more self explanitory than `compileOnly`. Let me know what you think of this change.


## ToDo
* [ ] Double-check artifacts if we're keeping `provided` and `optional`. I did this during development, but not since I got it all working.