### PR TITLE
Add field truncation to 

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/extensibility/context/ContextTagKeys.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/extensibility/context/ContextTagKeys.java
@@ -128,6 +128,8 @@ public class ContextTagKeys
     // 44: Optional string OperationRootId
     private String OperationRootId;
 
+    private String OperationCorrelationVector;
+
     // 51: Optional string SessionId
     private String SessionId;
 
@@ -811,6 +813,14 @@ public class ContextTagKeys
         return this.CloudRoleInstance;
     }
 
+    public final String getOperationCorrelationVector() {
+        return OperationCorrelationVector;
+    }
+
+    public final void setOperationCorrelationVector(String operationCorrelationVector) {
+        OperationCorrelationVector = operationCorrelationVector;
+    }
+
     public static ContextTagKeys getKeys()
     {
         return s_keys;
@@ -865,6 +875,7 @@ public class ContextTagKeys
         OperationId = "ai.operation.id";
         OperationParentId = "ai.operation.parentId";
         OperationRootId = "ai.operation.rootId";
+        OperationCorrelationVector = "ai.operation.correlationVector";
         SessionId = "ai.session.id";
         SessionIsFirst = "ai.session.isFirst";
         SessionIsNew = "ai.session.isNew";

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/MapUtil.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/MapUtil.java
@@ -73,7 +73,7 @@ public class MapUtil
     }
 
     public static Boolean getBoolValueOrNull(Map<String, String> map, String key) {
-        return map.containsKey(key) ? Boolean.parseBoolean(map.get(key)) : null;
+        return map.containsKey(key) ? Boolean.valueOf(map.get(key)) : null;
     }
 
     public static Date getDateValueOrNull(Map<String, String> map, String key) {

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
@@ -55,7 +55,7 @@ public abstract class BaseTelemetry<T extends Domain> implements Telemetry {
      * @param properties The context properties
      */
     protected void initialize(ConcurrentMap<String, String> properties) {
-        this.context = new TelemetryContext(properties, new ConcurrentHashMap<String, String>());
+        this.context = new TelemetryContext(properties, new ContextTagsMap());
     }
 
     public abstract int getVer();

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/ContextTagsMap.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/ContextTagsMap.java
@@ -1,0 +1,159 @@
+package com.microsoft.applicationinsights.telemetry;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import com.microsoft.applicationinsights.extensibility.context.ContextTagKeys;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This ensures the values for certain tags do not exceed their limits.
+ */
+class ContextTagsMap implements ConcurrentMap<String, String> {
+
+    private static final Map<String, Integer> tagSizeLimits = new HashMap<>();
+
+
+    static {
+        tagSizeLimits.put(ContextTagKeys.getKeys().getApplicationVersion(), 1024);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getDeviceId(), 1024);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getDeviceModel(), 256);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getDeviceOEMName(), 256);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getDeviceOSVersion(), 256);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getDeviceType(), 64);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getLocationIP(), 45);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getOperationId(), 128);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getOperationName(), 1024);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getOperationParentId(), 128);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getSyntheticSource(), 1024);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getSessionId(), 64);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getUserId(), 128);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getUserAccountId(), 1024);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getUserAuthUserId(), 1024);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getCloudRole(), 256);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getCloudRoleInstance(), 256);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getInternalSdkVersion(), 64);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getInternalAgentVersion(), 64);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getInternalNodeName(), 256);
+        tagSizeLimits.put(ContextTagKeys.getKeys().getOperationCorrelationVector(), 64);
+    }
+
+    private final ConcurrentMap<String, String> tags = new ConcurrentHashMap<>();
+
+    private static String sanitizeKey(String key) {
+        return key;
+    }
+
+    private static String truncate(String value, int maxLength) {
+        if (value != null && value.length() > maxLength) {
+            value = StringUtils.truncate(value, maxLength);
+        }
+        return value;
+    }
+
+    private String sanitizeValue(String key, String value) {
+        value = StringUtils.trim(value);
+        if (tagSizeLimits.containsKey(key)) {
+            value = truncate(value, tagSizeLimits.get(key));
+        }
+        return value;
+    }
+
+    @Override
+    public String putIfAbsent(String key, String value) {
+        return tags.putIfAbsent(key, sanitizeValue(key, value));
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        return tags.remove(key, value);
+    }
+
+    @Override
+    public boolean replace(String key, String oldValue, String newValue) {
+        return tags.replace(key, oldValue, sanitizeValue(key, newValue));
+    }
+
+    @Override
+    public String replace(String key, String value) {
+        return tags.replace(key, sanitizeValue(key, value));
+    }
+
+    @Override
+    public int size() {
+        return tags.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return tags.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return tags.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return tags.containsValue(value);
+    }
+
+    @Override
+    public String get(Object key) {
+        return tags.get(key);
+    }
+
+    @Override
+    public String put(String key, String value) {
+        return tags.put(key, sanitizeValue(key, value));
+    }
+
+    @Override
+    public String remove(Object key) {
+        return tags.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends String> m) {
+        Map<String, String> sanitized = new HashMap<>();
+        for (Entry<? extends String, ? extends String> entry : m.entrySet()) {
+            sanitized.put(entry.getKey(), sanitizeValue(entry.getKey(), entry.getValue()));
+        }
+        tags.putAll(sanitized);
+    }
+
+    @Override
+    public void clear() {
+        tags.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return tags.keySet();
+    }
+
+    @Override
+    public Collection<String> values() {
+        return tags.values();
+    }
+
+    @Override
+    public Set<Entry<String, String>> entrySet() {
+        return tags.entrySet();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return tags.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return tags.hashCode();
+    }
+}

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/TelemetryContext.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/TelemetryContext.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public final class TelemetryContext {
     private ConcurrentMap<String,String> properties;
-    private ConcurrentMap<String,String> tags;
+    private ContextTagsMap tags;
 
     private String instrumentationKey;
     private ComponentContext component;
@@ -61,7 +61,7 @@ public final class TelemetryContext {
      * Default Ctor
      */
     public TelemetryContext() {
-        this(new ConcurrentHashMap<String, String>(), new ConcurrentHashMap<String, String>());
+        this(new ConcurrentHashMap<String, String>(), new ContextTagsMap());
     }
 
     /**
@@ -212,7 +212,7 @@ public final class TelemetryContext {
         return internal;
     }
 
-    TelemetryContext(ConcurrentMap<String, String> properties, ConcurrentMap<String, String> tags) {
+    TelemetryContext(ConcurrentMap<String, String> properties, ContextTagsMap tags) {
         if (properties == null) {
             throw new IllegalArgumentException("properties cannot be null");
         }

--- a/core/src/test/java/com/microsoft/applicationinsights/telemetry/ContextTagsMapTests.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/telemetry/ContextTagsMapTests.java
@@ -1,0 +1,58 @@
+package com.microsoft.applicationinsights.telemetry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.microsoft.applicationinsights.extensibility.context.ContextTagKeys;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+public class ContextTagsMapTests {
+    private ContextTagsMap map;
+
+    @Before
+    public void setup() {
+        map = new ContextTagsMap();
+    }
+
+    @After
+    public void tearDown() {
+        map = null;
+    }
+
+
+    @Test
+    public void putTruncatesValueOverLimit() {
+        // max len is 64
+        String sessionIdKey = ContextTagKeys.getKeys().getSessionId();
+        String value = StringUtils.repeat("1234", 32);
+        map.put(sessionIdKey, value);
+        assertEquals(StringUtils.repeat("1234", 16), map.get(sessionIdKey));
+    }
+
+    @Test
+    public void putAllTruncatesValuesOverLimit() {
+        final String locationIpValue = StringUtils.repeat('x', 55); // max=45
+        final String deviceIdValue = StringUtils.repeat('y', 2048); //max=1024
+        final String operationParentIdValue = StringUtils.repeat('z', 127); //max=128, this one is intentionally within the limits
+
+        final String customKey = "not a limited key";
+        final String customValue = StringUtils.repeat("1234", 1024);
+
+        Map<String, String> kvps = new HashMap<>();
+        kvps.put(ContextTagKeys.getKeys().getLocationIP(), locationIpValue);
+        kvps.put(ContextTagKeys.getKeys().getDeviceId(), deviceIdValue);
+        kvps.put(ContextTagKeys.getKeys().getOperationParentId(), operationParentIdValue);
+        kvps.put(customKey, customValue);
+
+        map.putAll(kvps);
+
+        assertEquals(StringUtils.repeat('x', 45), map.get(ContextTagKeys.getKeys().getLocationIP()));
+        assertEquals(StringUtils.repeat('y', 1024), map.get(ContextTagKeys.getKeys().getDeviceId()));
+        assertEquals(operationParentIdValue, map.get(ContextTagKeys.getKeys().getOperationParentId()));
+        assertEquals(customValue, map.get(customKey));
+    }
+
+}

--- a/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtilsTests.java
+++ b/web/src/test/java/com/microsoft/applicationinsights/web/internal/correlation/TelemetryCorrelationUtilsTests.java
@@ -22,6 +22,7 @@
 package com.microsoft.applicationinsights.web.internal.correlation;
 
 import com.microsoft.applicationinsights.TelemetryConfiguration;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.*;
 import com.microsoft.applicationinsights.extensibility.context.OperationContext;
 import com.microsoft.applicationinsights.internal.util.DateTimeUtils;
@@ -405,7 +406,7 @@ public class TelemetryCorrelationUtilsTests {
         //validate operation context ID's
         OperationContext operation = requestTelemetry.getContext().getOperation();
         assertEquals(rootId, operation.getId());
-        assertEquals(incomingId, operation.getParentId());
+        assertEquals(StringUtils.truncate(incomingId, 128), operation.getParentId());
     }
 
     @Test
@@ -446,8 +447,8 @@ public class TelemetryCorrelationUtilsTests {
 
         //validate operation context ID's
         OperationContext operation = requestTelemetry.getContext().getOperation();
-        assertEquals(incomingId, operation.getId());
-        assertEquals(incomingId, operation.getParentId());
+        assertEquals(StringUtils.truncate(incomingId, 128), operation.getId());
+        assertEquals(StringUtils.truncate(incomingId, 128), operation.getParentId());
     }
 
     @Test


### PR DESCRIPTION
Fix #1180 

I created a wrapper map because the map reference escapes via `TelemetryContext.getTags()`.