### PR TITLE
Improve JMX performance counter

### DIFF
--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.microsoft.applicationinsights.agent.bootstrap.configuration.InstrumentationSettings.JmxMetric;
 import com.microsoft.applicationinsights.agent.bootstrap.configuration.InstrumentationSettings.PreviewConfiguration;
 import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.DiagnosticsHelper;
 import com.squareup.moshi.JsonAdapter;
@@ -63,6 +64,18 @@ public class ConfigurationBuilder {
         preview.roleName = overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_NAME, WEBSITE_SITE_NAME, preview.roleName);
         preview.roleInstance =
                 overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_INSTANCE, WEBSITE_INSTANCE_ID, preview.roleInstance);
+
+        JmxMetric threadCountJmxMetric = new JmxMetric();
+        threadCountJmxMetric.objectName = "java.lang:type=Threading";
+        threadCountJmxMetric.attribute = "threadCount";
+        threadCountJmxMetric.display = "Thread Count";
+        preview.jmxMetrics.add(threadCountJmxMetric);
+
+        JmxMetric classCountJmxMetric = new JmxMetric();
+        classCountJmxMetric.objectName = "java.lang:type=ClassLoading";
+        classCountJmxMetric.attribute = "LoadedClassCount";
+        classCountJmxMetric.display = "Loaded Class Count";
+        preview.jmxMetrics.add(classCountJmxMetric);
 
         return config;
     }

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -65,7 +65,7 @@ public class ConfigurationBuilder {
         preview.roleInstance =
                 overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_INSTANCE, WEBSITE_INSTANCE_ID, preview.roleInstance);
 
