### PR TITLE
Retry transmission on client side exception

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ErrorHandler.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ErrorHandler.java
@@ -43,6 +43,7 @@ public class ErrorHandler implements TransmissionHandler {
             case TransmissionSendResult.REQUEST_TIMEOUT:
             case TransmissionSendResult.INTERNAL_SERVER_ERROR:
             case TransmissionSendResult.SERVICE_UNAVAILABLE:
+            case TransmissionSendResult.CLIENT_SIDE_EXCEPTION:
                 backoffAndSendTransmission(args);
                 return true;
             default:

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionSendResult.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionSendResult.java
@@ -32,4 +32,5 @@ final class TransmissionSendResult {
     public final static int THROTTLED_OVER_EXTENDED_TIME = 439;
     public final static int INTERNAL_SERVER_ERROR = 500;
     public final static int SERVICE_UNAVAILABLE = 503;
+    public final static int CLIENT_SIDE_EXCEPTION = 0;
 }


### PR DESCRIPTION
Fixes an issue where read timeout (and other networking related exceptions) are not retried, e.g.

```
AI: ERROR 09-07-2020 06:02:52.258+0000, 547(ActiveTransmissionNetworkOutput_1-4): Failed to send.
Stack Trace:
java.net.SocketTimeoutException: Read timed out
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
        at java.net.SocketInputStream.read(SocketInputStream.java:171)
        at java.net.SocketInputStream.read(SocketInputStream.java:141)
        at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
        at sun.security.ssl.InputRecord.read(InputRecord.java:503)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:975)
        at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:933)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:137)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:153)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:282)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:138)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:165)
        at com.microsoft.applicationinsights.core.dependencies.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
        at com.microsoft.applicationinsights.core.dependencies.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.execchain.RedirectExec.execute(RedirectExec.java:111)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
        at com.microsoft.applicationinsights.core.dependencies.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
        at com.microsoft.applicationinsights.internal.channel.common.ApacheSender43.sendPostRequest(ApacheSender43.java:82)
        at com.microsoft.applicationinsights.internal.channel.common.TransmissionNetworkOutput.send(TransmissionNetworkOutput.java:176)
        at com.microsoft.applicationinsights.internal.channel.common.ActiveTransmissionNetworkOutput$1.run(ActiveTransmissionNetworkOutput.java:79)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)

AI: TRACE 09-07-2020 06:02:52.259+0000, 547(ActiveTransmissionNetworkOutput_1-4): Http response code 0 not handled by com.microsoft.applicationinsights.internal.channel.common.ErrorHandler
AI: TRACE 09-07-2020 06:02:52.259+0000, 547(ActiveTransmissionNetworkOutput_1-4): Http response code 0 not handled by com.microsoft.applicationinsights.internal.channel.common.PartialSuccessHandler
AI: TRACE 09-07-2020 06:02:52.259+0000, 547(ActiveTransmissionNetworkOutput_1-4): Http response code 0 not handled by com.microsoft.applicationinsights.internal.channel.common.ThrottlingHandler.
```