### PR TITLE
Update ETW fields

### DIFF
--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/MainEntryPoint.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/MainEntryPoint.java
@@ -74,7 +74,7 @@ public class MainEntryPoint {
             try {
                 StatusFile.putValueAndWrite("AgentInitializedSuccessfully", success);
             } catch (Exception e) {
-                startupLogger.error("Error writing status.json", e);
+                startupLogger.error("Error writing status.json", e); // lgtm[java/dereferenced-value-may-be-null]
             }
             MDC.clear();
         }

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/EtwAppender.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/EtwAppender.java
@@ -40,13 +40,9 @@ public class EtwAppender extends AppenderBase<ILoggingEvent> {
 
     public EtwAppender() {
         ApplicationMetadataFactory metadata = DiagnosticsHelper.getMetadataFactory();
-        // TODO siteName == appName ???
         proto.setAppName(metadata.getSiteName().getValue());
-        proto.setExtensionVersion(metadata.getExtensionVersion().getValue());
+        proto.setExtensionVersion(metadata.getSdkVersion().getValue());
         proto.setSubscriptionId(metadata.getSubscriptionId().getValue());
-        proto.setInstrumentationKey(metadata.getInstrumentationKey().getValue());
-        final String restype = DiagnosticsHelper.getCodelessResourceType();
-        proto.setResourceType(restype != null ? restype : "unknown");
     }
 
     @Override

--- a/agent/agent/src/main/java/io/opentelemetry/auto/bootstrap/AgentBootstrap.java
+++ b/agent/agent/src/main/java/io/opentelemetry/auto/bootstrap/AgentBootstrap.java
@@ -93,7 +93,7 @@ public class AgentBootstrap {
             final File bootstrapFile = new File(bootstrapURL.toURI());
 
             if (!bootstrapFile.isDirectory()) {
-                inst.appendToBootstrapClassLoaderSearch(new JarFile(bootstrapFile));
+                inst.appendToBootstrapClassLoaderSearch(new JarFile(bootstrapFile)); // lgtm[java/input-resource-leak]
                 return bootstrapURL;
             }
         }
@@ -136,7 +136,7 @@ public class AgentBootstrap {
             throw new RuntimeException("Unable to find javaagent file: " + javaagentFile);
         }
         bootstrapURL = javaagentFile.toURI().toURL();
-        inst.appendToBootstrapClassLoaderSearch(new JarFile(javaagentFile));
+        inst.appendToBootstrapClassLoaderSearch(new JarFile(javaagentFile)); // lgtm[java/input-resource-leak]
 
         return bootstrapURL;
     }

--- a/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exceptions.java
+++ b/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exceptions.java
@@ -67,10 +67,6 @@ public class Exceptions {
                 } else {
                     current.setTypeName(line);
                 }
-            } else {
-                // stack
-                current.getParsedStack();
-
             }
             System.out.println(line);
         }

--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -202,6 +202,25 @@
         <Class name="com.microsoft.applicationinsights.internal.channel.common.ApacheSender43" />
         <Field name="proxy" />
     </Match>
