### PR TITLE
Send JMX metrics to CustomMetrics instead of PerformanceCounter

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxMetricPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/JmxMetricPerformanceCounter.java
@@ -29,6 +29,8 @@ import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.microsoft.applicationinsights.internal.perfcounter.Constants.TOTAL_MEMORY_PC_COUNTER_NAME;
+
 /**
  * A performance counter that sends {@link com.microsoft.applicationinsights.telemetry.MetricTelemetry}
  *
@@ -46,11 +48,15 @@ public final class JmxMetricPerformanceCounter extends AbstractJmxPerformanceCou
     protected void send(TelemetryClient telemetryClient, String displayName, double value) {
         logger.trace("Metric JMX: {}, {}", displayName, value);
 
-    MetricTelemetry telemetry = new MetricTelemetry();
-    telemetry.markAsCustomPerfCounter();
+        MetricTelemetry telemetry = new MetricTelemetry();
         telemetry.setName(displayName);
         telemetry.setValue(value);
-        telemetry.getProperties().put("CustomPerfCounter", "true");
+
+        // keep "Available Bytes" under PerformanceCounter to prevent breaking performance blade on the ApplicationInsights Portal
+        if (displayName.equals(TOTAL_MEMORY_PC_COUNTER_NAME)) {
+            telemetry.markAsCustomPerfCounter();
+        }
+
         telemetryClient.track(telemetry);
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessMemoryPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/ProcessMemoryPerformanceCounter.java
@@ -27,10 +27,13 @@ import java.lang.management.MemoryUsage;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.internal.system.SystemInformation;
+import com.microsoft.applicationinsights.telemetry.MetricTelemetry;
 import com.microsoft.applicationinsights.telemetry.PerformanceCounterTelemetry;
 import com.microsoft.applicationinsights.telemetry.Telemetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.microsoft.applicationinsights.internal.perfcounter.Constants.PROCESS_MEM_PC_COUNTER_NAME;
 
 /**
  * The class supplies the memory usage in Mega Bytes of the Java process the SDK is in.
@@ -59,13 +62,8 @@ final class ProcessMemoryPerformanceCounter extends AbstractPerformanceCounter {
         double memoryBytes = (double)heapMemoryUsage.getUsed();
         memoryBytes += (double)nonHeapMemoryUsage.getUsed();
 
-        logger.trace("Performance Counter: {} {}: {}", getProcessCategoryName(), Constants.PROCESS_MEM_PC_COUNTER_NAME, memoryBytes);
-        Telemetry telemetry = new PerformanceCounterTelemetry(
-                getProcessCategoryName(),
-                Constants.PROCESS_MEM_PC_COUNTER_NAME,
-                SystemInformation.INSTANCE.getProcessId(),
-                memoryBytes);
-
-        telemetryClient.track(telemetry);
+        logger.trace("Performance Counter: {} {}: {}", getProcessCategoryName(), PROCESS_MEM_PC_COUNTER_NAME, memoryBytes);
+        MetricTelemetry metricTelemetry = new MetricTelemetry(PROCESS_MEM_PC_COUNTER_NAME, memoryBytes);
+        telemetryClient.track(metricTelemetry);
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/DeadLockDetectorPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/DeadLockDetectorPerformanceCounter.java
@@ -75,7 +75,6 @@ public final class DeadLockDetectorPerformanceCounter implements PerformanceCoun
     @Override
     public void report(TelemetryClient telemetryClient) {
         MetricTelemetry mt = new MetricTelemetry(METRIC_NAME, 0.0);
-        mt.markAsCustomPerfCounter();
 
         long[] threadIds = threadBean.findDeadlockedThreads();
         if (threadIds != null && threadIds.length > 0) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/GCPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/GCPerformanceCounter.java
@@ -78,10 +78,6 @@ public final class GCPerformanceCounter implements PerformanceCounter {
 
             MetricTelemetry mtTotalCount = new MetricTelemetry(GC_TOTAL_COUNT, countToReport);
             MetricTelemetry mtTotalTime = new MetricTelemetry(GC_TOTAL_TIME, timeToReport);
-
-            mtTotalCount.markAsCustomPerfCounter();
-            mtTotalTime.markAsCustomPerfCounter();
-
             telemetryClient.track(mtTotalCount);
             telemetryClient.track(mtTotalTime);
         }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/JvmHeapMemoryUsedPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/jvm/JvmHeapMemoryUsedPerformanceCounter.java
@@ -67,7 +67,6 @@ public class JvmHeapMemoryUsedPerformanceCounter implements PerformanceCounter {
         if (mhu != null) {
             long currentHeapUsed = mhu.getUsed() / Megabyte;
             MetricTelemetry memoryHeapUsage = new MetricTelemetry(HEAP_MEM_USED, currentHeapUsed);
-            memoryHeapUsage.markAsCustomPerfCounter();
             telemetryClient.track(memoryHeapUsage);
         }
     }

--- a/test/smoke/testApps/AutoPerfCounters/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/PerfCountersDataTest.java
+++ b/test/smoke/testApps/AutoPerfCounters/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/PerfCountersDataTest.java
@@ -3,6 +3,7 @@ package com.microsoft.applicationinsights.smoketest;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.microsoft.applicationinsights.internal.schemav2.Base;
+import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.DataPoint;
 import com.microsoft.applicationinsights.internal.schemav2.DataPointType;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
@@ -40,7 +41,7 @@ public class PerfCountersDataTest extends AiSmokeTest {
         Envelope totalCpu = mockedIngestion.waitForItem(getPerfCounterPredicate("Processor", "% Processor Time", "_Total"), 150, TimeUnit.SECONDS);
 
         Envelope processIo = mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "IO Data Bytes/sec"), 150, TimeUnit.SECONDS);
-        Envelope processMemUsed = mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "Private Bytes"), 150, TimeUnit.SECONDS);
+        Envelope processMemUsed = mockedIngestion.waitForItem(getPerfMetricPredicate("Private Bytes"), 150, TimeUnit.SECONDS);
         Envelope processCpu = mockedIngestion.waitForItem(getPerfCounterPredicate("Process", "% Processor Time"), 150, TimeUnit.SECONDS);
         System.out.println("PerformanceCounterData are good: " + (System.currentTimeMillis() - start));
 
@@ -53,10 +54,9 @@ public class PerfCountersDataTest extends AiSmokeTest {
         assertEquals("_Total", pdCpu.getInstanceName());
 
         assertPerfCounter(getBaseData(processIo));
-        assertPerfCounter(getBaseData(processMemUsed));
+        assertPerfMetric(getBaseData(processMemUsed));
         assertPerfCounter(getBaseData(processCpu));
-        assertSameInstanceName(processIo, processMemUsed, processCpu);
-
+        assertSameInstanceName(processIo, processCpu);
 
         start = System.currentTimeMillis();
         System.out.println("Waiting for metric data...");
@@ -102,7 +102,6 @@ public class PerfCountersDataTest extends AiSmokeTest {
     }
 
     private void assertPerfMetric(MetricData perfMetric) {
-        assertEquals("true", perfMetric.getProperties().get("CustomPerfCounter"));
         List<DataPoint> metrics = perfMetric.getMetrics();
         assertEquals(1, metrics.size());
         DataPoint dp = metrics.get(0);


### PR DESCRIPTION
CustomMetrics:
"Private Bytes"
“Heap Memory Used (MB)”
“GC Total Time”
“GC Total Count”
"Loaded Class Count"
"Current Thread Count"
"Suspected Deadlocked Threads"

Keep the following in PerformanceCounter (used by the Performance blade on the portal):
“Available Bytes”
“% Processor Time”
“IO Data Bytes/sec”