### PR TITLE
Fix appsvc windows log config and env var config 

### DIFF
--- a/agent-codeless/package/Microsoft.ApplicationInsights.JavaCodelessAgent.nuspec
+++ b/agent-codeless/package/Microsoft.ApplicationInsights.JavaCodelessAgent.nuspec
@@ -11,7 +11,13 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Application Insights Java Codeless Agent.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <releaseNotes />
+    <releaseNotes>
+        * Fixed IPA log directory defaults for Windows.
+        * Introduced environment variable `APPLICATIONINSIGHTS_DIAGNOSTICS_OUTPUT_DIRECTORY` for internal self-diagnostic logs.
+        * Updated Status File location to be relative to the log directory (controlled by same variables/properties).
+        * Added env var `APPLICATIONINSIGHTS_EXTENSION_LOG_FILE_ENABLED`. $HOME/LogFiles/ApplicationInsights/*.log is disabled when set to "false".
+        * Added env var `APPLICATIONINSIGHTS_EXTENSION_STATUS_FILE_ENABLED`. $HOME/LogFile/ApplicationInsights/status/status_*.json is disabled when set to "false".
+    </releaseNotes>
     <tags>Microsoft ApplicationInsights Java Codeless</tags>
   </metadata>
   <files>

--- a/agent-codeless/package/Microsoft.ApplicationInsights.JavaCodelessAgent.nuspec
+++ b/agent-codeless/package/Microsoft.ApplicationInsights.JavaCodelessAgent.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.ApplicationInsights.JavaCodelessAgent</id>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
     <title>Application Insights Java Codeless Agent Package</title>
     <authors>Microsoft</authors>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkID=391182</licenseUrl>

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/DiagnosticsHelper.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/DiagnosticsHelper.java
@@ -7,8 +7,11 @@ import java.nio.file.Path;
 import com.google.common.annotations.VisibleForTesting;
 
 public class DiagnosticsHelper {
-    private DiagnosticsHelper() {
-    }
+    private DiagnosticsHelper() { }
+
+    public static final String IPA_LOG_FILE_ENABLED_ENV_VAR = "APPLICATIONINSIGHTS_EXTENSION_LOG_FILE_ENABLED";
+
+    public static final String INTERNAL_LOG_OUTPUT_DIR_ENV_VAR = "APPLICATIONINSIGHTS_DIAGNOSTICS_OUTPUT_DIRECTORY";
 
     @VisibleForTesting
     static volatile boolean appServiceCodeless;
@@ -17,26 +20,7 @@ public class DiagnosticsHelper {
 
     private static volatile boolean functionsCodeless;
 
-    @VisibleForTesting
-    static boolean enabled;
-
-    @VisibleForTesting
-    static final String DIAGNOSTICS_OUTPUT_ENABLED_ENV_VAR_NAME = "APPLICATIONINSIGHTS_DIAGNOSTICS_OUTPUT_ENABLED";
-
-    public static final String DIAGNOSTICS_LOGGER_NAME = "applicationinsights.diagnostics";
-
-    static {
-        boolean result = true;
-        try {
-            final String envValue = System.getenv(DIAGNOSTICS_OUTPUT_ENABLED_ENV_VAR_NAME);
-            if (envValue != null) {
-                // Boolean.parseBoolean will be false if string is not "true"; if var is garbage, assume enabled
-                result = !envValue.equalsIgnoreCase("false");
-            }
-        } catch (Exception e) {
-        }
-        enabled = result;
-    }
+    public static final String DIAGNOSTICS_LOGGER_NAME = "applicationinsights.extension.diagnostics";
 
     public static void setAgentJarFile(File agentJarFile) {
         Path agentPath = agentJarFile.toPath();
@@ -63,10 +47,6 @@ public class DiagnosticsHelper {
 
     public static boolean isAnyCodelessAttach() {
         return appServiceCodeless || aksCodeless || functionsCodeless;
-    }
-
-    public static boolean shouldOutputDiagnostics() {
-        return enabled && isAppServiceCodeless();
     }
 
 }

--- a/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/log/ApplicationInsightsDiagnosticsLogFilter.java
+++ b/agent-codeless/src/main/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/log/ApplicationInsightsDiagnosticsLogFilter.java
@@ -9,8 +9,7 @@ import com.microsoft.applicationinsights.agentc.internal.diagnostics.Diagnostics
 public class ApplicationInsightsDiagnosticsLogFilter extends Filter<ILoggingEvent> {
     @Override
     public FilterReply decide(ILoggingEvent event) {
-        if (DiagnosticsHelper.shouldOutputDiagnostics()
-                && (event.getLevel().toInt() == Level.ERROR_INT || DiagnosticsHelper.DIAGNOSTICS_LOGGER_NAME.equals(event.getLoggerName()))) {
+        if (event.getLevel().toInt() == Level.ERROR_INT || DiagnosticsHelper.DIAGNOSTICS_LOGGER_NAME.equals(event.getLoggerName())) {
             return FilterReply.NEUTRAL; // accept logs if error level or if they are from the diagnostic logger
         } else {
             return FilterReply.DENY; // unless disabled or outside of diagnostics logging environment

--- a/agent-codeless/src/main/resources/appsvc.ai.logback.xml
+++ b/agent-codeless/src/main/resources/appsvc.ai.logback.xml
@@ -3,58 +3,21 @@
 <configuration>
     <appender name="CONSOLE" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSSX} %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <!-- site.logdir output -->
-    <appender name="LOGDIR" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${site.logdir:-/home/LogFiles}/ApplicationInsights/application-insights-extension.log</file>
-        <rollingPolicy class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${site.logdir:-/home/LogFiles}/ApplicationInsights/application-insights-extension-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxHistory>7</maxHistory>
-            <totalSizeCap>5MB</totalSizeCap>
-            <maxFileSize>3MB</maxFileSize>
-        </rollingPolicy>
-        <encoder class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-            <layout class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.ApplicationInsightsJsonLayout">
-                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
-                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
-                <appendLineSeparator>true</appendLineSeparator>
-                <jsonFormatter class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.MoshiJsonFormatter">
-                    <prettyPrint>false</prettyPrint>
-                </jsonFormatter>
-            </layout>
-        </encoder>
-    </appender>
+    <!-- site.logdir logs -->
+    <include optional="true" resource="${ai.config.appender.user-logdir.location:-rp-logger-config/user-logfile.appender.xml}" />
 
-    <!-- troubleshooting logs -->
-    <appender name="APPSVCTBS" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.ApplicationInsightsDiagnosticsLogFilter"/>
-        <file>/var/log/applicationinsights/application-insights-extension.log</file>
-        <rollingPolicy class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>/var/log/applicationinsights/application-insights-extension-%d{yyyy-MM-dd}.%i.log.old</fileNamePattern>
-            <maxHistory>1</maxHistory>
-            <totalSizeCap>10MB</totalSizeCap>
-            <maxFileSize>5MB</maxFileSize>
-        </rollingPolicy>
-        <encoder class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-            <layout class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.ApplicationInsightsJsonLayout">
-                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
-                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
-                <appendLineSeparator>true</appendLineSeparator>
-                <jsonFormatter class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.MoshiJsonFormatter">
-                    <prettyPrint>false</prettyPrint>
-                </jsonFormatter>
-            </layout>
-        </encoder>
-    </appender>
+    <!-- internal troubleshooting/diagnostics logs -->
+    <include optional="true" resource="${ai.config.appender.diagnostics.location:-rp-logger-config/diagnostics.appender.xml}" />
 
     <root level="${applicationInsights.agent.logging.level:-error}">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="LOGDIR"/>
-        <appender-ref ref="APPSVCTBS"/>
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="USER_LOG_FILE" /><!-- optional; platform dependent -->
+        <appender-ref ref="DIAGNOSTICS_FILE" /><!-- optional; platform dependent -->
     </root>
 
-    <logger name="applicationinsights.diagnostics" level="info" />
+    <logger name="applicationinsights.extension.diagnostics" level="${applciationinsights.extension.diagnostics.level:-info}" />
 </configuration>

--- a/agent-codeless/src/main/resources/appsvc.ai.logback.xml
+++ b/agent-codeless/src/main/resources/appsvc.ai.logback.xml
@@ -19,5 +19,5 @@
         <appender-ref ref="DIAGNOSTICS_FILE" /><!-- optional; platform dependent -->
     </root>
 
-    <logger name="applicationinsights.extension.diagnostics" level="${applciationinsights.extension.diagnostics.level:-info}" />
+    <logger name="applicationinsights.extension.diagnostics" level="${applicationinsights.extension.diagnostics.level:-info}" />
 </configuration>

--- a/agent-codeless/src/main/resources/rp-logger-config/diagnostics.appender.xml
+++ b/agent-codeless/src/main/resources/rp-logger-config/diagnostics.appender.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
-    <property scope="local" name="ai.appsvc.logfile.name" value="${ai.logfile.name:-application-insights-extension}" />
-    <property scope="local" name="ai.appsvc.logfile.ext" value="${ai.logfile.ext:-.log}" />
-    <property scope="local" name="ai.appsvc.logfile.old.ext" value="${ai.appsvc.logfile.ext:-.log}.old" />
+    <property scope="local" name="ai.appsvc.logfile.name" value="application-insights-extension" />
+    <property scope="local" name="ai.appsvc.logfile.ext" value=".log" />
+    <property scope="local" name="ai.appsvc.logfile.old.ext" value="${ai.appsvc.logfile.ext}.old" />
 
     <!-- internal troubleshooting/diagnostics logs -->
     <appender name="DIAGNOSTICS_FILE" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.RollingFileAppender">

--- a/agent-codeless/src/main/resources/rp-logger-config/diagnostics.appender.xml
+++ b/agent-codeless/src/main/resources/rp-logger-config/diagnostics.appender.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
-    <property scope="system" name="ai.appsvc.logfile.name" value="${ai.logfile.name:-application-insights-extension}" />
-    <property scope="system" name="ai.appsvc.logfile.ext" value="${ai.logfile.ext:-.log}" />
-    <property scope="system" name="ai.appsvc.logfile.old.ext" value="${ai.appsvc.logfile.ext:-.log}.old" />
+    <property scope="local" name="ai.appsvc.logfile.name" value="${ai.logfile.name:-application-insights-extension}" />
+    <property scope="local" name="ai.appsvc.logfile.ext" value="${ai.logfile.ext:-.log}" />
+    <property scope="local" name="ai.appsvc.logfile.old.ext" value="${ai.appsvc.logfile.ext:-.log}.old" />
 
     <!-- internal troubleshooting/diagnostics logs -->
     <appender name="DIAGNOSTICS_FILE" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.RollingFileAppender">

--- a/agent-codeless/src/main/resources/rp-logger-config/diagnostics.appender.xml
+++ b/agent-codeless/src/main/resources/rp-logger-config/diagnostics.appender.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <property scope="system" name="ai.appsvc.logfile.name" value="${ai.logfile.name:-application-insights-extension}" />
+    <property scope="system" name="ai.appsvc.logfile.ext" value="${ai.logfile.ext:-.log}" />
+    <property scope="system" name="ai.appsvc.logfile.old.ext" value="${ai.appsvc.logfile.ext:-.log}.old" />
+
+    <!-- internal troubleshooting/diagnostics logs -->
+    <appender name="DIAGNOSTICS_FILE" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${APPLICATIONINSIGHTS_DIAGNOSTICS_OUTPUT_DIRECTORY}/${ai.appsvc.logfile.name}${ai.appsvc.logfile.ext}</file>
+        <rollingPolicy class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${APPLICATIONINSIGHTS_DIAGNOSTICS_OUTPUT_DIRECTORY}/${ai.appsvc.logfile.name}-%d{yyyy-MM-dd}.%i${ai.appsvc.logfile.old.ext}</fileNamePattern>
+            <maxHistory>1</maxHistory>
+            <totalSizeCap>10MB</totalSizeCap>
+            <maxFileSize>5MB</maxFileSize>
+        </rollingPolicy>
+        <encoder class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.ApplicationInsightsJsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+                <jsonFormatter class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.MoshiJsonFormatter">
+                    <prettyPrint>false</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+        <!-- accepts logs only from applicationinsights.extension.diagnostics or errors -->
+        <filter class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.ApplicationInsightsDiagnosticsLogFilter"/>
+    </appender>
+</included>

--- a/agent-codeless/src/main/resources/rp-logger-config/user-logfile.appender.xml
+++ b/agent-codeless/src/main/resources/rp-logger-config/user-logfile.appender.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
-    <property scope="system" name="ai.logdir" value="${site.logdir:-${HOME:-.}/LogFiles}/ApplicationInsights" />
-    <property scope="system" name="ai.logfile.name" value="application-insights-extension" />
-    <property scope="system" name="ai.logfile.ext" value=".log" />
+    <property scope="local" name="ai.logdir" value="${site.logdir:-${HOME:-.}/LogFiles}/ApplicationInsights" />
+    <property scope="local" name="ai.logfile.name" value="application-insights-extension" />
+    <property scope="local" name="ai.logfile.ext" value=".log" />
 
     <!-- site.logdir output -->
     <appender name="USER_LOG_FILE" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.RollingFileAppender">

--- a/agent-codeless/src/main/resources/rp-logger-config/user-logfile.appender.xml
+++ b/agent-codeless/src/main/resources/rp-logger-config/user-logfile.appender.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <property scope="system" name="ai.logdir" value="${site.logdir:-${HOME:-.}/LogFiles}/ApplicationInsights" />
+    <property scope="system" name="ai.logfile.name" value="application-insights-extension" />
+    <property scope="system" name="ai.logfile.ext" value=".log" />
+
+    <!-- site.logdir output -->
+    <appender name="USER_LOG_FILE" class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${ai.logdir}/${ai.logfile.name}${ai.logfile.ext}</file>
+        <rollingPolicy class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${ai.logdir}/${ai.logfile.name}-%d{yyyy-MM-dd}.%i${ai.logfile.ext}</fileNamePattern>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>5MB</totalSizeCap>
+            <maxFileSize>3MB</maxFileSize>
+        </rollingPolicy>
+        <encoder class="com.microsoft.applicationinsights.agentc.shadow.ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.ApplicationInsightsJsonLayout">
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+                <jsonFormatter class="com.microsoft.applicationinsights.agentc.internal.diagnostics.log.MoshiJsonFormatter">
+                    <prettyPrint>false</prettyPrint>
+                </jsonFormatter>
+            </layout>
+        </encoder>
+    </appender>
+</included>

--- a/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/DiagnosticsTestHelper.java
+++ b/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/DiagnosticsTestHelper.java
@@ -4,18 +4,12 @@ public class DiagnosticsTestHelper {
     private DiagnosticsTestHelper() {
     }
 
-    public static final String ENABLED_ENV_VAR = DiagnosticsHelper.DIAGNOSTICS_OUTPUT_ENABLED_ENV_VAR_NAME;
-
     public static void setIsAppServiceCodeless(boolean appServiceCodeless) {
         DiagnosticsHelper.appServiceCodeless = appServiceCodeless;
     }
 
     public static void reset() {
-        DiagnosticsHelper.enabled = true;
         setIsAppServiceCodeless(false);
     }
 
-    public static void setEnabled(boolean enabled) {
-        DiagnosticsHelper.enabled = enabled;
-    }
 }

--- a/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/log/ApplicationInsightsDiagnosticsLogFilterTests.java
+++ b/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/log/ApplicationInsightsDiagnosticsLogFilterTests.java
@@ -32,12 +32,6 @@ public class ApplicationInsightsDiagnosticsLogFilterTests {
     }
 
     @Test
-    public void denyIfDiagnosticsAreDisabled() {
-        DiagnosticsTestHelper.setEnabled(false);
-        assertEquals(FilterReply.DENY, filter.decide(mockEvent));
-    }
-
-    @Test
     public void neutralIfError() {
         assertEquals(FilterReply.NEUTRAL, filter.decide(mockEvent));
     }

--- a/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/status/StatusFileTests.java
+++ b/agent-codeless/src/test/java/com/microsoft/applicationinsights/agentc/internal/diagnostics/status/StatusFileTests.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 import com.microsoft.applicationinsights.agentc.internal.diagnostics.AgentExtensionVersionFinder;
 import com.microsoft.applicationinsights.agentc.internal.diagnostics.DiagnosticsTestHelper;
 import com.microsoft.applicationinsights.internal.config.TelemetryConfigurationFactory;
-import com.microsoft.applicationinsights.internal.system.SystemInformation;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi.Builder;
 import org.hamcrest.Matchers;
@@ -17,6 +16,9 @@ import org.junit.*;
 import org.junit.contrib.java.lang.system.*;
 import org.junit.rules.*;
 
+import static com.microsoft.applicationinsights.agentc.internal.diagnostics.status.StatusFile.DEFAULT_APPLICATIONINSIGHTS_LOGDIR;
+import static com.microsoft.applicationinsights.agentc.internal.diagnostics.status.StatusFile.DEFAULT_LOGDIR;
+import static com.microsoft.applicationinsights.agentc.internal.diagnostics.status.StatusFile.STATUS_FILE_DIRECTORY;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -49,10 +51,7 @@ public class StatusFileTests {
 
     @Test
     public void defaultDirectoryIsCorrect() {
-        String expected = "/home/LogFiles/ApplicationInsights/status";
-        if (SystemInformation.INSTANCE.isWindows()) {
-            expected = "D:" + expected;
-        }
+        String expected = "./LogFiles/ApplicationInsights/status";
         assertEquals(expected, StatusFile.directory);
     }
 
@@ -61,7 +60,26 @@ public class StatusFileTests {
         String parentDir = "/temp/test/prop";
         System.setProperty("site.logdir", parentDir);
         StatusFile.init();
-        String expected = parentDir + StatusFile.DEFAULT_APPLICATIONINSIGHTS_LOGDIR +  StatusFile.STATUS_FILE_DIRECTORY;
+        String expected = parentDir + DEFAULT_APPLICATIONINSIGHTS_LOGDIR +  STATUS_FILE_DIRECTORY;
+        assertEquals(expected, StatusFile.directory);
+    }
+
+    @Test
+    public void homeEnvVarUpdatesBaseDir() {
+        String parentDir = "/temp/test";
+        envVars.set(StatusFile.HOME_ENV_VAR, parentDir);
+        StatusFile.init();
+        String expected = parentDir + DEFAULT_LOGDIR + DEFAULT_APPLICATIONINSIGHTS_LOGDIR + STATUS_FILE_DIRECTORY;
+        assertEquals(expected, StatusFile.directory);
+    }
+
+    @Test
+    public void siteLogDirHasPrecedenceOverHome() {
+        String homeDir = "/this/is/wrong";
+        String siteLogDir = "/the/correct/dir";
+        System.setProperty("site.logdir", siteLogDir);
+        StatusFile.init();
+        String expected = siteLogDir + DEFAULT_APPLICATIONINSIGHTS_LOGDIR + STATUS_FILE_DIRECTORY;
         assertEquals(expected, StatusFile.directory);
     }
 
@@ -104,13 +122,13 @@ public class StatusFileTests {
 
     @Test
     public void doesNotWriteIfEnabledEnvVarIsFalse() throws Exception {
-        envVars.set(DiagnosticsTestHelper.ENABLED_ENV_VAR, "false");
+        envVars.set(StatusFile.STATUS_FILE_ENABLED_ENV_VAR, "false");
         runWriteFileTest(false);
     }
 
     @Test
     public void ifEnabledVarHasInvalidValueThenItIsEnabled() throws Exception {
-        envVars.set(DiagnosticsTestHelper.ENABLED_ENV_VAR, "42");
+        envVars.set(StatusFile.STATUS_FILE_ENABLED_ENV_VAR, "42");
         DiagnosticsTestHelper.setIsAppServiceCodeless(true);
         runWriteFileTest(true);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 // Project properties
-version=2.6.0-BETA.2
+version=2.5.2
 group=com.microsoft.azure
-

--- a/test/smoke/testApps/VerifyShading/src/main/java/com/microsoft/ajl/simple/TestController.java
+++ b/test/smoke/testApps/VerifyShading/src/main/java/com/microsoft/ajl/simple/TestController.java
@@ -60,6 +60,7 @@ public class TestController {
         expectedEntries.add("NOTICE");
         expectedEntries.add("ai.logback.xml");
         expectedEntries.add("appsvc.ai.logback.xml");
+        expectedEntries.add("rp-logger-config/");
         expectedEntries.add("rp-logger-config/user-logfile.appender.xml");
         expectedEntries.add("rp-logger-config/diagnostics.appender.xml");
         expectedEntries.add("sdk-version.properties");

--- a/test/smoke/testApps/VerifyShading/src/main/java/com/microsoft/ajl/simple/TestController.java
+++ b/test/smoke/testApps/VerifyShading/src/main/java/com/microsoft/ajl/simple/TestController.java
@@ -60,6 +60,8 @@ public class TestController {
         expectedEntries.add("NOTICE");
         expectedEntries.add("ai.logback.xml");
         expectedEntries.add("appsvc.ai.logback.xml");
+        expectedEntries.add("rp-logger-config/user-logfile.appender.xml");
+        expectedEntries.add("rp-logger-config/diagnostics.appender.xml");
         expectedEntries.add("sdk-version.properties");
         JarFile jarFile = new JarFile(agentJarFile);
         List<String> unexpected = new ArrayList<>();


### PR DESCRIPTION
<strike>APPLICATIONINSIGHTS_LOGDIR overrides user accessible log directory, which also overrides the 'site.logdir' value.</strike>

APPLICATIONINSIGHTS_DIAGNOSTICS_OUTPUT_DIRECTORY is linux only and overrides the internal log directory.

Updated package to contain different configs for windows and linux.

- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated
