### PR TITLE
Fix dependency in published pom file

### DIFF
--- a/azure-application-insights-spring-boot-starter/build.gradle
+++ b/azure-application-insights-spring-boot-starter/build.gradle
@@ -49,7 +49,7 @@ apply from: "$buildScriptsDir/provided-configuration.gradle"
 
 def springBootVersion = '1.5.21.RELEASE'
 dependencies {
-    compile(project(path: ':web', configuration: 'shadow')) // web includes core
+    compile(project(':web')) // web includes core
     compile(project(':ApplicationInsightsInternalLogger'))
     compile ([group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'])
 


### PR DESCRIPTION
Changes in 2.6.0-BETA.2 caused the classifier `all` to be added to the -web dependency in the published pom file, which does not resolve to anything.

(See published [2.6.0-BETA pom](https://search.maven.org/artifact/com.microsoft.azure/applicationinsights-spring-boot-starter/2.6.0-BETA/jar) and [2.6.0-BETA.2 pom](https://search.maven.org/artifact/com.microsoft.azure/applicationinsights-spring-boot-starter/2.6.0-BETA.2/jar))



