### PR TITLE
Add http proxy configuration

### DIFF
--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/Configuration.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/Configuration.java
@@ -39,6 +39,8 @@ public class Configuration {
     public String roleName;
     @Nullable
     public String roleInstance;
+    @Nullable
+    public String httpProxy;
     public List<JmxMetric> jmxMetrics = Collections.emptyList();
 
     public ExperimentalConfiguration experimental = new ExperimentalConfiguration();

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/ConfigurationBuilder.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/ConfigurationBuilder.java
@@ -51,6 +51,8 @@ class ConfigurationBuilder {
     private static final String APPLICATIONINSIGHTS_ROLE_NAME = "APPLICATIONINSIGHTS_ROLE_NAME";
     private static final String APPLICATIONINSIGHTS_ROLE_INSTANCE = "APPLICATIONINSIGHTS_ROLE_INSTANCE";
 
+    private static final String APPLICATIONINSIGHTS_HTTP_PROXY = "APPLICATIONINSIGHTS_HTTP_PROXY";
+
     private static final String WEBSITE_SITE_NAME = "WEBSITE_SITE_NAME";
     private static final String WEBSITE_INSTANCE_ID = "WEBSITE_INSTANCE_ID";
 
@@ -64,6 +66,8 @@ class ConfigurationBuilder {
         config.roleName = overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_NAME, WEBSITE_SITE_NAME, config.roleName);
         config.roleInstance =
                 overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_INSTANCE, WEBSITE_INSTANCE_ID, config.roleInstance);
+
+        config.httpProxy = overlayWithEnvVar(APPLICATIONINSIGHTS_HTTP_PROXY, config.httpProxy);
 
         return config;
     }
@@ -134,6 +138,14 @@ class ConfigurationBuilder {
             return value;
         }
         value = getEnv(name2);
+        if (!Strings.isNullOrEmpty(value)) {
+            return value;
+        }
+        return defaultValue;
+    }
+
+    static String overlayWithEnvVar(String name, String defaultValue) {
+        String value = getEnv(name);
         if (!Strings.isNullOrEmpty(value)) {
             return value;
         }

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/MainEntryPoint.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/MainEntryPoint.java
@@ -64,6 +64,7 @@ import com.microsoft.applicationinsights.telemetry.PageViewTelemetry;
 import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.telemetry.TraceTelemetry;
+import org.apache.http.HttpHost;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.glowroot.instrumentation.engine.config.InstrumentationDescriptor;
 import org.glowroot.instrumentation.engine.config.InstrumentationDescriptors;
@@ -200,6 +201,10 @@ public class MainEntryPoint {
             // and JBoss/Wildfly need to install their own JUL manager before JUL is initialized
             ApacheSender43.safeToInitLatch = new CountDownLatch(1);
             instrumentation.addTransformer(new JulListeningClassFileTransformer(ApacheSender43.safeToInitLatch));
+        }
+
+        if (config.httpProxy != null) {
+            ApacheSender43.proxy = HttpHost.create(config.httpProxy);
         }
 
         TelemetryConfiguration configuration = TelemetryConfiguration.getActiveWithoutInitializingConfig();

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -205,6 +205,12 @@
         <Field name="safeToInitLatch" />
     </Match>
     <Match>
+        <!-- False positive. There's a null check and it is initialized by MainEntryPoint as part of the startup procedures. -->
+        <Bug pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD" />
+        <Class name="com.microsoft.applicationinsights.internal.channel.common.ApacheSender43" />
+        <Field name="proxy" />
+    </Match>
+    <Match>
         <!-- These rules are fine to skip. -->
         <Or>
             <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD" />

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -29,6 +29,7 @@ import javax.annotation.concurrent.GuardedBy;
 
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.internal.util.SSLOptionsUtil;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
@@ -39,6 +40,7 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContexts;
@@ -49,6 +51,7 @@ import org.apache.http.ssl.SSLContexts;
 public final class ApacheSender43 implements ApacheSender {
 
     public static volatile CountDownLatch safeToInitLatch;
+    public static volatile HttpHost proxy;
 
     private final Object lock = new Object();
 
@@ -143,9 +146,11 @@ public final class ApacheSender43 implements ApacheSender {
                         .build());
         cm.setMaxTotal(DEFAULT_MAX_TOTAL_CONNECTIONS);
         cm.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
-        return HttpClients.custom()
-                .setConnectionManager(cm)
-                .useSystemProperties()
-                .build();
+        HttpClientBuilder builder = HttpClients.custom()
+                .setConnectionManager(cm);
+        if (proxy != null) {
+            builder.setProxy(proxy);
+        }
+        return builder.build();
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ApacheSender43.java
@@ -147,7 +147,8 @@ public final class ApacheSender43 implements ApacheSender {
         cm.setMaxTotal(DEFAULT_MAX_TOTAL_CONNECTIONS);
         cm.setDefaultMaxPerRoute(DEFAULT_MAX_CONNECTIONS_PER_ROUTE);
         HttpClientBuilder builder = HttpClients.custom()
-                .setConnectionManager(cm);
+                .setConnectionManager(cm)
+                .useSystemProperties();
         if (proxy != null) {
             builder.setProxy(proxy);
         }


### PR DESCRIPTION
Using environment variable `APPLICATIONINSIGHTS_HTTP_PROXY`.

Format is `[scheme://]host[:port]` where scheme defaults to `http` and port defaults to `80` for http and `443` for https.
