### PR TITLE
Fix Spring Boot Starter failing with lazy init

### DIFF
--- a/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsTelemetryAutoConfiguration.java
+++ b/azure-application-insights-spring-boot-starter/src/main/java/com/microsoft/applicationinsights/autoconfigure/ApplicationInsightsTelemetryAutoConfiguration.java
@@ -147,6 +147,7 @@ public class ApplicationInsightsTelemetryAutoConfiguration {
         if (telemetryProcessors != null) {
             telemetryConfiguration.getTelemetryProcessors().addAll(telemetryProcessors);
         }
+        initializeTelemetryChannel(telemetryConfiguration);
         initializeComponents(telemetryConfiguration);
         initializePerformanceCounterContainer();
         return telemetryConfiguration;
@@ -173,9 +174,7 @@ public class ApplicationInsightsTelemetryAutoConfiguration {
 
 
 
-    @Bean
-    @ConditionalOnMissingBean
-    public TelemetryChannel telemetryChannel(TelemetryConfiguration configuration) {
+    private void initializeTelemetryChannel(TelemetryConfiguration configuration) {
         InProcess inProcess = applicationInsightsProperties.getChannel().getInProcess();
         final InProcessTelemetryChannel channel;
         if (StringUtils.isNotEmpty(inProcess.getEndpointAddress())) {
@@ -189,7 +188,6 @@ public class ApplicationInsightsTelemetryAutoConfiguration {
         }
 
         configuration.setChannel(channel);
-        return channel;
     }
 
     @Bean


### PR DESCRIPTION
In Spring 2.2.x, adding this new flag to `application.properties`:

```
spring.main.lazy-initialization=true
```

causes our spring boot starter not to create and register the `TelemetryChannel` (because no one depends on that bean, so it is never created in "lazy" mode), and so `NopTelemetryChannel` is used and no telemetry is sent.