### PR TITLE
fix for issue where null pointer exception is thrown when attribute value is not provided and matchType is regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# Version 3.0.1 GA
+* fix for an issue where null pointer exception is being thrown when attribute value is not provided and matchType is regexp
+
 # Version 3.0.0 GA
 * Config changes
 	- Change json config file name from ApplicationInsights.json to applicationinsights.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 # Version 3.0.1 GA
-* fix for an issue where null pointer exception is being thrown when attribute value is not provided and matchType is regexp
+* Telemetry processor config throws null pointer exception when attribute value is not provided and matchType is regexp
 
 # Version 3.0.0 GA
 * Config changes

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/processors/AgentProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/processors/AgentProcessor.java
@@ -110,7 +110,9 @@ public abstract class AgentProcessor {
             Map<AttributeKey<?>, Pattern> attributeKeyValuePatterns = new HashMap<>();
             if (attributes != null) {
                 for (ProcessorAttribute attribute : attributes) {
-                    attributeKeyValuePatterns.put(AttributeKey.stringKey(attribute.key), Pattern.compile(attribute.value));
+                    if (attribute.value != null) {
+                        attributeKeyValuePatterns.put(AttributeKey.stringKey(attribute.key), Pattern.compile(attribute.value));
+                    }
                 }
             }
             List<Pattern> spanPatterns = new ArrayList<>();


### PR DESCRIPTION
fix for issue where null pointer exception is thrown when attribute value is not provided and matchType is regexp

