### PR TITLE
SimpleHttpChannel has been deleted

### DIFF
--- a/core/spotbugs.exclude.xml
+++ b/core/spotbugs.exclude.xml
@@ -203,15 +203,6 @@
         <Field name="proxy" />
     </Match>
     <Match><!-- False Positive from new try-with-resources bytecode in Java 11: https://github.com/spotbugs/spotbugs/issues/756 -->
-        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
-        <Class name="com.microsoft.applicationinsights.internal.channel.simplehttp.SimpleHttpChannel" />
-        <Method name="send" />
-        <Or>
-            <Local name="httpClient" />
-            <Local name="response" />
-        </Or>
-    </Match>
-    <Match><!-- False Positive from new try-with-resources bytecode in Java 11: https://github.com/spotbugs/spotbugs/issues/756 -->
         <Or>
             <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE" />
             <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />


### PR DESCRIPTION
Remove the SimpleHttpChannel from the Spotbug exclusions since it doesn't exists anymore :)