### PR TITLE
Fix logging configuration

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
@@ -243,15 +243,15 @@ public class BeforeAgentInstaller {
         if (logging == null) {
             return defaultValue;
         }
-        Object thresholdObj = logging.get("level");
-        if (thresholdObj == null) {
+        Object levelObj = logging.get("level");
+        if (levelObj == null) {
             return defaultValue;
         }
-        if (!(thresholdObj instanceof String)) {
-            startupLogger.warn("logging level must be a string, but found: {}", thresholdObj.getClass());
+        if (!(levelObj instanceof String)) {
+            startupLogger.warn("logging level must be a string, but found: {}", levelObj.getClass());
             return defaultValue;
         }
-        String threshold = (String) thresholdObj;
+        String threshold = (String) levelObj;
         if (threshold.isEmpty()) {
             return defaultValue;
         }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
@@ -243,12 +243,12 @@ public class BeforeAgentInstaller {
         if (logging == null) {
             return defaultValue;
         }
-        Object thresholdObj = logging.get("threshold");
+        Object thresholdObj = logging.get("level");
         if (thresholdObj == null) {
             return defaultValue;
         }
         if (!(thresholdObj instanceof String)) {
-            startupLogger.warn("logging threshold must be a string, but found: {}", thresholdObj.getClass());
+            startupLogger.warn("logging level must be a string, but found: {}", thresholdObj.getClass());
             return defaultValue;
         }
         String threshold = (String) thresholdObj;

--- a/test/smoke/appServers/global-resources/logging_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/logging_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "logging": {
+      "level": "warn"
+    }
+  }
+}

--- a/test/smoke/testApps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
+++ b/test/smoke/testApps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
@@ -8,19 +8,18 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-@UseAgent
+@UseAgent("logging")
 public class TraceJavaUtilLoggingTest extends AiSmokeTest {
 
     @Test
     @TargetUri("/traceJavaUtilLogging")
     public void testTraceJavaUtilLogging() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(3);
+        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(2);
 
         Envelope rdEnvelope = rdList.get(0);
         Envelope mdEnvelope1 = mdList.get(0);
         Envelope mdEnvelope2 = mdList.get(1);
-        Envelope mdEnvelope3 = mdList.get(2);
 
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
@@ -32,27 +31,20 @@ public class TraceJavaUtilLoggingTest extends AiSmokeTest {
             }
         });
 
-        MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
         MessageData md3 = logs.get(2);
-
-        assertEquals("This is jul info.", md1.getMessage());
-        assertEquals(SeverityLevel.Information, md1.getSeverityLevel());
-        assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("INFO", md1.getProperties().get("LoggingLevel"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
         assertEquals("This is jul warning.", md2.getMessage());
         assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
         assertEquals("WARNING", md2.getProperties().get("LoggingLevel"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope2);
+        assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
         assertEquals("This is jul severe.", md3.getMessage());
         assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
         assertEquals("SEVERE", md3.getProperties().get("LoggingLevel"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope3);
+        assertParentChild(rd, rdEnvelope, mdEnvelope2);
     }
 
     @Test

--- a/test/smoke/testApps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
+++ b/test/smoke/testApps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
@@ -31,19 +31,19 @@ public class TraceJavaUtilLoggingTest extends AiSmokeTest {
             }
         });
 
+        MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
-        MessageData md3 = logs.get(2);
 
-        assertEquals("This is jul warning.", md2.getMessage());
-        assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
-        assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("WARNING", md2.getProperties().get("LoggingLevel"));
+        assertEquals("This is jul warning.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
+        assertEquals("Logger", md1.getProperties().get("SourceType"));
+        assertEquals("WARNING", md1.getProperties().get("LoggingLevel"));
         assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
-        assertEquals("This is jul severe.", md3.getMessage());
-        assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
-        assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("SEVERE", md3.getProperties().get("LoggingLevel"));
+        assertEquals("This is jul severe.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
+        assertEquals("Logger", md2.getProperties().get("SourceType"));
+        assertEquals("SEVERE", md2.getProperties().get("LoggingLevel"));
         assertParentChild(rd, rdEnvelope, mdEnvelope2);
     }
 

--- a/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -34,7 +34,7 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
 
         MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
-        MessageData md3 = logs.get(3);
+        MessageData md3 = logs.get(2);
 
         assertEquals("This is log4j1.2 warn.", md1.getMessage());
         assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());

--- a/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -8,20 +8,19 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-@UseAgent
+@UseAgent("logging")
 public class TraceLog4j1_2Test extends AiSmokeTest {
 
     @Test
     @TargetUri("/traceLog4j1_2")
     public void testTraceLog4j1_2() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(4);
+        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(3);
 
         Envelope rdEnvelope = rdList.get(0);
         Envelope mdEnvelope1 = mdList.get(0);
         Envelope mdEnvelope2 = mdList.get(1);
         Envelope mdEnvelope3 = mdList.get(2);
-        Envelope mdEnvelope4 = mdList.get(3);
 
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
@@ -35,36 +34,28 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
 
         MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
-        MessageData md3 = logs.get(2);
-        MessageData md4 = logs.get(3);
+        MessageData md3 = logs.get(3);
 
-        assertEquals("This is log4j1.2 info.", md1.getMessage());
-        assertEquals(SeverityLevel.Information, md1.getSeverityLevel());
+        assertEquals("This is log4j1.2 warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("INFO", md1.getProperties().get("LoggingLevel"));
-        assertFalse(md1.getProperties().containsKey("MDC key"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
+        assertEquals("MDC value", md1.getProperties().get("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
-        assertEquals("This is log4j1.2 warn.", md2.getMessage());
-        assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
+        assertEquals("This is log4j1.2 error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("WARN", md2.getProperties().get("LoggingLevel"));
-        assertEquals("MDC value", md2.getProperties().get("MDC key"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
+        assertFalse(md2.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope2);
 
-        assertEquals("This is log4j1.2 error.", md3.getMessage());
-        assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
+        assertEquals("This is log4j1.2 fatal.", md3.getMessage());
+        assertEquals(SeverityLevel.Critical, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("ERROR", md3.getProperties().get("LoggingLevel"));
+        assertEquals("FATAL", md3.getProperties().get("LoggingLevel"));
         assertFalse(md3.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope3);
-
-        assertEquals("This is log4j1.2 fatal.", md4.getMessage());
-        assertEquals(SeverityLevel.Critical, md4.getSeverityLevel());
-        assertEquals("Logger", md4.getProperties().get("SourceType"));
-        assertEquals("FATAL", md4.getProperties().get("LoggingLevel"));
-        assertFalse(md4.getProperties().containsKey("MDC key"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope4);
     }
 
     @Test

--- a/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -14,20 +14,19 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-@UseAgent
+@UseAgent("logging")
 public class TraceLog4j1_2Test extends AiSmokeTest {
 
     @Test
     @TargetUri("/traceLog4j1_2")
     public void testTraceLog4j1_2() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(4);
+        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(3);
 
         Envelope rdEnvelope = rdList.get(0);
         Envelope mdEnvelope1 = mdList.get(0);
         Envelope mdEnvelope2 = mdList.get(1);
         Envelope mdEnvelope3 = mdList.get(2);
-        Envelope mdEnvelope4 = mdList.get(3);
 
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
@@ -42,35 +41,27 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
         MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
         MessageData md3 = logs.get(2);
-        MessageData md4 = logs.get(3);
 
-        assertEquals("This is log4j1.2 info.", md1.getMessage());
-        assertEquals(SeverityLevel.Information, md1.getSeverityLevel());
+        assertEquals("This is log4j1.2 warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("INFO", md1.getProperties().get("LoggingLevel"));
-        assertFalse(md1.getProperties().containsKey("MDC key"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
+        assertEquals("MDC value", md1.getProperties().get("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
-        assertEquals("This is log4j1.2 warn.", md2.getMessage());
-        assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
+        assertEquals("This is log4j1.2 error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("WARN", md2.getProperties().get("LoggingLevel"));
-        assertEquals("MDC value", md2.getProperties().get("MDC key"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
+        assertFalse(md2.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope2);
 
-        assertEquals("This is log4j1.2 error.", md3.getMessage());
-        assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
+        assertEquals("This is log4j1.2 fatal.", md3.getMessage());
+        assertEquals(SeverityLevel.Critical, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("ERROR", md3.getProperties().get("LoggingLevel"));
+        assertEquals("FATAL", md3.getProperties().get("LoggingLevel"));
         assertFalse(md3.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope3);
-
-        assertEquals("This is log4j1.2 fatal.", md4.getMessage());
-        assertEquals(SeverityLevel.Critical, md4.getSeverityLevel());
-        assertEquals("Logger", md4.getProperties().get("SourceType"));
-        assertEquals("FATAL", md4.getProperties().get("LoggingLevel"));
-        assertFalse(md4.getProperties().containsKey("MDC key"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope4);
     }
 
     @Test

--- a/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -9,20 +9,19 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-@UseAgent
+@UseAgent("logging")
 public class TraceLog4j2Test extends AiSmokeTest {
 
     @Test
     @TargetUri("/traceLog4j2")
     public void testTraceLog4j2() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(4);
+        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(3);
 
         Envelope rdEnvelope = rdList.get(0);
         Envelope mdEnvelope1 = mdList.get(0);
         Envelope mdEnvelope2 = mdList.get(1);
         Envelope mdEnvelope3 = mdList.get(2);
-        Envelope mdEnvelope4 = mdList.get(3);
 
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
@@ -37,35 +36,27 @@ public class TraceLog4j2Test extends AiSmokeTest {
         MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
         MessageData md3 = logs.get(2);
-        MessageData md4 = logs.get(3);
 
-        assertEquals("This is log4j2 info.", md1.getMessage());
-        assertEquals(SeverityLevel.Information, md1.getSeverityLevel());
+        assertEquals("This is log4j2 warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("INFO", md1.getProperties().get("LoggingLevel"));
-        assertFalse(md1.getProperties().containsKey("MDC key"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
+        assertEquals("MDC value", md1.getProperties().get("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
-        assertEquals("This is log4j2 warn.", md2.getMessage());
-        assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
+        assertEquals("This is log4j2 error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("WARN", md2.getProperties().get("LoggingLevel"));
-        assertEquals("MDC value", md2.getProperties().get("MDC key"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
+        assertFalse(md2.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope2);
 
-        assertEquals("This is log4j2 error.", md3.getMessage());
-        assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
+        assertEquals("This is log4j2 fatal.", md3.getMessage());
+        assertEquals(SeverityLevel.Critical, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("ERROR", md3.getProperties().get("LoggingLevel"));
+        assertEquals("FATAL", md3.getProperties().get("LoggingLevel"));
         assertFalse(md3.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope3);
-
-        assertEquals("This is log4j2 fatal.", md4.getMessage());
-        assertEquals(SeverityLevel.Critical, md4.getSeverityLevel());
-        assertEquals("Logger", md4.getProperties().get("SourceType"));
-        assertEquals("FATAL", md4.getProperties().get("LoggingLevel"));
-        assertFalse(md4.getProperties().containsKey("MDC key"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope4);
     }
 
     @Test

--- a/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -15,20 +15,19 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-@UseAgent
+@UseAgent("logging")
 public class TraceLog4j2Test extends AiSmokeTest {
 
     @Test
     @TargetUri("/traceLog4j2")
     public void testTraceLog4j2() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(4);
+        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(3);
 
         Envelope rdEnvelope = rdList.get(0);
         Envelope mdEnvelope1 = mdList.get(0);
         Envelope mdEnvelope2 = mdList.get(1);
         Envelope mdEnvelope3 = mdList.get(2);
-        Envelope mdEnvelope4 = mdList.get(3);
 
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
@@ -43,35 +42,27 @@ public class TraceLog4j2Test extends AiSmokeTest {
         MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
         MessageData md3 = logs.get(2);
-        MessageData md4 = logs.get(3);
 
-        assertEquals("This is log4j2 info.", md1.getMessage());
-        assertEquals(SeverityLevel.Information, md1.getSeverityLevel());
+        assertEquals("This is log4j2 warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("INFO", md1.getProperties().get("LoggingLevel"));
-        assertFalse(md1.getProperties().containsKey("MDC key"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
+        assertEquals("MDC value", md1.getProperties().get("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
-        assertEquals("This is log4j2 warn.", md2.getMessage());
-        assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
+        assertEquals("This is log4j2 error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("WARN", md2.getProperties().get("LoggingLevel"));
-        assertEquals("MDC value", md2.getProperties().get("MDC key"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
+        assertFalse(md2.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope2);
 
-        assertEquals("This is log4j2 error.", md3.getMessage());
-        assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
+        assertEquals("This is log4j2 fatal.", md3.getMessage());
+        assertEquals(SeverityLevel.Critical, md3.getSeverityLevel());
         assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("ERROR", md3.getProperties().get("LoggingLevel"));
+        assertEquals("FATAL", md3.getProperties().get("LoggingLevel"));
         assertFalse(md3.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope3);
-
-        assertEquals("This is log4j2 fatal.", md4.getMessage());
-        assertEquals(SeverityLevel.Critical, md4.getSeverityLevel());
-        assertEquals("Logger", md4.getProperties().get("SourceType"));
-        assertEquals("FATAL", md4.getProperties().get("LoggingLevel"));
-        assertFalse(md4.getProperties().containsKey("MDC key"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope4);
     }
 
     @Test

--- a/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -23,12 +23,11 @@ public class TraceLogBackTest extends AiSmokeTest {
     @TargetUri("/traceLogBack")
     public void testTraceLogBack() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(3);
+        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(2);
 
         Envelope rdEnvelope = rdList.get(0);
         Envelope mdEnvelope1 = mdList.get(0);
         Envelope mdEnvelope2 = mdList.get(1);
-        Envelope mdEnvelope3 = mdList.get(2);
 
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
@@ -42,28 +41,20 @@ public class TraceLogBackTest extends AiSmokeTest {
 
         MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
-        MessageData md3 = logs.get(2);
 
-        assertEquals("This is logback info.", md1.getMessage());
-        assertEquals(SeverityLevel.Information, md1.getSeverityLevel());
+        assertEquals("This is logback warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("INFO", md1.getProperties().get("LoggingLevel"));
-        assertFalse(md1.getProperties().containsKey("MDC key"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
+        assertEquals("MDC value", md1.getProperties().get("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
-        assertEquals("This is logback warn.", md2.getMessage());
-        assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
+        assertEquals("This is logback error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("WARN", md2.getProperties().get("LoggingLevel"));
-        assertEquals("MDC value", md2.getProperties().get("MDC key"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
+        assertFalse(md2.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope2);
-
-        assertEquals("This is logback error.", md3.getMessage());
-        assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
-        assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("ERROR", md3.getProperties().get("LoggingLevel"));
-        assertFalse(md3.getProperties().containsKey("MDC key"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope3);
     }
 
     @Test

--- a/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-@UseAgent
+@UseAgent("logging")
 public class TraceLogBackTest extends AiSmokeTest {
 
     @Before

--- a/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -29,12 +29,11 @@ public class TraceLogBackTest extends AiSmokeTest {
     @TargetUri("/traceLogBack")
     public void testTraceLogBack() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(3);
+        List<Envelope> mdList = mockedIngestion.waitForMessageItemsInRequest(2);
 
         Envelope rdEnvelope = rdList.get(0);
         Envelope mdEnvelope1 = mdList.get(0);
         Envelope mdEnvelope2 = mdList.get(1);
-        Envelope mdEnvelope3 = mdList.get(2);
 
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
@@ -48,28 +47,20 @@ public class TraceLogBackTest extends AiSmokeTest {
 
         MessageData md1 = logs.get(0);
         MessageData md2 = logs.get(1);
-        MessageData md3 = logs.get(2);
 
-        assertEquals("This is logback info.", md1.getMessage());
-        assertEquals(SeverityLevel.Information, md1.getSeverityLevel());
+        assertEquals("This is logback warn.", md1.getMessage());
+        assertEquals(SeverityLevel.Warning, md1.getSeverityLevel());
         assertEquals("Logger", md1.getProperties().get("SourceType"));
-        assertEquals("INFO", md1.getProperties().get("LoggingLevel"));
-        assertFalse(md1.getProperties().containsKey("MDC key"));
+        assertEquals("WARN", md1.getProperties().get("LoggingLevel"));
+        assertEquals("MDC value", md1.getProperties().get("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope1);
 
-        assertEquals("This is logback warn.", md2.getMessage());
-        assertEquals(SeverityLevel.Warning, md2.getSeverityLevel());
+        assertEquals("This is logback error.", md2.getMessage());
+        assertEquals(SeverityLevel.Error, md2.getSeverityLevel());
         assertEquals("Logger", md2.getProperties().get("SourceType"));
-        assertEquals("WARN", md2.getProperties().get("LoggingLevel"));
-        assertEquals("MDC value", md2.getProperties().get("MDC key"));
+        assertEquals("ERROR", md2.getProperties().get("LoggingLevel"));
+        assertFalse(md2.getProperties().containsKey("MDC key"));
         assertParentChild(rd, rdEnvelope, mdEnvelope2);
-
-        assertEquals("This is logback error.", md3.getMessage());
-        assertEquals(SeverityLevel.Error, md3.getSeverityLevel());
-        assertEquals("Logger", md3.getProperties().get("SourceType"));
-        assertEquals("ERROR", md3.getProperties().get("LoggingLevel"));
-        assertFalse(md3.getProperties().containsKey("MDC key"));
-        assertParentChild(rd, rdEnvelope, mdEnvelope3);
     }
 
     @Test

--- a/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-@UseAgent
+@UseAgent("logging")
 public class TraceLogBackTest extends AiSmokeTest {
 
     @Before


### PR DESCRIPTION
The code was using `level` in one place and `threshold` in another.

`level` is correct (and what's in documentation).

This PR also improves the tests so that the would have caught this issue.

Resolves #1415