### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/agent/agent-tooling/build.gradle
+++ b/agent/agent-tooling/build.gradle
@@ -37,7 +37,15 @@ dependencies {
 
     compile 'com.google.guava:guava:27.1-android'
 
-    compile 'io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.15.0+ai.patch.1'
+    compile ('io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.15.0+ai.patch.1') {
+        exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-jaeger'
+        exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-logging'
+        exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-otlp'
+        exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-otlp-metrics'
+        exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-prometheus'
+        exclude group: 'io.opentelemetry', module: 'opentelemetry-exporter-zipkin'
+        exclude group: 'io.grpc', module: 'grpc-netty'
+    }
     compile 'io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.15.0+ai.patch.1'
     // TODO sync bytebuddy version with version from auto-tooling (above)
     compile group: 'net.bytebuddy', name: 'byte-buddy', version: '1.10.10'


### PR DESCRIPTION
The agent jar file got really big with latest otel update, trimming it back down to normal here.