-        if (jmxMetricExisted(preview.jmxMetrics, "java.lang:type=Threading", "ThreadCount")) {
+        if (!jmxMetricExisted(preview.jmxMetrics, "java.lang:type=Threading", "ThreadCount")) {
             JmxMetric threadCountJmxMetric = new JmxMetric();
             threadCountJmxMetric.objectName = "java.lang:type=Threading";
             threadCountJmxMetric.attribute = "ThreadCount";
@@ -73,7 +73,7 @@ public class ConfigurationBuilder {
             preview.jmxMetrics.add(threadCountJmxMetric);
         }
 
-        if (jmxMetricExisted(preview.jmxMetrics, "java.lang:type=ClassLoading", "LoadedClassCount")) {
+        if (!jmxMetricExisted(preview.jmxMetrics, "java.lang:type=ClassLoading", "LoadedClassCount")) {
             JmxMetric classCountJmxMetric = new JmxMetric();
             classCountJmxMetric.objectName = "java.lang:type=ClassLoading";
             classCountJmxMetric.attribute = "LoadedClassCount";

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -67,8 +67,8 @@ public class ConfigurationBuilder {
 
         JmxMetric threadCountJmxMetric = new JmxMetric();
         threadCountJmxMetric.objectName = "java.lang:type=Threading";
-        threadCountJmxMetric.attribute = "threadCount";
-        threadCountJmxMetric.display = "Thread Count";
+        threadCountJmxMetric.attribute = "ThreadCount";
+        threadCountJmxMetric.display = "Current Thread Count";
         preview.jmxMetrics.add(threadCountJmxMetric);
 
         JmxMetric classCountJmxMetric = new JmxMetric();

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -86,7 +86,7 @@ public class ConfigurationBuilder {
 
     private static boolean jmxMetricExisted(List<InstrumentationSettings.JmxMetric> jmxMetrics, String objectName, String attribute) {
         for (JmxMetric metric : jmxMetrics) {
-            if (metric.objectName == objectName && metric.attribute == attribute) {
+            if (metric.objectName.equals(objectName) && metric.attribute.equals(attribute)) {
                 return true;
             }
         }

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -65,19 +65,32 @@ public class ConfigurationBuilder {
         preview.roleInstance =
                 overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_INSTANCE, WEBSITE_INSTANCE_ID, preview.roleInstance);
 
-        JmxMetric threadCountJmxMetric = new JmxMetric();
-        threadCountJmxMetric.objectName = "java.lang:type=Threading";
-        threadCountJmxMetric.attribute = "ThreadCount";
-        threadCountJmxMetric.display = "Current Thread Count";
-        preview.jmxMetrics.add(threadCountJmxMetric);
+        if (jmxMetricExisted(preview.jmxMetrics, "java.lang:type=Threading", "ThreadCount")) {
+            JmxMetric threadCountJmxMetric = new JmxMetric();
+            threadCountJmxMetric.objectName = "java.lang:type=Threading";
+            threadCountJmxMetric.attribute = "ThreadCount";
+            threadCountJmxMetric.display = "Current Thread Count";
+            preview.jmxMetrics.add(threadCountJmxMetric);
+        }
 
-        JmxMetric classCountJmxMetric = new JmxMetric();
-        classCountJmxMetric.objectName = "java.lang:type=ClassLoading";
-        classCountJmxMetric.attribute = "LoadedClassCount";
-        classCountJmxMetric.display = "Loaded Class Count";
-        preview.jmxMetrics.add(classCountJmxMetric);
+        if (jmxMetricExisted(preview.jmxMetrics, "java.lang:type=ClassLoading", "LoadedClassCount")) {
+            JmxMetric classCountJmxMetric = new JmxMetric();
+            classCountJmxMetric.objectName = "java.lang:type=ClassLoading";
+            classCountJmxMetric.attribute = "LoadedClassCount";
+            classCountJmxMetric.display = "Loaded Class Count";
+            preview.jmxMetrics.add(classCountJmxMetric);
+        }
 
         return config;
+    }
+
+    private static boolean jmxMetricExisted(List<InstrumentationSettings.JmxMetric> jmxMetrics, String objectName, String attribute) {
+        for (JmxMetric metric : jmxMetrics) {
+            if (metric.objectName == objectName && metric.attribute == attribute) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Configuration loadConfigurationFile(Path agentJarPath) throws IOException {

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/InstrumentationSettings.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/InstrumentationSettings.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.agent.bootstrap.configuration;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class InstrumentationSettings {
         public HttpProxy httpProxy = new HttpProxy();
         public boolean developerMode;
 
-        public List<JmxMetric> jmxMetrics = Collections.emptyList();
+        public List<JmxMetric> jmxMetrics = new ArrayList<>();
 
         public Map<String, Map<String, Object>> instrumentation = Collections.emptyMap();
     }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/jmx/JmxDataFetcher.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/jmx/JmxDataFetcher.java
@@ -73,7 +73,7 @@ public class JmxDataFetcher {
                 Collection<Object> resultForAttribute = fetch(server, objects, attribute.name);
                 result.put(attribute.displayName, resultForAttribute);
             } catch (Exception e) {
-                logger.error("Failed to fetch JMX object '{}' with attribute '{}': ", objectName, attribute.name, e);
+                logger.warn("Failed to fetch JMX object '{}' with attribute '{}': ", objectName, attribute.name);
                 throw e;
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.jmx.JmxAttributeData;
 import com.microsoft.applicationinsights.internal.jmx.JmxDataFetcher;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,11 @@ public abstract class AbstractJmxPerformanceCounter implements PerformanceCounte
                 double value = 0.0;
                 for (Object obj : displayAndValues.getValue()) {
                     try {
-                        value += Double.parseDouble(String.valueOf(obj));
+                        if (obj instanceof Boolean) {
+                            value = ((Boolean) obj).booleanValue() ? 1 : 0;
+                        } else {
+                            value += Double.parseDouble(String.valueOf(obj));
+                        }
                     } catch (Exception e) {
                         ok = false;
                         break;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
@@ -84,8 +84,8 @@ public abstract class AbstractJmxPerformanceCounter implements PerformanceCounte
             }
         } catch (Exception e) {
             if (!alreadyLogged) {
-                logger.error("Error while fetching JMX data: '{}', The PC will be ignored", e.toString());
-                logger.trace("Error while fetching JMX data, The PC will be ignored", e);
+                logger.error("Error while fetching JMX data: '{}'", e.toString());
+                logger.trace("Error while fetching JMX data", e);
                 alreadyLogged = true;
             }
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/AbstractJmxPerformanceCounter.java
@@ -43,8 +43,7 @@ public abstract class AbstractJmxPerformanceCounter implements PerformanceCounte
     private final String id;
     private final String objectName;
     private final Collection<JmxAttributeData> attributes;
-    private boolean relevant = true;
-    private boolean firstTime = true;
+    private boolean alreadyLogged = false;
 
     @Override
     public String getId() {
@@ -58,10 +57,6 @@ public abstract class AbstractJmxPerformanceCounter implements PerformanceCounte
      */
     @Override
     public synchronized void report(TelemetryClient telemetryClient) {
-        if (!relevant) {
-            return;
-        }
-
         try {
             Map<String, Collection<Object>> result =
                     JmxDataFetcher.fetch(objectName, attributes);
@@ -88,16 +83,11 @@ public abstract class AbstractJmxPerformanceCounter implements PerformanceCounte
                 }
             }
         } catch (Exception e) {
-            if (firstTime) {
+            if (!alreadyLogged) {
                 logger.error("Error while fetching JMX data: '{}', The PC will be ignored", e.toString());
                 logger.trace("Error while fetching JMX data, The PC will be ignored", e);
-                relevant = false;
-            } else {
-                logger.error("Error while fetching JMX data: '{}'", e.toString());
-                logger.trace("Error while fetching JMX data", e);
+                alreadyLogged = true;
             }
-        } finally {
-            firstTime = false;
         }
     }
 


### PR DESCRIPTION
Fix [#8242793](https://msazure.visualstudio.com/One/_boards/board/t/Azure%20Attach%20(Java%20NET)/Features/?workitem=8242793), [#8087964](https://msazure.visualstudio.com/One/_boards/board/t/Azure%20Attach%20(Java%20NET)/Features/?workitem=8087964), [#7965248](https://msazure.visualstudio.com/One/_boards/board/t/Azure%20Attach%20(Java%20NET)/Features/?workitem=7965248)

boolean JMX counter will look like the following in Application Insights:
![image](https://user-images.githubusercontent.com/56097766/92842534-862e9600-f398-11ea-85f5-a16d86775da5.png)

Testing was done manually using the spring-petclinic application.