### PR TITLE
Fix W3C BackCompat

### DIFF
--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/SdkBridgeImpl.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/SdkBridgeImpl.java
@@ -73,6 +73,7 @@ class SdkBridgeImpl extends AbstractSdkBridge<RequestTelemetryContext> {
             setter.put(carrier, "traceparent", traceparent.toString());
             if (w3cBackCompat) {
                 setter.put(carrier, "Request-Id", "|" + traceparent.getTraceId() + "." + traceparent.getSpanId() + ".");
+                setter.put(carrier, "Request-Context", TelemetryCorrelationUtils.retrieveApplicationCorrelationId());
             }
             if (tracestate != null) {
                 setter.put(carrier, "tracestate", tracestate);


### PR DESCRIPTION
We weren't passing `Request-Context` when backcompat is enabled, which means if a downstream service is in a different Application Insights resource, it won't be able to link back up to the original request (until the new distributed tracing indexer is in place, but that could be some time still).