### PR TITLE
fix classifier added by 'shadow' configuration

### DIFF
--- a/azure-application-insights-spring-boot-starter/build.gradle
+++ b/azure-application-insights-spring-boot-starter/build.gradle
@@ -95,7 +95,14 @@ whenPomConfigured = { p ->
             dep.artifactId != agentArtifactId && dep.artifactId != loggerArtifactId &&
             !(dep.groupId in ['org.apache.http', 'eu.infomas', 'org.apache.commons', 'commons-io',
                               'com.google.guava', 'com.google.code.gson', 'org.apache.httpcomponents',
-                              'io.grpc', 'com.google.protobuf'])}
+                              'io.grpc', 'com.google.protobuf'])
+    }
+    .collect { dep ->
+        if (dep.artifactId == 'applicationinsights-web') {
+            dep.classifier = null
+        }
+        dep
+    }
     p.dependencies += project.configurations.provided.allDependencies
             .findAll { it.group != 'com.microsoft.azure' }
             .collect {


### PR DESCRIPTION
Fix #1199.

Introduced by this change: https://github.com/microsoft/ApplicationInsights-Java/commit/c898d4998ddde88f27b494bda0ac59962bf7e14f
Apparently the 'shadow' configuration (defined by the shadowJar plugin) adds the 'all' classifier to the dependency in the pom by default.

Using the shadow configuration as a dependency simplifies the build script and prevents the need to change the spring-boot-starter build file if web or core dependencies change.

For significant contributions please make sure you have completed the following items:
- [x] Design discussion issue #
- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated
