### PR TITLE
Suppress duplicate AI agents

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
@@ -90,6 +90,7 @@ public class BeforeAgentInstaller {
         instrumentation.addTransformer(new HeartBeatModuleClassFileTransformer());
         instrumentation.addTransformer(new ApplicationInsightsAppenderClassFileTransformer());
         instrumentation.addTransformer(new WebRequestTrackingFilterClassFileTransformer());
+        instrumentation.addTransformer(new DuplicateAgentClassFileTransformer());
     }
 
     private static void start(Instrumentation instrumentation) throws Exception {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/DuplicateAgentClassFileTransformer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/DuplicateAgentClassFileTransformer.java
@@ -41,9 +41,10 @@ public class DuplicateAgentClassFileTransformer implements ClassFileTransformer 
     private static final Logger logger = LoggerFactory.getLogger(DuplicateAgentClassFileTransformer.class);
 
     // using constant here so that it will NOT get shaded
-    // IMPORTANT FOR THIS NOT TO BE FINAL, OTHERWISE COMPILER COULD INLINE IT BELOW AND APPLY .substring(1)
+    // IMPORTANT FOR THIS NOT TO BE FINAL (or private)
+    // OTHERWISE COMPILER COULD THEORETICALLY INLINE IT BELOW AND APPLY .substring(1)
     // and then it WOULD be shaded
-    public static String[] UNSHADED_CLASS_NAMES = new String[] {
+    static String[] UNSHADED_CLASS_NAMES = new String[] {
             "!io/opentelemetry/javaagent/OpenTelemetryAgent", // 3.0
             "!io/opentelemetry/auto/bootstrap/AgentBootstrap", // early 3.0 previews
             "!com/microsoft/applicationinsights/agent/internal/Premain", // 2.5.0+

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/DuplicateAgentClassFileTransformer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/DuplicateAgentClassFileTransformer.java
@@ -1,0 +1,109 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package com.microsoft.applicationinsights.agent.internal;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.security.ProtectionDomain;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.bytebuddy.jar.asm.ClassReader;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.ClassWriter;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static net.bytebuddy.jar.asm.Opcodes.ASM7;
+import static net.bytebuddy.jar.asm.Opcodes.RETURN;
+
+public class DuplicateAgentClassFileTransformer implements ClassFileTransformer {
+
+    private static final Logger logger = LoggerFactory.getLogger(DuplicateAgentClassFileTransformer.class);
+
+    // using constant here so that it will NOT get shaded
+    // IMPORTANT FOR THIS NOT TO BE FINAL, OTHERWISE COMPILER COULD INLINE IT BELOW AND APPLY .substring(1)
+    // and then it WOULD be shaded
+    public static String[] UNSHADED_CLASS_NAMES = new String[] {
+            "!io/opentelemetry/javaagent/OpenTelemetryAgent", // 3.0
+            "!io/opentelemetry/auto/bootstrap/AgentBootstrap", // early 3.0 previews
+            "!com/microsoft/applicationinsights/agent/internal/Premain", // 2.5.0+
+            "!com/microsoft/applicationinsights/agent/internal/agent/AgentImplementation" // prior to 2.5.0
+    };
+
+    private final Set<String> unshadedClassNames;
+
+    public DuplicateAgentClassFileTransformer() {
+        Set<String> unshadedClassNames = new HashSet<>();
+        for (String unshadedClassName : UNSHADED_CLASS_NAMES) {
+            unshadedClassNames.add(unshadedClassName.substring(1));
+        }
+        this.unshadedClassNames = unshadedClassNames;
+    }
+
+    @Override
+    public byte /*@Nullable*/[] transform(@Nullable ClassLoader loader, @Nullable String className,
+                                          @Nullable Class<?> classBeingRedefined,
+                                          @Nullable ProtectionDomain protectionDomain,
+                                          byte[] classfileBuffer) {
+
+        if (!unshadedClassNames.contains(className)) {
+            return null;
+        }
+        try {
+            ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            ClassVisitor cv = new DuplicateAgentClassVisitor(cw);
+            ClassReader cr = new ClassReader(classfileBuffer);
+            cr.accept(cv, 0);
+            return cw.toByteArray();
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            return null;
+        }
+    }
+
+    private static class DuplicateAgentClassVisitor extends ClassVisitor {
+
+        private final ClassWriter cw;
+
+        private DuplicateAgentClassVisitor(ClassWriter cw) {
+            super(ASM7, cw);
+            this.cw = cw;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, @Nullable String signature,
+                                         String /*@Nullable*/[] exceptions) {
+            MethodVisitor mv = cw.visitMethod(access, name, descriptor, signature, exceptions);
+            if (name.equals("premain") && descriptor.equals("(Ljava/lang/String;Ljava/lang/instrument/Instrumentation;)V")) {
+                // no-op the initialize() method
+                mv.visitCode();
+                mv.visitInsn(RETURN);
+                mv.visitMaxs(0, 1);
+                mv.visitEnd();
+                return null;
+            } else {
+                return mv;
+            }
+        }
+    }
+}

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/DuplicateAgentClassFileTransformer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/DuplicateAgentClassFileTransformer.java
@@ -45,7 +45,6 @@ public class DuplicateAgentClassFileTransformer implements ClassFileTransformer 
     // OTHERWISE COMPILER COULD THEORETICALLY INLINE IT BELOW AND APPLY .substring(1)
     // and then it WOULD be shaded
     static String[] UNSHADED_CLASS_NAMES = new String[] {
-            "!io/opentelemetry/javaagent/OpenTelemetryAgent", // 3.0
             "!io/opentelemetry/auto/bootstrap/AgentBootstrap", // early 3.0 previews
             "!com/microsoft/applicationinsights/agent/internal/Premain", // 2.5.0+
             "!com/microsoft/applicationinsights/agent/internal/agent/AgentImplementation" // prior to 2.5.0

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/JulListeningClassFileTransformer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/JulListeningClassFileTransformer.java
@@ -31,9 +31,10 @@ import java.util.concurrent.CountDownLatch;
 class JulListeningClassFileTransformer implements ClassFileTransformer {
 
     // using constant here so that it will NOT get shaded
-    // IMPORTANT FOR THIS NOT TO BE FINAL, OTHERWISE COMPILER COULD INLINE IT BELOW AND APPLY .substring(1)
+    // IMPORTANT FOR THIS NOT TO BE FINAL (or private)
+    // OTHERWISE COMPILER COULD THEORETICALLY INLINE IT BELOW AND APPLY .substring(1)
     // and then it WOULD be shaded
-    public static String UNSHADED_PREFIX = "!java/util/logging/Logger";
+    static String UNSHADED_PREFIX = "!java/util/logging/Logger";
 
     private final String unshadedClassName = UNSHADED_PREFIX.substring(1);
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/instrumentation/sdk/UnshadedSdkPackageName.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/instrumentation/sdk/UnshadedSdkPackageName.java
@@ -23,9 +23,10 @@ package com.microsoft.applicationinsights.agent.internal.instrumentation.sdk;
 public class UnshadedSdkPackageName {
 
     // using constant here so that it will NOT get shaded
-    // IMPORTANT FOR THIS NOT TO BE PUBLIC AND NOT FINAL, OTHERWISE COMPILER COULD INLINE IT BELOW AND APPLY
-    // .substring(1) and then it WOULD be shaded
-    public static String ALMOST_PREFIX = "!com/microsoft/applicationinsights";
+    // IMPORTANT FOR THIS NOT TO BE FINAL (or private)
+    // OTHERWISE COMPILER COULD THEORETICALLY INLINE IT BELOW AND APPLY .substring(1)
+    // and then it WOULD be shaded
+    static String ALMOST_PREFIX = "!com/microsoft/applicationinsights";
 
     public static String get() {
         return ALMOST_PREFIX.substring(1);

--- a/agent/agent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/agent/agent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -59,6 +59,9 @@ import java.util.regex.Pattern;
  *   <li>Do dot touch any logging facilities here so we can configure them later
  * </ul>
  */
+// IMPORTANT!! If this class is renamed, be sure to add the previous name to DuplicateAgentClassFileTransformer
+// so that previous versions will be suppressed (current versions with the same class name are suppressed
+// below via the alreadyLoaded flag
 public class OpenTelemetryAgent {
 
     // this is to prevent the agent from loading and instrumenting everything twice

--- a/agent/agent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
+++ b/agent/agent/src/main/java/io/opentelemetry/javaagent/OpenTelemetryAgent.java
@@ -61,8 +61,17 @@ import java.util.regex.Pattern;
  */
 public class OpenTelemetryAgent {
 
+    // this is to prevent the agent from loading and instrumenting everything twice
+    // (leading to unpredictable results) when -javaagent:applicationinsights-agent.jar
+    // appears multiple times on the command line
+    private static volatile boolean alreadyLoaded;
+
     public static void premain(final String agentArgs, final Instrumentation inst) {
+        if (alreadyLoaded) {
+            return;
+        }
         agentmain(agentArgs, inst);
+        alreadyLoaded = true;
     }
 
     public static void agentmain(final String agentArgs, final Instrumentation inst) {


### PR DESCRIPTION
This PR makes sure that, as long as the 3.0.0 java agent is the first `-javaagent` on the command line, that it will suppress other Application Insights java agents.

This is primarily helpful for App Services attach, where we use `JAVA_TOOL_OPTIONS` (which is prepended to the command line args).

This also resolves #1345 😄 (https://stackoverflow.com/questions/60838748/intellij-idea-java-instrumentation-premain-gets-called-twice-when-directly-run).