### PR TITLE
Fix APPLICATIONINSIGHTS_CONNECTION_STRING env var

### DIFF
--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -47,6 +47,11 @@ public class ConfigurationBuilder {
 
     private static final String APPLICATIONINSIGHTS_CONFIGURATION_FILE = "APPLICATIONINSIGHTS_CONFIGURATION_FILE";
 
+    private static final String APPLICATIONINSIGHTS_CONNECTION_STRING = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+
+    // this is for backwards compatibility only
+    private static final String APPINSIGHTS_INSTRUMENTATIONKEY = "APPINSIGHTS_INSTRUMENTATIONKEY";
+
     private static final String APPLICATIONINSIGHTS_ROLE_NAME = "APPLICATIONINSIGHTS_ROLE_NAME";
     private static final String APPLICATIONINSIGHTS_ROLE_INSTANCE = "APPLICATIONINSIGHTS_ROLE_INSTANCE";
 
@@ -167,6 +172,16 @@ public class ConfigurationBuilder {
     }
 
     static void overlayEnvVars(Configuration config) throws IOException {
+        config.connectionString = overlayWithEnvVar(APPLICATIONINSIGHTS_CONNECTION_STRING, config.connectionString);
+        if (config.connectionString == null) {
+            // this is for backwards compatibility only
+            String instrumentationKey = System.getenv(APPINSIGHTS_INSTRUMENTATIONKEY);
+            if (instrumentationKey != null && !instrumentationKey.isEmpty()) {
+                // TODO log an info message recommending APPLICATIONINSIGHTS_CONNECTION_STRING
+                config.connectionString = "InstrumentationKey=" + instrumentationKey;
+            }
+        }
+
         config.role.name = overlayWithEnvVars(APPLICATIONINSIGHTS_ROLE_NAME, WEBSITE_SITE_NAME, config.role.name);
         config.role.instance = overlayWithEnvVars(APPLICATIONINSIGHTS_ROLE_INSTANCE, WEBSITE_INSTANCE_ID, config.role.instance);
 

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationTest.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationTest.java
@@ -150,8 +150,6 @@ public class ConfigurationTest {
         assertNotNull(attributesExtractConfig.actions.get(0).extractAttribute.extractAttributePattern);
         assertEquals(4,attributesExtractConfig.actions.get(0).extractAttribute.extractAttributeGroupNames.size());
         assertEquals("httpProtocol",attributesExtractConfig.actions.get(0).extractAttribute.extractAttributeGroupNames.get(0));
-
-
     }
 
     @Test
@@ -169,13 +167,23 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void shouldOverrideConnectionString() throws IOException {
+        envVars.set("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=11111111-1111-1111-1111-111111111111");
+
+        Configuration configuration = loadConfiguration();
+        ConfigurationBuilder.overlayEnvVars(configuration);
+
+        assertEquals("InstrumentationKey=11111111-1111-1111-1111-111111111111", configuration.connectionString);
+    }
+
+    @Test
     public void shouldOverrideSamplingPercentage() throws IOException {
         envVars.set("APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE", "0.25");
 
         Configuration configuration = loadConfiguration();
         ConfigurationBuilder.overlayEnvVars(configuration);
 
-        assertTrue(configuration.sampling.percentage == 0.25);
+        assertEquals(0.25, configuration.sampling.percentage, 0);
     }
 
     @Test

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
@@ -247,9 +247,7 @@ public class BeforeAgentInstaller {
     }
 
     private static boolean hasConnectionStringOrInstrumentationKey(Configuration config) {
-        return !Strings.isNullOrEmpty(config.connectionString)
-                || !Strings.isNullOrEmpty(System.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING"))
-                || !Strings.isNullOrEmpty(System.getenv("APPINSIGHTS_INSTRUMENTATIONKEY"));
+        return !Strings.isNullOrEmpty(config.connectionString);
     }
 
     private static String getLoggingFrameworksThreshold(Configuration config, String defaultValue) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -104,7 +104,6 @@ public enum TelemetryConfigurationFactory {
     }
 
     private void setMinimumConfiguration(ApplicationInsightsXmlConfiguration userConfiguration, TelemetryConfiguration configuration) {
-        setConnectionString(userConfiguration, configuration);
         setRoleName(userConfiguration, configuration);
         setRoleInstance(userConfiguration, configuration);
         configuration.setChannel(new InProcessTelemetryChannel(configuration));

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/config/TelemetryConfigurationFactory.java
@@ -54,14 +54,6 @@ public enum TelemetryConfigurationFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(TelemetryConfigurationFactory.class);
 
-    // Default file name
-    private static final String CONFIG_FILE_NAME = "ApplicationInsights.xml";
-    private static final String BUILT_IN_NAME = "BuiltIn";
-
-    public static final String CONNECTION_STRING_ENV_VAR_NAME = "APPLICATIONINSIGHTS_CONNECTION_STRING";
-
-    static final String EXTERNAL_PROPERTY_IKEY_NAME_SECONDARY = "APPINSIGHTS_INSTRUMENTATIONKEY";
-
     private static final Set<String> defaultPerformaceModuleClassNames = new HashSet<>();
 
     static {
@@ -94,7 +86,6 @@ public enum TelemetryConfigurationFactory {
     public void initialize(TelemetryConfiguration configuration,
                            ApplicationInsightsXmlConfiguration applicationInsightsConfig) {
 
-        setInstrumentationKey(applicationInsightsConfig, configuration);
         setConnectionString(applicationInsightsConfig, configuration);
         setRoleName(applicationInsightsConfig, configuration);
         setRoleInstance(applicationInsightsConfig, configuration);
@@ -113,7 +104,7 @@ public enum TelemetryConfigurationFactory {
     }
 
     private void setMinimumConfiguration(ApplicationInsightsXmlConfiguration userConfiguration, TelemetryConfiguration configuration) {
-        setInstrumentationKey(userConfiguration, configuration);
+        setConnectionString(userConfiguration, configuration);
         setRoleName(userConfiguration, configuration);
         setRoleInstance(userConfiguration, configuration);
         configuration.setChannel(new InProcessTelemetryChannel(configuration));
@@ -156,56 +147,9 @@ public enum TelemetryConfigurationFactory {
         modules.addAll(pcModules);
     }
 
-    /**
-     * Setting an instrumentation key:
-     * First we try the environment variable 'APPINSIGHTS_INSTRUMENTATIONKEY'
-     * Next we will try to fetch the i-key from the ApplicationInsights.xml
-     * @param userConfiguration The configuration that was represents the user's configuration in ApplicationInsights.xml.
-     * @param configuration The configuration class.
-     */
-    private void setInstrumentationKey(ApplicationInsightsXmlConfiguration userConfiguration, TelemetryConfiguration configuration) {
-        try {
-            String ikey;
-
-            ikey = System.getenv(EXTERNAL_PROPERTY_IKEY_NAME_SECONDARY);
-            if (!Strings.isNullOrEmpty(ikey)) {
-                configuration.setInstrumentationKey(ikey);
-                return;
-            }
-
-            // Else, try to find the i-key in ApplicationInsights.xml
-            if (userConfiguration != null) {
-                ikey = userConfiguration.getInstrumentationKey();
-                if (ikey == null) {
-                    return;
-                }
-
-                ikey = ikey.trim();
-                if (ikey.length() == 0) {
-                    return;
-                }
-
-                configuration.setInstrumentationKey(ikey);
-            }
-        } catch (Exception e) {
-            logger.error("Failed to set instrumentation key: '{}'", e.toString());
-        }
-    }
-
     private void setConnectionString(ApplicationInsightsXmlConfiguration configXml, TelemetryConfiguration configuration) {
-        // connection string > ikey
-        // hardcoded > env var > system property > config.xml
 
-        // hardcoded should follow a different path
-        String connectionString = configXml.getConnectionString(); // config.xml
-
-        String nextValue = System.getenv(CONNECTION_STRING_ENV_VAR_NAME);
-        if (!Strings.isNullOrEmpty(nextValue)) {
-            if (!Strings.isNullOrEmpty(connectionString)) {
-                logger.warn("Environment variable {} is overriding connection string value from {}", CONNECTION_STRING_ENV_VAR_NAME, CONFIG_FILE_NAME);
-            }
-            connectionString = nextValue;
-        }
+        String connectionString = configXml.getConnectionString();
 
         if (connectionString != null) {
             configuration.setConnectionString(connectionString);


### PR DESCRIPTION
Resolves #1428

The problem is with this code that was introduced in 3.0.1-BETA:

https://github.com/microsoft/ApplicationInsights-Java/blob/1ec91209c6fe14ee4e38cbae030bde6ceea82405/agent/agent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java#L43-L49

Because `APPLICATIONINSIGHTS_CONNECTION_STRING` was being resolved later on instead of up front in the config object like other env vars.

This PR moves the resolving of both `APPLICATIONINSIGHTS_CONNECTION_STRING` and the legacy `APPINSIGHTS_INSTRUMENTATIONKEY` to `ConfigurationBuilder`, which makes this code correct.