### PR TITLE
Remove duplicate configuration setting for suppressing logging

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
@@ -127,11 +127,6 @@ public class BeforeAgentInstaller {
         if (!isInstrumentationEnabled(config, "jdbc")) {
             properties.put("otel.instrumentation.jdbc.enabled", "false");
         }
-        if (!isInstrumentationEnabled(config, "logging")) {
-            properties.put("otel.instrumentation.log4j.enabled", "false");
-            properties.put("otel.instrumentation.java-util-logging.enabled", "false");
-            properties.put("otel.instrumentation.logback.enabled", "false");
-        }
         if (!isInstrumentationEnabled(config, "redis")) {
             properties.put("otel.instrumentation.jedis.enabled", "false");
             properties.put("otel.instrumentation.lettuce.enabled", "false");


### PR DESCRIPTION
Simpler when there is just one way to configure a particular behavior.

In this case, we can already suppress log capture using APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=OFF (and similar in json).