### PR TITLE
logging - apply layout for log4j event

### DIFF
--- a/logging/log4j2/src/main/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppender.java
+++ b/logging/log4j2/src/main/java/com/microsoft/applicationinsights/log4j/v2/ApplicationInsightsAppender.java
@@ -191,7 +191,8 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         }
 
         try {
-            ApplicationInsightsLogEvent aiEvent = new ApplicationInsightsLogEvent(event);
+            //Formats a logging event using the layout
+            ApplicationInsightsLogEvent aiEvent = new ApplicationInsightsLogEvent(event,getLayout());
             this.telemetryClientProxy.sendEvent(aiEvent);
         } catch (Exception e) {
             // Appender failure must not fail the running application.

--- a/logging/log4j2/src/main/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEvent.java
+++ b/logging/log4j2/src/main/java/com/microsoft/applicationinsights/log4j/v2/internal/ApplicationInsightsLogEvent.java
@@ -21,29 +21,33 @@
 
 package com.microsoft.applicationinsights.log4j.v2.internal;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import com.microsoft.applicationinsights.internal.common.ApplicationInsightsEvent;
 import com.microsoft.applicationinsights.internal.logger.InternalLogger;
 import com.microsoft.applicationinsights.telemetry.SeverityLevel;
+
+import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.spi.StandardLevel;
 
 public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent {
 
     private LogEvent logEvent;
+    private Layout<? extends Serializable> layout;
 
-    public ApplicationInsightsLogEvent(LogEvent logEvent) {
+    public ApplicationInsightsLogEvent(LogEvent logEvent, Layout<? extends Serializable> layout) {
         this.logEvent = logEvent;
+        this.layout = layout;
     }
 
     @Override
     public String getMessage() {
-        String message = this.logEvent.getMessage() != null ?
-                this.logEvent.getMessage().getFormattedMessage() :
-                "Log4j Trace";
-
-        return message;
+        // Serializes the given event using the appender's layout if present.
+        return layout != null ? layout.toSerializable(logEvent).toString() :
+                logEvent.getMessage() != null ? logEvent.getMessage().getFormattedMessage() :
+                    "Log4j Trace";
     }
 
     @Override


### PR DESCRIPTION
Fix Custom layout can't be used with appinsights log4j v2.

```
The PatternLayout has no effect on the log4j sent to Azure AppInsights:
e.g:
<Configuration packages="com.microsoft.applicationinsights.log4j.v2">
    <Appenders>
        <ApplicationInsightsAppender name="aiAppender" instrumentationKey=my_instrumentation_key">
               <PatternLayout pattern="%d - %X{trace_id} - %m%n" />
        </ApplicationInsightsAppender>
    </Appenders>

    <Loggers>
        <AsyncRoot level="INFO">
            <AppenderRef ref="aiAppender" />
        </AsyncRoot>

        <!-- AsyncLogger -->
        ...  

    </Loggers>
</Configuration>
```
