### PR TITLE
Fix uribuilder in connection string parsing

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/connection/ConnectionString.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/connection/ConnectionString.java
@@ -6,7 +6,6 @@ import com.google.common.base.Strings;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.utils.URIBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -81,16 +80,17 @@ public class ConnectionString {
         if (!Strings.isNullOrEmpty(snapshotEndpoint)) {
             config.getEndpointProvider().setSnapshotEndpoint(toUriOrThrow(snapshotEndpoint, Keywords.SNAPSHOT_ENDPOINT));
         }
-
     }
+
 
     private static URI toUriOrThrow(String uri, String field) throws InvalidConnectionStringException {
         try {
-            final URIBuilder builder = new URIBuilder(uri);
-            if (Strings.isNullOrEmpty(builder.getScheme())) {
-                builder.setScheme("https");
+            URI result = new URI(uri);
+            final String scheme = result.getScheme();
+            if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+                throw new InvalidConnectionStringException(field+" must specify supported protocol, either 'http' or 'https': \""+uri+"\"");
             }
-            return builder.build();
+            return result;
         } catch (URISyntaxException e) {
             throw new InvalidConnectionStringException(field + " is invalid: \"" + uri + "\"", e);
         }


### PR DESCRIPTION
When a protocol is missing, it should insert `https`, but this isn't working. The current result is missing "//", e.g. `http:example.com`.

Edit: Instead, we will be more strict an throw an exception when the an endpoint value in the connection string is missing a protocol.