+    <Match><!-- False Positive from new try-with-resources bytecode in Java 11: https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+        <Class name="com.microsoft.applicationinsights.internal.channel.simplehttp.SimpleHttpChannel" />
+        <Method name="send" />
+        <Or>
+            <Local name="httpClient" />
+            <Local name="response" />
+        </Or>
+    </Match>
+    <Match><!-- False Positive from new try-with-resources bytecode in Java 11: https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Or>
+            <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE" />
+            <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+            <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE" />
+        </Or>
+        <Class name="com.microsoft.applicationinsights.internal.config.TelemetryConfigurationFactory" />
+        <Method name="initialize" />
+        <Local name="configurationFile" />
+    </Match>
     <Match>
         <!-- These rules are fine to skip. -->
         <Or>

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -390,7 +390,7 @@ public class TelemetryClient {
     public void track(Telemetry telemetry) {
 
         if (generateCounter.incrementAndGet() % 10000 == 0) {
-            logger.info("Total events generated till now %d", generateCounter.get());
+            logger.info("Total events generated till now {}", generateCounter.get());
         }
 
         if (telemetry == null) {

--- a/core/src/main/java/com/microsoft/applicationinsights/channel/concrete/TelemetryChannelBase.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/channel/concrete/TelemetryChannelBase.java
@@ -314,7 +314,7 @@ public abstract class TelemetryChannelBase<T> implements TelemetryChannel {
         }
 
         if (itemsSent.incrementAndGet() % LOG_TELEMETRY_ITEMS_MODULUS == 0) {
-            logger.info("items sent till now %d", itemsSent.get());
+            logger.info("items sent till now: {}", itemsSent.get());
         }
 
         if (isDeveloperMode()) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/jmx/JmxDataFetcher.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/jmx/JmxDataFetcher.java
@@ -73,9 +73,7 @@ public class JmxDataFetcher {
                 Collection<Object> resultForAttribute = fetch(server, objects, attribute.name);
                 result.put(attribute.displayName, resultForAttribute);
             } catch (Exception e) {
-                logger
-                        .error("Failed to fetch JMX object '%s' with attribute '%s': '%s'", objectName, attribute.name,
-                                e.toString());
+                logger.error("Failed to fetch JMX object '{}' with attribute '{}': ", objectName, attribute.name, e);
                 throw e;
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
@@ -203,7 +203,7 @@ public final class JniPCConnector {
         }
         InputStream in = classLoader.getResourceAsStream(libraryToLoad);
         if (in == null) {
-            throw new RuntimeException(String.format("Failed to find '{}' in jar", libraryToLoad));
+            throw new RuntimeException("Failed to find '"+libraryToLoad+"' in jar");
         }
 
         OutputStream out = null;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JniPCConnector.java
@@ -112,11 +112,11 @@ public final class JniPCConnector {
         }
 
         if (logger.isTraceEnabled()) {
-            logger.trace("Registering performance counter: {}\\{} [{}]", category, counter, StringUtils.trimToEmpty(instance));
+            logger.trace("Registering performance counter: {} \\ {} [{}]", category, counter, StringUtils.trimToEmpty(instance));
         }
         final String s = addCounter(category, counter, instance);
         if (StringUtils.isEmpty(s) && logger.isWarnEnabled()) {
-            logger.warn("Performance coutner registration failed for {}\\{} [{}]", category, counter, StringUtils.trimToEmpty(instance));
+            logger.warn("Performance coutner registration failed for {} \\ {} [{}]", category, counter, StringUtils.trimToEmpty(instance));
         }
         return s;
     }
@@ -203,7 +203,7 @@ public final class JniPCConnector {
         }
         InputStream in = classLoader.getResourceAsStream(libraryToLoad);
         if (in == null) {
-            throw new RuntimeException(String.format("Failed to find '%s' in jar", libraryToLoad));
+            throw new RuntimeException(String.format("Failed to find '{}' in jar", libraryToLoad));
         }
 
         OutputStream out = null;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/PerformanceCounterContainer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/PerformanceCounterContainer.java
@@ -186,7 +186,7 @@ public enum PerformanceCounterContainer implements Stoppable {
      */
     void setStartCollectingDelayInMillis(long startCollectingDelayInMillis) {
         if (startCollectingDelayInMillis < START_DEFAULT_MIN_DELAY_IN_MILLIS) {
-            logger.error("Start Collecting Delay: illegal value '%d'. The minimum value, '%'d, is used instead.", startCollectingDelayInMillis, START_DEFAULT_MIN_DELAY_IN_MILLIS);
+            logger.error("Start Collecting Delay: illegal value '{}'. The minimum value, '{}', is used instead.", startCollectingDelayInMillis, START_DEFAULT_MIN_DELAY_IN_MILLIS);
 
             startCollectingDelayInMillis = START_DEFAULT_MIN_DELAY_IN_MILLIS;
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixProcessIOPerformanceCounter.java
@@ -108,15 +108,13 @@ final class UnixProcessIOPerformanceCounter extends AbstractUnixPerformanceCount
             result = parser.getValue();
         } catch (Exception e) {
             result = null;
-            logPerfCounterErrorError("Error while parsing file: '%s'", getId());
-            logPerfCounterErrorTrace("Error while parsing file: '%s'", getId(), e);
+            logPerfCounterErrorError("Error while parsing file: '{}'", getId(), e);
         } finally {
             if (bufferedReader != null ) {
                 try {
                     bufferedReader.close();
                 } catch (Exception e) {
-                    logPerfCounterErrorError("Error while closing file : '%s'", e.toString());
-                    logPerfCounterErrorTrace("Error while closing file", e);
+                    logPerfCounterErrorError("Error while closing file : '{}'", e);
                 }
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/UnixTotalCpuPerformanceCounter.java
@@ -102,15 +102,13 @@ final class UnixTotalCpuPerformanceCounter extends AbstractUnixPerformanceCounte
             bufferedReader = new BufferedReader(new FileReader(getProcessFile()));
             line = bufferedReader.readLine();
         } catch (Exception e) {
-            logPerfCounterErrorError("Error while parsing file: '%s'", e.toString());
-            logPerfCounterErrorTrace("Error while parsing file", e);
+            logPerfCounterErrorError("Error while parsing file: ", e);
         } finally {
             if (bufferedReader != null ) {
                 try {
                     bufferedReader.close();
                 } catch (Exception e) {
-                    logPerfCounterErrorError("Error while closing file : '%s'", e.toString());
-                    logPerfCounterErrorTrace("Error while closing file", e);
+                    logPerfCounterErrorError("Error while closing file: ", e);
                 }
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/LimitsEnforcer.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/LimitsEnforcer.java
@@ -1,7 +1,6 @@
 package com.microsoft.applicationinsights.internal.util;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +52,7 @@ public final class LimitsEnforcer {
         switch (type) {
             case DEFAULT_ON_ERROR:
                 if (value == null || value < minimum || value > maximum) {
-                    logger.warn("'{}': bad value is replaced by the default: '%d'", propertyName, defaultValue);
+                    logger.warn("'{}': bad value is replaced by the default: '{}'", propertyName, defaultValue);
                     currentValue = defaultValue;
                 } else {
                     currentValue = value;
@@ -63,20 +62,20 @@ public final class LimitsEnforcer {
             case CLOSEST_LIMIT_ON_ERROR:
                 if (value == null) {
                     currentValue = defaultValue;
-                    logger.info("'{}': null value is replaced with '%d'", propertyName, defaultValue);
+                    logger.info("'{}': null value is replaced with '{}'", propertyName, defaultValue);
                 } else if (value < minimum) {
                     currentValue = minimum;
-                    logger.warn("'{}': value is under the minimum, therefore is replaced with '%d'", propertyName, minimum);
+                    logger.warn("'{}': value is under the minimum, therefore is replaced with '{}'", propertyName, minimum);
                 } else if (value > maximum) {
                     currentValue = maximum;
-                    logger.warn("'{}': value is above the maximum, therefore is replaced with '%d'", propertyName, maximum);
+                    logger.warn("'{}': value is above the maximum, therefore is replaced with '{}'", propertyName, maximum);
                 } else {
                     currentValue = value;
                 }
                 break;
 
             default:
-                throw new IllegalStateException(String.format("Unknown type %s", type));
+                throw new IllegalStateException("Unknown type "+type);
         }
 
         return currentValue;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/PeriodicTaskPool.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/PeriodicTaskPool.java
@@ -107,15 +107,14 @@ public class PeriodicTaskPool implements Stoppable {
         }
 
         if (!periodicTaskMap.containsKey(task)) {
-            logger.error(String.format("No such Task {} running",task));
+            logger.error("No such Task {} running", task);
             return false;
         }
 
         ScheduledFuture<?> futureToCancel = periodicTaskMap.get(task);
 
         if (futureToCancel.isCancelled() || futureToCancel.isDone()) {
-            logger.info("Cannot cancel task {}, It is either completed or already cancelled",
-                    task);
+            logger.info("Cannot cancel task {}, It is either completed or already cancelled", task);
             return false;
         }
         periodicTaskMap.remove(task);

--- a/core/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/web/internal/correlation/CdsProfileFetcher.java
@@ -116,7 +116,7 @@ public class CdsProfileFetcher implements ApplicationIdResolver, Closeable {
 
         // check if we have tried resolving this ikey too many times. If so, quit to save on perf.
         if (failureCounters.containsKey(instrumentationKey) && failureCounters.get(instrumentationKey) >= retryPolicy.getMaxInstantRetries()) {
-            logger.info("The profile fetch task will not execute for next %d minutes. Max number of retries reached.", retryPolicy.getResetPeriodInMinutes());
+            logger.info("The profile fetch task will not execute for next {} minutes. Max number of retries reached.", retryPolicy.getResetPeriodInMinutes());
             return result;
         }
 

--- a/etw/README.md
+++ b/etw/README.md
@@ -23,17 +23,21 @@ The build should find the tools and Windows SDK, but if needed these environment
   * Location of Windows 10 SDK library folder (for linker requirements)
   * Default: `%APPINSIGHTS_WIN_SDK_PATH%/Lib/10.0.18362.0/um`
 
-## Build Tasks and Options
 
-TODO general build options
-
-### Native Build Tasks
+## Native Build Tasks
 To see full list of tasks, run `gradlew :etw:native:tasks --all`
 
 Native build tasks are of the form `<action><variant><architecture>`. For example, `compileDebugX86` or `linkReleaseX86-64`.
 
 There are only two variants: `Debug` and `Release`, and there are only two architectures: `X86` and `X86-64`.
 
+## Setting Variant for Project Assemble
+
+Use the project property (`-P` option) `ai.etw.native.build` set to the desired native build variant, `debug` or `release`. This property is automatically set to `release` when `-DisRelease=true` is used.
+
+## Enabling verbose logging
+
+The property `ai.etw.native.verbose` accepts a boolean value; when true, it enables verbose logging. This is done with preprocessor directives, so it must be rebuilt to enable. This slows execution time significantly under sufficient load. The build throws an error if this property is true for a relase build.
 
 * compile
   * Compiles the C++ sources.
@@ -45,8 +49,14 @@ There are only two variants: `Debug` and `Release`, and there are only two archi
   * Runs complier with `/P` option. Preprocesses C++ sources to a file. More info in docs: https://docs.microsoft.com/en-us/cpp/build/reference/p-preprocess-to-a-file
   * This can be run without specifying the architecture: `preprocessDebug` and `preprocessRelease` are both valid. This will run the preprocessor for each architecture listed above.
 
-# Tests
+# Unit Tests
 
 There is one test in java which checks that the DLL is extracted properly.
 
 There are two other tests which send 50k and 500k events to ETW. These are disabled if native verbose logging is enabled as it slows the execution time significantly.
+
+These can be disabled manually with the project property `ai.etw.tests.long.disabled` set to `true`.
+
+# The etw-testapp project
+
+This uses a special build of the agent, `applicationinsights-agent-codeless-<version>-devtest.jar`, which includes an additional class for accessing internal methods. These are used to trigger ETW events manually as well as run a load-type test of ETW events on a loop.

--- a/etw/java/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/events/model/IpaEtwEventBase.java
+++ b/etw/java/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/events/model/IpaEtwEventBase.java
@@ -93,14 +93,14 @@ public abstract class IpaEtwEventBase implements IpaEtwEvent {
     }
 
     protected String processMessageFormat() {
-        if (!StringUtils.isEmpty(this.logger)) {
+        if (StringUtils.isNotEmpty(this.logger)) {
             String prefix = "["+this.logger;
-            if (StringUtils.isEmpty(this.operation)) {
+            if (StringUtils.isNotEmpty(this.operation)) {
                 prefix += "/"+this.operation;
             }
             prefix += "] ";
             return prefix + messageFormat;
-        } else if(!StringUtils.isEmpty(this.operation)) {
+        } else if(StringUtils.isNotEmpty(this.operation)) {
             return "[-/"+this.operation+"] "+messageFormat;
         } else {
             return messageFormat;

--- a/etw/java/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/events/model/IpaEtwEventBase.java
+++ b/etw/java/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/events/model/IpaEtwEventBase.java
@@ -25,7 +25,6 @@ import org.apache.commons.lang3.StringUtils;
 public abstract class IpaEtwEventBase implements IpaEtwEvent {
     private String extensionVersion;
     private String appName;
-    private String resourceType;
     private String instrumentationKey;
     private String subscriptionId;
 
@@ -41,18 +40,8 @@ public abstract class IpaEtwEventBase implements IpaEtwEvent {
     public IpaEtwEventBase(IpaEtwEventBase event) {
         extensionVersion = event.extensionVersion;
         appName = event.appName;
-        resourceType = event.resourceType;
         instrumentationKey = event.instrumentationKey;
         subscriptionId = event.subscriptionId;
-
-        logger = event.logger;
-        messageFormat = event.messageFormat;
-        messageArgs = event.messageArgs;
-        operation = event.operation;
-    }
-
-    public String getLogger() {
-        return StringUtils.defaultString(logger);
     }
 
     public void setLogger(String logger) {
@@ -75,22 +64,6 @@ public abstract class IpaEtwEventBase implements IpaEtwEvent {
         this.appName = appName;
     }
 
-    public String getResourceType() {
-        return StringUtils.defaultString(resourceType);
-    }
-
-    public void setResourceType(String resourceType) {
-        this.resourceType = resourceType;
-    }
-
-    public String getInstrumentationKey() {
-        return StringUtils.defaultString(instrumentationKey);
-    }
-
-    public void setInstrumentationKey(String instrumentationKey) {
-        this.instrumentationKey = instrumentationKey;
-    }
-
     public String getSubscriptionId() {
         return StringUtils.defaultString(subscriptionId);
     }
@@ -108,15 +81,30 @@ public abstract class IpaEtwEventBase implements IpaEtwEvent {
     }
 
     public String getFormattedMessage() {
+        // operation
+        // logger
+        // exception (in error class)
+        final String fmt = processMessageFormat();
         if (messageArgs == null || messageArgs.length == 0) {
-            return StringUtils.defaultString(messageFormat);
+            return StringUtils.defaultString(fmt);
         } else {
-            return String.format(messageFormat, messageArgs);
+            return String.format(fmt, messageArgs);
         }
     }
 
-    public String getOperation() {
-        return StringUtils.defaultString(operation);
+    protected String processMessageFormat() {
+        if (!StringUtils.isEmpty(this.logger)) {
+            String prefix = "["+this.logger;
+            if (StringUtils.isEmpty(this.operation)) {
+                prefix += "/"+this.operation;
+            }
+            prefix += "] ";
+            return prefix + messageFormat;
+        } else if(!StringUtils.isEmpty(this.operation)) {
+            return "[-/"+this.operation+"] "+messageFormat;
+        } else {
+            return messageFormat;
+        }
     }
 
     public void setOperation(String operation) {

--- a/etw/java/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/events/model/IpaEtwEventErrorBase.java
+++ b/etw/java/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/events/model/IpaEtwEventErrorBase.java
@@ -20,6 +20,8 @@
  */
 package com.microsoft.applicationinsights.agent.bootstrap.diagnostics.etw.events.model;
 
+import org.apache.commons.lang3.StringUtils;
+
 public abstract class IpaEtwEventErrorBase extends IpaEtwEventBase {
     private String stacktrace;
 
@@ -34,11 +36,13 @@ public abstract class IpaEtwEventErrorBase extends IpaEtwEventBase {
         }
     }
 
-    public String getStacktraceString() {
-        if (stacktrace == null) {
-            return "";
+    @Override
+    protected String processMessageFormat() {
+        if (StringUtils.isEmpty(stacktrace)) {
+            return super.processMessageFormat();
+        } else {
+            return super.processMessageFormat() + "\n" + this.stacktrace;
         }
-        return stacktrace;
     }
 
     public void setStacktrace(String stacktrace) {

--- a/etw/java/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/EtwProviderTests.java
+++ b/etw/java/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/EtwProviderTests.java
@@ -64,7 +64,6 @@ public class EtwProviderTests {
         PROTOTYPE.setExtensionVersion("fake-version");
         PROTOTYPE.setInstrumentationKey(UUID.randomUUID().toString());
         PROTOTYPE.setSubscriptionId(UUID.randomUUID().toString());
-        PROTOTYPE.setResourceType("local-tests");
 
         String speriod = System.getProperty("ai.tests.etw.stats.period");
         long period = 2000; // default 2 seconds.

--- a/etw/java/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/EtwProviderTests.java
+++ b/etw/java/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/etw/EtwProviderTests.java
@@ -62,7 +62,6 @@ public class EtwProviderTests {
     static {
         PROTOTYPE.setAppName("EtwProvider-tests");
         PROTOTYPE.setExtensionVersion("fake-version");
-        PROTOTYPE.setInstrumentationKey(UUID.randomUUID().toString());
         PROTOTYPE.setSubscriptionId(UUID.randomUUID().toString());
 
         String speriod = System.getProperty("ai.tests.etw.stats.period");
@@ -134,20 +133,11 @@ public class EtwProviderTests {
         EtwProvider ep = new EtwProvider();
         ep.writeEvent(einfo);
         ep.writeEvent(eerror);
-        printStacktraceLength(eerror);
         ep.writeEvent(ewarn);
-        printStacktraceLength(ewarn);
         ep.writeEvent(ecritical);
-        printStacktraceLength(ecritical);
         IpaWarn otherWarn = createWarn("test.warn.logger2", "some-op", null, "another warning");
         otherWarn.setStacktrace("TEST STACKTRACE");
         ep.writeEvent(otherWarn);
-        printStacktraceLength(otherWarn);
-    }
-
-    private static void printStacktraceLength(IpaEtwEventErrorBase evt) {
-        System.out.println(">>>" + evt.id() + " event.stacktrace.length = "+evt.getStacktraceString().length());
-        System.err.println(">>> ST:" + evt.getStacktraceString());
     }
 
     private void longTestCheck() {

--- a/etw/native/src/main/cpp/etw_provider.cpp
+++ b/etw/native/src/main/cpp/etw_provider.cpp
@@ -101,66 +101,42 @@ int getEventId(JNIEnv * env, jobject &jobj_event) throw(aijnierr_t) {
     }
 }
 
-#define ETW_FIELD_LOGGER            "Logger"
 #define ETW_FIELD_MESSAGE           "msg"
 #define ETW_FIELD_EXTENSION_VERSION "ExtVer"
 #define ETW_FIELD_SUBSCRIPTION_ID   "SubscriptionId"
 #define ETW_FIELD_APPNAME           "AppName"
-#define ETW_FIELD_RESOURCE_TYPE     "ResourceType"
-#define ETW_FIELD_IKEY              "InstrumentationKey"
-#define ETW_FIELD_STACKTRACE        "Exception"
-#define ETW_FIELD_OPERATION         "Operation"
 
 
 void writeEvent_IpaEtwEvent(JNIEnv * env, jobject &jobj_event, int event_id) noexcept {
-    char * logger = NULL;
     char * message = NULL;
     char * extensionVersion = NULL;
     char * subscriptionId = NULL;
     char * appName = NULL;
-    char * resourceType = NULL;
-    char * ikey = NULL;
-    char * stackTrace = NULL;
-    char * operation = NULL;
     TraceLoggingRegister(provider_EtwHandle);
     try
     {
         // convert all jstrings
-        logger = stringGetter2cstr(env, jobj_event, "getLogger", logger, JSTRID_LOGGER);
         extensionVersion = stringGetter2cstr(env, jobj_event, "getExtensionVersion", extensionVersion, JSTRID_EXTENSION_VERSION);
         message = stringGetter2cstr(env, jobj_event, "getFormattedMessage", message, JSTRID_MESSAGE);
         subscriptionId = stringGetter2cstr(env, jobj_event, "getSubscriptionId", subscriptionId, JSTRID_SUBSCRIPTION_ID);
         appName = stringGetter2cstr(env, jobj_event, "getAppName", appName, JSTRID_APP_NAME);
-        resourceType = stringGetter2cstr(env, jobj_event, "getResourceType", resourceType, JSTRID_RESOURCE_TYPE);
-        ikey = stringGetter2cstr(env, jobj_event, "getInstrumentationKey", ikey, JSTRID_IKEY);
-        operation = stringGetter2cstr(env, jobj_event, "getOperation", operation, JSTRID_OPERATION);
 
         // write event
-        if (event_id == EVENTID_INFO) {
-            WRITE_INFO_EVENT(
-                TraceLoggingValue(message, ETW_FIELD_MESSAGE),
-                TraceLoggingValue(extensionVersion, ETW_FIELD_EXTENSION_VERSION),
-                TraceLoggingValue(subscriptionId, ETW_FIELD_SUBSCRIPTION_ID),
-                TraceLoggingValue(appName, ETW_FIELD_APPNAME),
-                TraceLoggingValue(resourceType, ETW_FIELD_RESOURCE_TYPE),
-                TraceLoggingValue(logger, ETW_FIELD_LOGGER),
-                TraceLoggingValue(ikey, ETW_FIELD_IKEY),
-                TraceLoggingValue(operation, ETW_FIELD_OPERATION));
-            DBG("\nwrote INFO");
-        } else { // all other event types could have Stacktrace data
-            stackTrace = stringGetter2cstr(env, jobj_event, "getStacktraceString", stackTrace, JSTRID_STACK_TRACE);
-            switch(event_id) {
+        switch(event_id) {
+            case EVENTID_INFO:
+                WRITE_INFO_EVENT(
+                    TraceLoggingValue(message, ETW_FIELD_MESSAGE),
+                    TraceLoggingValue(extensionVersion, ETW_FIELD_EXTENSION_VERSION),
+                    TraceLoggingValue(subscriptionId, ETW_FIELD_SUBSCRIPTION_ID),
+                    TraceLoggingValue(appName, ETW_FIELD_APPNAME));
+                DBG("\nwrote INFO");
+                break;
                 case EVENTID_WARN:
                     WRITE_WARN_EVENT(
                         TraceLoggingValue(message, ETW_FIELD_MESSAGE),
                         TraceLoggingValue(extensionVersion, ETW_FIELD_EXTENSION_VERSION),
                         TraceLoggingValue(subscriptionId, ETW_FIELD_SUBSCRIPTION_ID),
-                        TraceLoggingValue(appName, ETW_FIELD_APPNAME),
-                        TraceLoggingValue(resourceType, ETW_FIELD_RESOURCE_TYPE),
-                        TraceLoggingValue(logger, ETW_FIELD_LOGGER),
-                        TraceLoggingValue(ikey, ETW_FIELD_IKEY),
-                        TraceLoggingValue(operation, ETW_FIELD_OPERATION),
-                        TraceLoggingValue(stackTrace, ETW_FIELD_STACKTRACE));
+                        TraceLoggingValue(appName, ETW_FIELD_APPNAME));
                     DBG("\nwrote WARN");
                     break;
                 case EVENTID_ERROR:
@@ -168,12 +144,7 @@ void writeEvent_IpaEtwEvent(JNIEnv * env, jobject &jobj_event, int event_id) noe
                         TraceLoggingValue(message, ETW_FIELD_MESSAGE),
                         TraceLoggingValue(extensionVersion, ETW_FIELD_EXTENSION_VERSION),
                         TraceLoggingValue(subscriptionId, ETW_FIELD_SUBSCRIPTION_ID),
-                        TraceLoggingValue(appName, ETW_FIELD_APPNAME),
-                        TraceLoggingValue(resourceType, ETW_FIELD_RESOURCE_TYPE),
-                        TraceLoggingValue(logger, ETW_FIELD_LOGGER),
-                        TraceLoggingValue(ikey, ETW_FIELD_IKEY),
-                        TraceLoggingValue(operation, ETW_FIELD_OPERATION),
-                        TraceLoggingValue(stackTrace, ETW_FIELD_STACKTRACE));
+                        TraceLoggingValue(appName, ETW_FIELD_APPNAME));
                     DBG("\nwrote ERROR");
                     break;
                 case EVENTID_CRITICAL:
@@ -181,24 +152,11 @@ void writeEvent_IpaEtwEvent(JNIEnv * env, jobject &jobj_event, int event_id) noe
                         TraceLoggingValue(message, ETW_FIELD_MESSAGE),
                         TraceLoggingValue(extensionVersion, ETW_FIELD_EXTENSION_VERSION),
                         TraceLoggingValue(subscriptionId, ETW_FIELD_SUBSCRIPTION_ID),
-                        TraceLoggingValue(appName, ETW_FIELD_APPNAME),
-                        TraceLoggingValue(resourceType, ETW_FIELD_RESOURCE_TYPE),
-                        TraceLoggingValue(logger, ETW_FIELD_LOGGER),
-                        TraceLoggingValue(ikey, ETW_FIELD_IKEY),
-                        TraceLoggingValue(operation, ETW_FIELD_OPERATION),
-                        TraceLoggingValue(stackTrace, ETW_FIELD_STACKTRACE));
+                        TraceLoggingValue(appName, ETW_FIELD_APPNAME));
                     DBG("\nwrote CRITICAL");
                     break;
             }
-        }
-        DBG(" event:\n\tmsg=%s,\n\tExtVer=%s,\n\tSubscriptionId=%s,\n\tAppName=%s,\n\tResourceType=%s,\n\tLogger=%s\n\tIkey=%s\n\tOperation=%s\n", message, extensionVersion, subscriptionId, appName, resourceType, logger, ikey, operation);
-#if !defined(NDEBUG) && defined(AIETW_VERBOSE)
-        if (stackTrace != NULL) {
-            DBG("\tException=%s\n\n", stackTrace);
-        } else {
-            DBG("\n");
-        }
-#endif
+        DBG(" event:\n\tmsg=%s,\n\tExtVer=%s,\n\tSubscriptionId=%s,\n\tAppName=%s,\n", message, extensionVersion, subscriptionId, appName);
     }
     catch (aijnierr_t jnierr)
     {
@@ -215,11 +173,6 @@ void writeEvent_IpaEtwEvent(JNIEnv * env, jobject &jobj_event, int event_id) noe
     delete[] extensionVersion;
     delete[] subscriptionId;
     delete[] appName;
-    delete[] resourceType;
-    delete[] logger;
-    delete[] ikey;
-    delete[] stackTrace;
-    delete[] operation;
 }
 
 char * stringGetter2cstr(JNIEnv * env, jobject &jobj_target, const char * method_name, char * rval, aijnierr_t field_id) throw(aijnierr_t) {
@@ -282,20 +235,10 @@ std::string jstrid2name(int jnierr) noexcept {
             return ETW_FIELD_APPNAME;
         case JSTRID_EXTENSION_VERSION:
             return ETW_FIELD_EXTENSION_VERSION;
-        case JSTRID_LOGGER:
-            return ETW_FIELD_LOGGER;
         case JSTRID_MESSAGE:
             return ETW_FIELD_MESSAGE;
-        case JSTRID_RESOURCE_TYPE:
-            return ETW_FIELD_RESOURCE_TYPE;
-        case JSTRID_STACK_TRACE:
-            return ETW_FIELD_STACKTRACE;
         case JSTRID_SUBSCRIPTION_ID:
             return ETW_FIELD_SUBSCRIPTION_ID;
-        case JSTRID_IKEY:
-            return ETW_FIELD_IKEY;
-        case JSTRID_OPERATION:
-            return ETW_FIELD_OPERATION;
         default:
             return "unknown";
     }

--- a/etw/native/src/main/headers/etw_provider.h
+++ b/etw/native/src/main/headers/etw_provider.h
@@ -49,14 +49,9 @@ typedef int aijnierr_t;
 #define AIJNIERR_CLASS_NOT_FOUND    0x06
 
 #define JSTRID_MESSAGE              0x0100
-#define JSTRID_LOGGER               0x0200
-#define JSTRID_STACK_TRACE          0x0300
 #define JSTRID_EXTENSION_VERSION    0x0400
 #define JSTRID_SUBSCRIPTION_ID      0x0500
 #define JSTRID_APP_NAME             0x0600
-#define JSTRID_RESOURCE_TYPE        0x0700
-#define JSTRID_IKEY                 0x0800
-#define JSTRID_OPERATION            0x0900
 
 #define STR_MAX_BUFF_SIZE   1024000
 


### PR DESCRIPTION
The removes the fields _Logger_, _ResourceType_, _InstrumentationKey_, _Exception_ and _Operation_. 

I updated the message to this format: 
* `[logger/operation] message\n stacktrace`
* `[-/operation] message`
* `[logger] message`
* `[] message`
* `[]`
The variations shown illustrate what **msg** will look like if some variables are empty.

