### PR TITLE
Use span name directly for telemetry name

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/FixedRateSampler.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/FixedRateSampler.java
@@ -17,7 +17,7 @@ public final class FixedRateSampler implements Sampler {
 
     private static final Logger logger = LoggerFactory.getLogger(FixedRateSampler.class);
 
-    private static final AttributeKey<Double> AI_SAMPLING_PERCENTAGE = AttributeKey.doubleKey("ai.sampling.percentage");
+    private static final AttributeKey<Double> AI_SAMPLING_PERCENTAGE = AttributeKey.doubleKey("ai.internal.sampling.percentage");
 
     // all sampling percentage must be in a ratio of 100/N where N is a whole number (2, 3, 4, …)
     // e.g. 50 for 1/2 or 33.33 for 1/3

--- a/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
+++ b/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
@@ -69,7 +69,7 @@ public class Exporter implements SpanExporter {
 
     private static final Joiner JOINER = Joiner.on(", ");
 
-    private static final AttributeKey<Double> AI_SAMPLING_PERCENTAGE = AttributeKey.doubleKey("ai.sampling.percentage");
+    private static final AttributeKey<Double> AI_SAMPLING_PERCENTAGE = AttributeKey.doubleKey("ai.internal.sampling.percentage");
 
     private static final AttributeKey<Boolean> AI_INTERNAL_LOG = AttributeKey.booleanKey("ai.internal.log");
 

--- a/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
+++ b/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
@@ -20,8 +20,6 @@
  */
 package com.microsoft.applicationinsights.agent;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -166,11 +164,7 @@ public class Exporter implements SpanExporter {
             telemetry.setUrl(httpUrl);
         }
 
-        String httpMethod = removeAttributeString(attributes, SemanticAttributes.HTTP_METHOD);
         String name = span.getName();
-        if (httpMethod != null && name.startsWith("/")) {
-            name = httpMethod + " " + name;
-        }
         telemetry.setName(name);
         telemetry.getContext().getOperation().setName(name);
 
@@ -240,10 +234,6 @@ public class Exporter implements SpanExporter {
         telemetry.setDuration(new Duration(NANOSECONDS.toMillis(span.getEndEpochNanos() - span.getStartEpochNanos())));
 
         telemetry.setSuccess(span.getStatus().isOk());
-        String description = span.getStatus().getDescription();
-        if (description != null) {
-            telemetry.getProperties().put("statusDescription", description);
-        }
 
         Double samplingPercentage = removeAiSamplingPercentage(attributes);
 
@@ -255,17 +245,17 @@ public class Exporter implements SpanExporter {
     private void applySemanticConventions(Map<AttributeKey<?>, Object> attributes, RemoteDependencyTelemetry telemetry) {
         String httpMethod = removeAttributeString(attributes, SemanticAttributes.HTTP_METHOD);
         if (httpMethod != null) {
-            applyHttpRequestSpan(attributes, telemetry, httpMethod);
+            applyHttpClientSpan(attributes, telemetry, httpMethod);
             return;
         }
         String rpcSystem = removeAttributeString(attributes, SemanticAttributes.RPC_SYSTEM);
         if (rpcSystem != null) {
-            applyRpcRequestSpan(attributes, telemetry, rpcSystem);
+            applyRpcClientSpan(attributes, telemetry, rpcSystem);
             return;
         }
         String dbSystem = removeAttributeString(attributes, SemanticAttributes.DB_SYSTEM);
         if (dbSystem != null) {
-            applyDatabaseQuerySpan(attributes, telemetry, dbSystem);
+            applyDatabaseClientSpan(attributes, telemetry, dbSystem);
             return;
         }
         String messagingSystem = removeAttributeString(attributes, SemanticAttributes.MESSAGING_SYSTEM);
@@ -336,7 +326,8 @@ public class Exporter implements SpanExporter {
             telemetry.getContext().getOperation().setParentId(parentSpanId);
         }
 
-        setProperties(telemetry.getProperties(), timeEpochNanos, level, loggerName, attributes);
+        setProperties(telemetry.getProperties(), level, loggerName, attributes);
+        telemetry.setTimestamp(new Date(NANOSECONDS.toMillis(timeEpochNanos)));
         track(telemetry, samplingPercentage);
     }
 
@@ -344,6 +335,8 @@ public class Exporter implements SpanExporter {
                                        String errorStack, String traceId, String parentSpanId,
                                        Double samplingPercentage, Map<AttributeKey<?>, Object> attributes) {
         ExceptionTelemetry telemetry = new ExceptionTelemetry();
+
+        telemetry.setTimestamp(new Date());
 
         if (SpanId.isValid(parentSpanId)) {
             telemetry.getContext().getOperation().setId(traceId);
@@ -353,7 +346,8 @@ public class Exporter implements SpanExporter {
         telemetry.getData().setExceptions(Exceptions.minimalParse(errorStack));
         telemetry.setSeverityLevel(toSeverityLevel(level));
         telemetry.getProperties().put("Logger Message", message);
-        setProperties(telemetry.getProperties(), timeEpochNanos, level, loggerName, attributes);
+        setProperties(telemetry.getProperties(), level, loggerName, attributes);
+        telemetry.setTimestamp(new Date(NANOSECONDS.toMillis(timeEpochNanos)));
         track(telemetry, samplingPercentage);
     }
 
@@ -384,7 +378,7 @@ public class Exporter implements SpanExporter {
         return CompletableResultCode.ofSuccess();
     }
 
-    private static void setProperties(Map<String, String> properties, long timeEpochNanos, String level, String loggerName, Map<AttributeKey<?>, Object> attributes) {
+    private static void setProperties(Map<String, String> properties, String level, String loggerName, Map<AttributeKey<?>, Object> attributes) {
         if (level != null) {
             properties.put("SourceType", "Logger");
             properties.put("LoggingLevel", level);
@@ -402,12 +396,7 @@ public class Exporter implements SpanExporter {
         }
     }
 
-    private static void applyHttpRequestSpan(Map<AttributeKey<?>, Object> attributes, RemoteDependencyTelemetry telemetry, String httpMethod) {
-
-        Object httpStatusCode = attributes.remove(SemanticAttributes.HTTP_STATUS_CODE);
-        if (httpStatusCode instanceof Long) {
-            telemetry.setResultCode(Long.toString((Long) httpStatusCode));
-        }
+    private static void applyHttpClientSpan(Map<AttributeKey<?>, Object> attributes, RemoteDependencyTelemetry telemetry, String httpMethod) {
 
         String target = removeAttributeString(attributes, SemanticAttributes.PEER_SERVICE);
         if (target == null) {
@@ -422,7 +411,7 @@ public class Exporter implements SpanExporter {
         }
         String targetAppId = removeAttributeString(attributes, SPAN_TARGET_ATTRIBUTE_NAME);
         if (targetAppId == null || AiAppId.getAppId().equals(targetAppId)) {
-            telemetry.setType("HTTP");
+            telemetry.setType("Http");
             telemetry.setTarget(target);
         } else {
             // using "Http (tracked component)" is important for dependencies that go cross-component (have an appId in their target field)
@@ -431,25 +420,16 @@ public class Exporter implements SpanExporter {
             telemetry.setTarget(target + " | " + targetAppId);
         }
 
-        String url = removeAttributeString(attributes, SemanticAttributes.HTTP_URL);
-        if (url != null) {
-            try {
-                URI uriObject = new URI(url);
-                // TODO is this right, overwriting name to include the full path?
-                String path = uriObject.getPath();
-                if (Strings.isNullOrEmpty(path)) {
-                    telemetry.setName(httpMethod + " /");
-                } else {
-                    telemetry.setName(httpMethod + " " + path);
-                }
-            } catch (URISyntaxException e) {
-                logger.error(e.getMessage());
-                logger.debug(e.getMessage(), e);
-            }
+        Object httpStatusCode = attributes.remove(SemanticAttributes.HTTP_STATUS_CODE);
+        if (httpStatusCode instanceof Long) {
+            telemetry.setResultCode(Long.toString((Long) httpStatusCode));
         }
+
+        String url = removeAttributeString(attributes, SemanticAttributes.HTTP_URL);
+        telemetry.setCommandName(url);
     }
 
-    private static void applyRpcRequestSpan(Map<AttributeKey<?>, Object> attributes, RemoteDependencyTelemetry telemetry, String rpcSystem) {
+    private static void applyRpcClientSpan(Map<AttributeKey<?>, Object> attributes, RemoteDependencyTelemetry telemetry, String rpcSystem) {
         telemetry.setType(rpcSystem);
         // TODO is this too fine-grained (e.g. many grpc service name = class name)
         //  maybe better to use net.peer like in http but those are not implemented for grpc client spans yet
@@ -462,7 +442,7 @@ public class Exporter implements SpanExporter {
 
     private static final Set<String> SQL_DB_SYSTEMS = ImmutableSet.of("db2", "derby", "mariadb", "mssql", "mysql", "oracle", "postgresql", "sqlite", "other_sql", "hsqldb", "h2");
 
-    private static void applyDatabaseQuerySpan(Map<AttributeKey<?>, Object> attributes, RemoteDependencyTelemetry telemetry, String dbSystem) {
+    private static void applyDatabaseClientSpan(Map<AttributeKey<?>, Object> attributes, RemoteDependencyTelemetry telemetry, String dbSystem) {
         String type;
         if (SQL_DB_SYSTEMS.contains(dbSystem)) {
             type = "SQL";

--- a/test/smoke/testApps/HttpClients/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/HttpClientSmokeTest.java
+++ b/test/smoke/testApps/HttpClients/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/HttpClientSmokeTest.java
@@ -31,9 +31,10 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com/search?q=spaces%20test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
@@ -52,9 +53,10 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com/search?q=spaces%20test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
@@ -73,9 +75,10 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com/search?q=spaces%20test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
@@ -94,9 +97,10 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com/search?q=spaces%20test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
@@ -115,9 +119,10 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com/search?q=spaces%20test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
@@ -137,9 +142,10 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com/search?q=spaces%20test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
@@ -158,9 +164,10 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com/search?q=spaces%20test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 
@@ -179,9 +186,11 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("HTTP", rdd.getType());
+        assertEquals("Http", rdd.getType());
         assertEquals("www.bing.com", rdd.getTarget());
-        assertEquals("GET /search", rdd.getName());
+        assertEquals("HTTP GET", rdd.getName());
+        // TODO investigate why %2520 is captured instead of %20
+        assertEquals("https://www.bing.com/search?q=spaces%2520test", rdd.getData());
         assertParentChild(rd, rdEnvelope, rddEnvelope);
     }
 

--- a/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsTest.java
+++ b/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsTest.java
@@ -34,7 +34,7 @@ public class JmsTest extends AiSmokeTest {
         RemoteDependencyData rdd2 =
                 (RemoteDependencyData) ((Data) rddEnvelope2.getData()).getBaseData();
 
-        assertEquals("GET /sendMessage", rd1.getName());
+        assertEquals("/sendMessage", rd1.getName());
         assertEquals("HelloController.sendMessage", rdd2.getName());
 
         assertEquals("Queue Message | jms", rdd1.getType());

--- a/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
+++ b/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
@@ -37,14 +37,14 @@ public class KafkaTest extends AiSmokeTest {
     public void doMostBasicTest() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 2);
 
-        Envelope rdEnvelope1 = getRequestEnvelope(rdList, "GET /sendMessage");
+        Envelope rdEnvelope1 = getRequestEnvelope(rdList, "/sendMessage");
         String operationId = rdEnvelope1.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 3, operationId);
 
         Envelope rdEnvelope2 = getRequestEnvelope(rdList, "mytopic process");
         Envelope rddEnvelope1 = getDependencyEnvelope(rddList, "HelloController.sendMessage");
         Envelope rddEnvelope2 = getDependencyEnvelope(rddList, "mytopic send");
-        Envelope rddEnvelope3 = getDependencyEnvelope(rddList, "GET /");
+        Envelope rddEnvelope3 = getDependencyEnvelope(rddList, "/");
 
         RequestData rd1 = (RequestData) ((Data) rdEnvelope1.getData()).getBaseData();
         RequestData rd2 = (RequestData) ((Data) rdEnvelope2.getData()).getBaseData();
@@ -53,7 +53,7 @@ public class KafkaTest extends AiSmokeTest {
         RemoteDependencyData rdd2 = (RemoteDependencyData) ((Data) rddEnvelope2.getData()).getBaseData();
         RemoteDependencyData rdd3 = (RemoteDependencyData) ((Data) rddEnvelope3.getData()).getBaseData();
 
-        assertEquals("GET /sendMessage", rd1.getName());
+        assertEquals("/sendMessage", rd1.getName());
         assertEquals("HelloController.sendMessage", rdd1.getName());
 
         assertEquals("Queue Message | kafka", rdd2.getType());
@@ -63,7 +63,7 @@ public class KafkaTest extends AiSmokeTest {
         assertEquals("mytopic", rd2.getSource());
         assertEquals("mytopic process", rd2.getName());
 
-        assertEquals("GET /", rdd3.getName());
+        assertEquals("/", rdd3.getName());
 
         assertParentChild(rdd1.getId(), rdEnvelope1, rddEnvelope2);
         assertParentChild(rdd2.getId(), rddEnvelope1, rdEnvelope2);

--- a/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
+++ b/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
@@ -44,7 +44,7 @@ public class KafkaTest extends AiSmokeTest {
         Envelope rdEnvelope2 = getRequestEnvelope(rdList, "mytopic process");
         Envelope rddEnvelope1 = getDependencyEnvelope(rddList, "HelloController.sendMessage");
         Envelope rddEnvelope2 = getDependencyEnvelope(rddList, "mytopic send");
-        Envelope rddEnvelope3 = getDependencyEnvelope(rddList, "/");
+        Envelope rddEnvelope3 = getDependencyEnvelope(rddList, "HTTP GET");
 
         RequestData rd1 = (RequestData) ((Data) rdEnvelope1.getData()).getBaseData();
         RequestData rd2 = (RequestData) ((Data) rdEnvelope2.getData()).getBaseData();
@@ -63,7 +63,8 @@ public class KafkaTest extends AiSmokeTest {
         assertEquals("mytopic", rd2.getSource());
         assertEquals("mytopic process", rd2.getName());
 
-        assertEquals("/", rdd3.getName());
+        assertEquals("HTTP GET", rdd3.getName());
+        assertEquals("https://www.bing.com", rdd3.getData());
 
         assertParentChild(rdd1.getId(), rdEnvelope1, rddEnvelope2);
         assertParentChild(rdd2.getId(), rddEnvelope1, rdEnvelope2);

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -137,7 +137,8 @@ public class SpringbootSmokeTest extends AiSmokeTest {
 
         assertEquals("/asyncDependencyCall", rd.getName());
         assertEquals("TestController.asyncDependencyCall", rdd1.getName());
-        assertEquals("/", rdd2.getName());
+        assertEquals("HTTP GET", rdd2.getName());
+        assertEquals("https://www.bing.com", rdd2.getData());
         assertEquals("TestController.asyncDependencyCall", rdd3.getName());
         assertEquals("www.bing.com", rdd2.getTarget());
 

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -135,9 +135,9 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd3 =
                 (RemoteDependencyData) ((Data) rddEnvelope3.getData()).getBaseData();
 
-        assertEquals("GET /asyncDependencyCall", rd.getName());
+        assertEquals("/asyncDependencyCall", rd.getName());
         assertEquals("TestController.asyncDependencyCall", rdd1.getName());
-        assertEquals("GET /", rdd2.getName());
+        assertEquals("/", rdd2.getName());
         assertEquals("TestController.asyncDependencyCall", rdd3.getName());
         assertEquals("www.bing.com", rdd2.getTarget());
 

--- a/test/smoke/testApps/SpringCloudStream/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringCloudStreamTest.java
+++ b/test/smoke/testApps/SpringCloudStream/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringCloudStreamTest.java
@@ -49,7 +49,7 @@ public class SpringCloudStreamTest extends AiSmokeTest {
         RemoteDependencyData rdd1 = (RemoteDependencyData) ((Data) rddEnvelope1.getData()).getBaseData();
         RemoteDependencyData rdd2 = (RemoteDependencyData) ((Data) rddEnvelope2.getData()).getBaseData();
 
-        assertEquals("GET /sendMessage", rd1.getName());
+        assertEquals("/sendMessage", rd1.getName());
         assertEquals("GreetingsController.sendMessage", rdd1.getName());
 
         assertEquals("Queue Message | kafka", rdd2.getType());

--- a/test/smoke/testApps/WebFlux/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebFluxTest.java
+++ b/test/smoke/testApps/WebFlux/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebFluxTest.java
@@ -23,7 +23,7 @@ public class WebFluxTest extends AiSmokeTest {
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
         assertTrue(rd.getSuccess());
-        assertEquals("GET /test/**", rd.getName());
+        assertEquals("/test/**", rd.getName());
         assertEquals("200", rd.getResponseCode());
     }
 

--- a/test/smoke/testApps/gRPC/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/GrpcTest.java
+++ b/test/smoke/testApps/gRPC/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/GrpcTest.java
@@ -19,7 +19,7 @@ public class GrpcTest extends AiSmokeTest {
     public void doSimpleTest() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 2);
 
-        Envelope rdEnvelope1 = getRequestEnvelope(rdList, "GET /simple");
+        Envelope rdEnvelope1 = getRequestEnvelope(rdList, "/simple");
         Envelope rdEnvelope2 = getRequestEnvelope(rdList, "example.Greeter/SayHello");
         String operationId = rdEnvelope1.getTags().get("ai.operation.id");
 
@@ -46,7 +46,7 @@ public class GrpcTest extends AiSmokeTest {
     public void doConversationTest() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 2);
 
-        Envelope rdEnvelope1 = getRequestEnvelope(rdList, "GET /conversation");
+        Envelope rdEnvelope1 = getRequestEnvelope(rdList, "/conversation");
         Envelope rdEnvelope2 = getRequestEnvelope(rdList, "example.Greeter/Conversation");
         String operationId = rdEnvelope1.getTags().get("ai.operation.id");
 


### PR DESCRIPTION
Users will be able to use config-based telemetry processors to bring back old names if really desired.