### PR TITLE
Resolve NullPointer exception when running under test with MockMvc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# Version 2.6.2-BETA.3
+* Fixed NullPointer when testing with MockMvc ([#1281](https://github.com/microsoft/ApplicationInsights-Java/issues/1281))
+
 # Version 2.6.2-BETA.2
 * Fixed RequestTelemetryContext initialization ([#1247](https://github.com/microsoft/ApplicationInsights-Java/issues/1247)). Thanks, librucha!
 

--- a/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
+++ b/web/src/main/java/com/microsoft/applicationinsights/web/internal/WebRequestTrackingFilter.java
@@ -117,7 +117,7 @@ public final class WebRequestTrackingFilter implements Filter {
      * @throws ServletException Exception that can be thrown from invoking the filters chain.
      */
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
-        if (req instanceof  HttpServletRequest && res instanceof HttpServletResponse) {
+        if (handler != null && req instanceof  HttpServletRequest && res instanceof HttpServletResponse) {
             HttpServletRequest httpRequest = (HttpServletRequest) req;
             HttpServletResponse httpResponse = (HttpServletResponse) res;
             boolean hasAlreadyBeenFiltered = httpRequest.getAttribute(ALREADY_FILTERED) != null;


### PR DESCRIPTION
Fix #1281 by adding a simple null check in WebRquestTrackingFilter

If needed, here's a line for CHANGELOG.md (I don't know what version to tag it under. I'm happy to add this to my PR if I know where to put it):

* Fixed NullPointer when testing with MockMvc ([#](https://github.com/microsoft/ApplicationInsights-Java/issues/1281))


For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #
- [x] Changes in public surface reviewed (n/a)
- [x] CHANGELOG.md updated (see note above)

