### PR TITLE
Fix perf issue resolving FQDN for localhost

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/common/CommonUtils.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/common/CommonUtils.java
@@ -33,7 +33,7 @@ public class CommonUtils {
   }
 
   /**
-   * Returns the hostname using {@link InetAddress#getCanonicalHostName()} on {@link InetAddress#getLocalHost()}.
+   * Returns the hostname using {@link InetAddress#getHostName()} on {@link InetAddress#getLocalHost()}.
    * If an error is encountered, the error is logged and it returns null.
    *
    * @return the local hostname, or null
@@ -41,7 +41,7 @@ public class CommonUtils {
   public static String getHostName() {
     try {
       InetAddress addr = InetAddress.getLocalHost();
-      return addr.getCanonicalHostName();
+      return addr.getHostName();
     } catch (UnknownHostException ex) {
       InternalLogger.INSTANCE.warn("Error resolving hostname:%n%s", ExceptionUtils.getStackTrace(ex));
       return null;


### PR DESCRIPTION
`InetAddress.getCanonicalHostName()` looks up FQDN, which can be very slow on some systems.

This is already fixed in the 3.0 preview branch.