### PR TITLE
Add env vars for disabling instrumentation

### DIFF
--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -74,25 +74,20 @@ public class ConfigurationBuilder {
     public static Configuration create(Path agentJarPath) throws IOException {
         Configuration config = loadConfigurationFile(agentJarPath);
         overlayEnvVars(config);
-
         return config;
     }
 
     private static void loadLogCaptureEnvVar(Configuration config) {
-        Map<String, Object> logging = config.instrumentation.get("logging");
-        if (logging == null) {
-            logging = new HashMap<>();
-            config.instrumentation.put("logging", logging);
-        }
-
-        final String loggingEnvVar = overlayWithEnvVar(APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL, (String)null);
+        String loggingEnvVar = getEnvVar(APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL);
         if (loggingEnvVar != null) {
-            logging.put("level", loggingEnvVar);
+            config.instrumentation
+                    .computeIfAbsent("logging", k -> new HashMap<>())
+                    .put("level", loggingEnvVar);
         }
     }
 
     private static void loadJmxMetricsEnvVar(Configuration config) throws IOException {
-        String jmxMetricsEnvVarJson = overlayWithEnvVar(APPLICATIONINSIGHTS_JMX_METRICS, (String)null);
+        String jmxMetricsEnvVarJson = getEnvVar(APPLICATIONINSIGHTS_JMX_METRICS);
 
         // JmxMetrics env variable has higher precedence over jmxMetrics config from applicationinsights.json
         if (jmxMetricsEnvVarJson != null && !jmxMetricsEnvVarJson.isEmpty()) {
@@ -131,13 +126,32 @@ public class ConfigurationBuilder {
         return false;
     }
 
+    private static void loadInstrumentationEnabledEnvVars(Configuration config) {
+        loadInstrumentationEnabledEnvVar(config, "micrometer", "APPLICATIONINSIGHTS_INSTRUMENTATION_MICROMETER_ENABLED");
+        loadInstrumentationEnabledEnvVar(config, "jdbc", "APPLICATIONINSIGHTS_INSTRUMENTATION_JDBC_ENABLED");
+        loadInstrumentationEnabledEnvVar(config, "redis", "APPLICATIONINSIGHTS_INSTRUMENTATION_REDIS_ENABLED");
+        loadInstrumentationEnabledEnvVar(config, "kafka", "APPLICATIONINSIGHTS_INSTRUMENTATION_KAFKA_ENABLED");
+        loadInstrumentationEnabledEnvVar(config, "mongo", "APPLICATIONINSIGHTS_INSTRUMENTATION_MONGO_ENABLED");
+        loadInstrumentationEnabledEnvVar(config, "cassandra", "APPLICATIONINSIGHTS_INSTRUMENTATION_CASSANDRA_ENABLED");
+        loadInstrumentationEnabledEnvVar(config, "spring-scheduling", "APPLICATIONINSIGHTS_INSTRUMENTATION_SPRING_SCHEDULING_ENABLED");
+    }
+
+    private static void loadInstrumentationEnabledEnvVar(Configuration config, String instrumentationName, String envVarName) {
+        String instrumentationEnabledEnvVar = getEnvVar(envVarName);
+        if (instrumentationEnabledEnvVar != null) {
+            Map<String, Object> properties = config.instrumentation.computeIfAbsent(instrumentationName, k -> new HashMap<>());
+            // intentionally allowing NumberFormatException to bubble up as invalid configuration and prevent agent from starting
+            properties.put("enabled", Boolean.parseBoolean(instrumentationEnabledEnvVar));
+        }
+    }
+
     private static Configuration loadConfigurationFile(Path agentJarPath) throws IOException {
         if (DiagnosticsHelper.isAnyCodelessAttach()) {
             // codeless attach only supports configuration via environment variables (for now at least)
             return new Configuration();
         }
 
-        String configPathStr = getEnvVarOrProperty(APPLICATIONINSIGHTS_CONFIGURATION_FILE, "applicationinsights.configuration.file");
+        String configPathStr = getConfigPath();
         if (configPathStr != null) {
             Path configPath = agentJarPath.resolveSibling(configPathStr);
             if (Files.exists(configPath)) {
@@ -168,17 +182,6 @@ public class ConfigurationBuilder {
         }
     }
 
-    // never returns empty string (empty string is normalized to null)
-    private static String getEnvVar(String name) {
-        return trimAndEmptyToNull(System.getenv(name));
-    }
-
-    // never returns empty string (empty string is normalized to null)
-    private static String getEnvVarOrProperty(String envVarName, String propertyName) {
-        String value = trimAndEmptyToNull(System.getenv(envVarName));
-        return value != null ? value : trimAndEmptyToNull(System.getProperty(propertyName));
-    }
-
     public static void overlayEnvVars(Configuration config) throws IOException {
         config.connectionString = overlayWithEnvVar(APPLICATIONINSIGHTS_CONNECTION_STRING, config.connectionString);
         if (config.connectionString == null) {
@@ -192,13 +195,13 @@ public class ConfigurationBuilder {
 
         if (isTrimEmpty(config.role.name)) {
             // only use WEBSITE_SITE_NAME as a fallback
-            config.role.name = getEnv(WEBSITE_SITE_NAME);
+            config.role.name = getEnvVar(WEBSITE_SITE_NAME);
         }
         config.role.name = overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_NAME, config.role.name);
 
         if (isTrimEmpty(config.role.instance)) {
             // only use WEBSITE_INSTANCE_ID as a fallback
-            config.role.instance = getEnv(WEBSITE_INSTANCE_ID);
+            config.role.instance = getEnvVar(WEBSITE_INSTANCE_ID);
         }
         config.role.instance = overlayWithEnvVar(APPLICATIONINSIGHTS_ROLE_INSTANCE, config.role.instance);
 
@@ -210,35 +213,45 @@ public class ConfigurationBuilder {
         loadJmxMetricsEnvVar(config);
 
         addDefaultJmxMetricsIfNotPresent(config);
+
+        loadInstrumentationEnabledEnvVars(config);
+    }
+
+    private static String getConfigPath() {
+        String value = getEnvVar(APPLICATIONINSIGHTS_CONFIGURATION_FILE);
+        if (value != null) {
+            return value;
+        }
+        // intentionally not checking system properties for other system properties
+        // with the intention to keep configuration paths minimal to help with supportability
+        return trimAndEmptyToNull(System.getProperty("applicationinsights.configuration.file"));
+    }
+
+    private static String getWebsiteSiteNameEnvVar() {
+        String value = getEnvVar(WEBSITE_SITE_NAME);
+        // TODO is the best way to identify running as Azure Functions worker?
+        // TODO is this the correct way to match role name from Azure Functions IIS host?
+        if ("java".equals(System.getenv("FUNCTIONS_WORKER_RUNTIME"))) {
+            // special case for Azure Functions
+            return value.toLowerCase(Locale.ENGLISH);
+        }
+        return value;
     }
 
     static String overlayWithEnvVar(String name, String defaultValue) {
-        String value = getEnv(name);
-        if (value != null && !value.isEmpty()) {
-            return value;
-        }
-
-        return defaultValue;
+        String value = getEnvVar(name);
+        return value != null ? value : defaultValue;
     }
 
-    static Double overlayWithEnvVar(String name, Double defaultValue) {
-        String value = getEnv(name);
-        if (value != null && !value.isEmpty()) {
-            return Double.parseDouble(value);
-        }
-
-        return defaultValue;
+    static double overlayWithEnvVar(String name, double defaultValue) {
+        String value = getEnvVar(name);
+        // intentionally allowing NumberFormatException to bubble up as invalid configuration and prevent agent from starting
+        return value != null ? Double.parseDouble(value) : defaultValue;
     }
 
-    private static String getEnv(String name) {
-        String value = System.getenv(name);
-        // TODO is the best way to identify running as Azure Functions worker?
-        // TODO is this the correct way to match role name from Azure Functions IIS host?
-        if (name.equals("WEBSITE_SITE_NAME") && "java".equals(System.getenv("FUNCTIONS_WORKER_RUNTIME"))) {
-            // special case for Azure Functions
-            value = value.toLowerCase(Locale.ENGLISH);
-        }
-        return value;
+    // never returns empty string (empty string is normalized to null)
+    private static String getEnvVar(String name) {
+        return trimAndEmptyToNull(System.getenv(name));
     }
 
     // visible for testing

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationBuilder.java
@@ -131,6 +131,7 @@ public class ConfigurationBuilder {
         loadInstrumentationEnabledEnvVar(config, "jdbc", "APPLICATIONINSIGHTS_INSTRUMENTATION_JDBC_ENABLED");
         loadInstrumentationEnabledEnvVar(config, "redis", "APPLICATIONINSIGHTS_INSTRUMENTATION_REDIS_ENABLED");
         loadInstrumentationEnabledEnvVar(config, "kafka", "APPLICATIONINSIGHTS_INSTRUMENTATION_KAFKA_ENABLED");
+        loadInstrumentationEnabledEnvVar(config, "jms", "APPLICATIONINSIGHTS_INSTRUMENTATION_JMS_ENABLED");
         loadInstrumentationEnabledEnvVar(config, "mongo", "APPLICATIONINSIGHTS_INSTRUMENTATION_MONGO_ENABLED");
         loadInstrumentationEnabledEnvVar(config, "cassandra", "APPLICATIONINSIGHTS_INSTRUMENTATION_CASSANDRA_ENABLED");
         loadInstrumentationEnabledEnvVar(config, "spring-scheduling", "APPLICATIONINSIGHTS_INSTRUMENTATION_SPRING_SCHEDULING_ENABLED");

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationTest.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationTest.java
@@ -286,6 +286,7 @@ public class ConfigurationTest {
         shouldOverrideInstrumentationEnable("jdbc");
         shouldOverrideInstrumentationEnable("redis");
         shouldOverrideInstrumentationEnable("kafka");
+        shouldOverrideInstrumentationEnable("jms");
         shouldOverrideInstrumentationEnable("mongo");
         shouldOverrideInstrumentationEnable("cassandra");
         shouldOverrideInstrumentationEnable("spring-scheduling");

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationTest.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/configuration/ConfigurationTest.java
@@ -3,6 +3,7 @@ package com.microsoft.applicationinsights.agent.bootstrap.configuration;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Locale;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -277,6 +278,26 @@ public class ConfigurationTest {
         assertEquals(jmxMetrics.get(0).name, configuration.jmxMetrics.get(0).name); // class count is overridden by the env var
         assertEquals(jmxMetrics.get(1).name, configuration.jmxMetrics.get(1).name); // code cache is overridden by the env var
         assertEquals(configuration.jmxMetrics.get(2).name, "Current Thread Count");
+    }
+
+    @Test
+    public void shouldOverrideInstrumentationEnabled() throws IOException {
+        shouldOverrideInstrumentationEnable("micrometer");
+        shouldOverrideInstrumentationEnable("jdbc");
+        shouldOverrideInstrumentationEnable("redis");
+        shouldOverrideInstrumentationEnable("kafka");
+        shouldOverrideInstrumentationEnable("mongo");
+        shouldOverrideInstrumentationEnable("cassandra");
+        shouldOverrideInstrumentationEnable("spring-scheduling");
+    }
+
+    private void shouldOverrideInstrumentationEnable(String instrumentationName) throws IOException {
+        envVars.set("APPLICATIONINSIGHTS_INSTRUMENTATION_" + instrumentationName.replace('-', '_').toUpperCase(Locale.ROOT) + "_ENABLED", "false");
+
+        Configuration configuration = loadConfiguration();
+        ConfigurationBuilder.overlayEnvVars(configuration);
+
+        assertEquals(false, configuration.instrumentation.get(instrumentationName).get("enabled"));
     }
 
     @Test(expected = JsonDataException.class)

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
@@ -140,6 +140,9 @@ public class BeforeAgentInstaller {
         if (!isInstrumentationEnabled(config, "kafka")) {
             properties.put("otel.instrumentation.kafka.enabled", "false");
         }
+        if (!isInstrumentationEnabled(config, "jms")) {
+            properties.put("otel.instrumentation.jms.enabled", "false");
+        }
         if (!isInstrumentationEnabled(config, "mongo")) {
             properties.put("otel.instrumentation.mongo.enabled", "false");
         }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/BeforeAgentInstaller.java
@@ -146,6 +146,9 @@ public class BeforeAgentInstaller {
         if (!isInstrumentationEnabled(config, "cassandra")) {
             properties.put("otel.instrumentation.cassandra.enabled", "false");
         }
+        if (!isInstrumentationEnabled(config, "spring-scheduling")) {
+            properties.put("otel.instrumentation.spring-scheduling.enabled", "false");
+        }
         if (!config.preview.openTelemetryApiSupport) {
             properties.put("otel.instrumentation.opentelemetry-api.enabled", "false");
         }

--- a/test/smoke/appServers/global-resources/disabled_cassandra_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_cassandra_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "cassandra": {
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/appServers/global-resources/disabled_jdbc_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_jdbc_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "jdbc": {
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/appServers/global-resources/disabled_jms_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_jms_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "jms": {
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/appServers/global-resources/disabled_kafka_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_kafka_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "kafka": {
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/appServers/global-resources/disabled_micrometer_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_micrometer_applicationinsights.json
@@ -1,0 +1,9 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "micrometer": {
+      "reportingIntervalSeconds": 5,
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/appServers/global-resources/disabled_mongo_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_mongo_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "mongo": {
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/appServers/global-resources/disabled_redis_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_redis_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "redis": {
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/appServers/global-resources/disabled_springscheduling_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_springscheduling_applicationinsights.json
@@ -1,0 +1,8 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:60606/",
+  "instrumentation": {
+    "spring-scheduling": {
+      "enabled": false
+    }
+  }
+}

--- a/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JedisDisabledTest.java
+++ b/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JedisDisabledTest.java
@@ -1,0 +1,32 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_redis")
+@WithDependencyContainers(@DependencyContainer(value="redis", portMapping="6379"))
+public class JedisDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/index.jsp")
+    public void doCalcSendsRequestDataAndMetricData() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+
+        assertTrue(rd.getSuccess());
+        assertEquals("/CachingCalculator/index.jsp", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
+        // sleep a bit and make sure no jedis dependencies are reported
+        Thread.sleep(5000);
+        assertEquals(0, mockedIngestion.getCountForType("RemoteDependencyData"));
+   }
+}

--- a/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JedisTest.java
+++ b/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JedisTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.*;
 
 @UseAgent
 @WithDependencyContainers(@DependencyContainer(value="redis", portMapping="6379"))
-public class SampleTestWithDependencyContainer extends AiSmokeTest {
+public class JedisTest extends AiSmokeTest {
 
     @Test
     @TargetUri("/index.jsp")

--- a/test/smoke/testApps/Cassandra/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/CassandraDisabledTest.java
+++ b/test/smoke/testApps/Cassandra/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/CassandraDisabledTest.java
@@ -1,0 +1,41 @@
+package com.microsoft.applicationinsights.smoketestapp;
+
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
+import com.microsoft.applicationinsights.smoketest.DependencyContainer;
+import com.microsoft.applicationinsights.smoketest.TargetUri;
+import com.microsoft.applicationinsights.smoketest.UseAgent;
+import com.microsoft.applicationinsights.smoketest.WithDependencyContainers;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_cassandra")
+@WithDependencyContainers(
+        @DependencyContainer(
+                value = "cassandra:3",
+                portMapping = "9042",
+                hostnameEnvironmentVariable = "CASSANDRA")
+)
+public class CassandraDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/cassandra")
+    public void cassandra() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+
+        assertTrue(rd.getSuccess());
+        assertEquals("HTTP GET", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
+        // sleep a bit and make sure no cassandra dependencies are reported
+        Thread.sleep(5000);
+        assertEquals(0, mockedIngestion.getCountForType("RemoteDependencyData"));
+    }
+}

--- a/test/smoke/testApps/Cassandra/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/CassandraTest.java
+++ b/test/smoke/testApps/Cassandra/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/CassandraTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.*;
                 portMapping = "9042",
                 hostnameEnvironmentVariable = "CASSANDRA")
 )
-public class CassandraSmokeTest extends AiSmokeTest {
+public class CassandraTest extends AiSmokeTest {
 
     @Test
     @TargetUri("/cassandra")

--- a/test/smoke/testApps/JMS/build.gradle
+++ b/test/smoke/testApps/JMS/build.gradle
@@ -16,4 +16,6 @@ dependencies {
 
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.1.7.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-activemq', version: '2.1.7.RELEASE'
+
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.7'
 }

--- a/test/smoke/testApps/JMS/src/main/java/com/microsoft/ajl/simple/Receiver.java
+++ b/test/smoke/testApps/JMS/src/main/java/com/microsoft/ajl/simple/Receiver.java
@@ -1,5 +1,10 @@
 package com.microsoft.ajl.simple;
 
+import java.io.IOException;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.stereotype.Component;
 
@@ -7,7 +12,10 @@ import org.springframework.stereotype.Component;
 public class Receiver {
 
     @JmsListener(destination = "message", containerFactory = "factory")
-    public void message(String message) {
-        System.out.println("===> " + message);
+    public void message(String message) throws IOException {
+        System.out.println("received: " + message);
+
+        CloseableHttpClient httpClient = HttpClientBuilder.create().disableAutomaticRetries().build();
+        httpClient.execute(new HttpGet("https://www.bing.com")).close();
     }
 }

--- a/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsDisabledTest.java
+++ b/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsDisabledTest.java
@@ -1,0 +1,61 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_jms")
+public class JmsDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/sendMessage")
+    public void doMostBasicTest() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+
+        String operationId = rdEnvelope.getTags().get("ai.operation.id");
+        List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        Envelope rddEnvelope = rddList.get(0);
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
+
+        assertTrue(rd.getSuccess());
+        assertEquals("/sendMessage", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
+        assertEquals("HelloController.sendMessage", rdd.getName());
+
+        assertParentChild(rd.getId(), rdEnvelope, rddEnvelope);
+
+        // verify the downstream http dependency that is no longer part of the same trace
+        rddList = mockedIngestion.waitForItems("RemoteDependencyData", 2);
+        rddEnvelope = rddList.get(0);
+        if (operationId.equals(rddEnvelope.getTags().get("ai.operation.id"))) {
+            rddEnvelope = rddList.get(1);
+        }
+        rdd = (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
+
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com", rdd.getData());
+
+        // sleep a bit and make sure no kafka "requests" or dependencies are reported
+        Thread.sleep(5000);
+        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        assertEquals(2, mockedIngestion.getCountForType("RemoteDependencyData"));
+    }
+
+    private static void assertParentChild(String parentId, Envelope parentEnvelope, Envelope childEnvelope) {
+        String operationId = parentEnvelope.getTags().get("ai.operation.id");
+
+        assertNotNull(operationId);
+
+        assertEquals(operationId, childEnvelope.getTags().get("ai.operation.id"));
+        assertEquals(parentId, childEnvelope.getTags().get("ai.operation.parentId"));
+    }
+}

--- a/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsTest.java
+++ b/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsTest.java
@@ -6,9 +6,8 @@ import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
-import org.junit.Test;
+import org.junit.*;
 
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.*;
 
 @UseAgent
@@ -19,33 +18,59 @@ public class JmsTest extends AiSmokeTest {
     public void doMostBasicTest() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 2);
 
-        Envelope rdEnvelope1 = rdList.get(0);
+        Envelope rdEnvelope1 = getRequestEnvelope(rdList, "/sendMessage");
         String operationId = rdEnvelope1.getTags().get("ai.operation.id");
-        List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 2, operationId);
+        List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 3, operationId);
 
-        Envelope rdEnvelope2 = rdList.get(1);
-        Envelope rddEnvelope1 = rddList.get(0);
-        Envelope rddEnvelope2 = rddList.get(1);
+        Envelope rdEnvelope2 = getRequestEnvelope(rdList, "message process");
+        Envelope rddEnvelope1 = getDependencyEnvelope(rddList, "HelloController.sendMessage");
+        Envelope rddEnvelope2 = getDependencyEnvelope(rddList, "message send");
+        Envelope rddEnvelope3 = getDependencyEnvelope(rddList, "HTTP GET");
 
         RequestData rd1 = (RequestData) ((Data) rdEnvelope1.getData()).getBaseData();
         RequestData rd2 = (RequestData) ((Data) rdEnvelope2.getData()).getBaseData();
-        RemoteDependencyData rdd1 =
-                (RemoteDependencyData) ((Data) rddEnvelope1.getData()).getBaseData();
-        RemoteDependencyData rdd2 =
-                (RemoteDependencyData) ((Data) rddEnvelope2.getData()).getBaseData();
+
+        RemoteDependencyData rdd1 = (RemoteDependencyData) ((Data) rddEnvelope1.getData()).getBaseData();
+        RemoteDependencyData rdd2 = (RemoteDependencyData) ((Data) rddEnvelope2.getData()).getBaseData();
+        RemoteDependencyData rdd3 = (RemoteDependencyData) ((Data) rddEnvelope3.getData()).getBaseData();
 
         assertEquals("/sendMessage", rd1.getName());
-        assertEquals("HelloController.sendMessage", rdd2.getName());
+        assertEquals("HelloController.sendMessage", rdd1.getName());
 
-        assertEquals("Queue Message | jms", rdd1.getType());
-        assertEquals("message", rdd1.getTarget());
-        assertEquals("message send", rdd1.getName());
+        assertEquals("Queue Message | jms", rdd2.getType());
+        assertEquals("message", rdd2.getTarget());
+        assertEquals("message send", rdd2.getName());
 
         assertEquals("message", rd2.getSource());
         assertEquals("message process", rd2.getName());
 
-        assertParentChild(rdd2.getId(), rdEnvelope1, rddEnvelope1);
-        assertParentChild(rdd1.getId(), rddEnvelope2, rdEnvelope2);
+        assertEquals("HTTP GET", rdd3.getName());
+        assertEquals("https://www.bing.com", rdd3.getData());
+
+        assertParentChild(rd1.getId(), rdEnvelope1, rddEnvelope1);
+        assertParentChild(rdd1.getId(), rddEnvelope1, rddEnvelope2);
+        assertParentChild(rdd2.getId(), rddEnvelope2, rdEnvelope2);
+        assertParentChild(rd2.getId(), rdEnvelope2, rddEnvelope3);
+    }
+
+    private static Envelope getRequestEnvelope(List<Envelope> envelopes, String name) {
+        for (Envelope envelope : envelopes) {
+            RequestData rd = (RequestData) ((Data) envelope.getData()).getBaseData();
+            if (rd.getName().equals(name)) {
+                return envelope;
+            }
+        }
+        throw new IllegalStateException("Could not find request with name: " + name);
+    }
+
+    private static Envelope getDependencyEnvelope(List<Envelope> envelopes, String name) {
+        for (Envelope envelope : envelopes) {
+            RemoteDependencyData rdd = (RemoteDependencyData) ((Data) envelope.getData()).getBaseData();
+            if (rdd.getName().equals(name)) {
+                return envelope;
+            }
+        }
+        throw new IllegalStateException("Could not find dependency with name: " + name);
     }
 
     private static void assertParentChild(

--- a/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcDisabledTest.java
+++ b/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcDisabledTest.java
@@ -1,0 +1,33 @@
+package com.microsoft.applicationinsights.smoketestapp;
+
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
+import com.microsoft.applicationinsights.smoketest.TargetUri;
+import com.microsoft.applicationinsights.smoketest.UseAgent;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_jdbc")
+public class JdbcDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/hsqldbPreparedStatement")
+    public void hsqldbPreparedStatement() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+
+        assertTrue(rd.getSuccess());
+        assertEquals("HTTP GET", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
+        // sleep a bit and make sure no jdbc dependencies are reported
+        Thread.sleep(5000);
+        assertEquals(0, mockedIngestion.getCountForType("RemoteDependencyData"));
+    }
+}

--- a/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
+++ b/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
                 portMapping = "1433",
                 hostnameEnvironmentVariable = "SQLSERVER")
 })
-public class JdbcSmokeTest extends AiSmokeTest {
+public class JdbcTest extends AiSmokeTest {
 
     @Test
     @TargetUri("/hsqldbPreparedStatement")

--- a/test/smoke/testApps/JettyNativeHandler/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JettyNativeHandlerTest.java
+++ b/test/smoke/testApps/JettyNativeHandler/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JettyNativeHandlerTest.java
@@ -23,5 +23,6 @@ public class JettyNativeHandlerTest extends AiSmokeTest {
 
         assertTrue(rd.getSuccess());
         assertEquals("SimpleHandlerEx.handle", rd.getName());
+        assertEquals("200", rd.getResponseCode());
     }
 }

--- a/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaDisabledTest.java
+++ b/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaDisabledTest.java
@@ -1,0 +1,79 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_kafka")
+@WithDependencyContainers({
+        @DependencyContainer(
+                value = "confluentinc/cp-zookeeper",
+                portMapping = "2181",
+                environmentVariables = {
+                        "ZOOKEEPER_CLIENT_PORT=2181"
+                },
+                hostnameEnvironmentVariable = "ZOOKEEPER"),
+        @DependencyContainer(
+                value = "confluentinc/cp-kafka",
+                portMapping = "9092",
+                environmentVariables = {
+                        "KAFKA_ZOOKEEPER_CONNECT=${ZOOKEEPER}:2181",
+                        "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${CONTAINERNAME}:9092",
+                        "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1"
+                },
+                hostnameEnvironmentVariable = "KAFKA")
+})
+public class KafkaDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/sendMessage")
+    public void doMostBasicTest() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+
+        String operationId = rdEnvelope.getTags().get("ai.operation.id");
+        List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        Envelope rddEnvelope = rddList.get(0);
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
+
+        assertTrue(rd.getSuccess());
+        assertEquals("/sendMessage", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
+        assertEquals("HelloController.sendMessage", rdd.getName());
+
+        assertParentChild(rd.getId(), rdEnvelope, rddEnvelope);
+
+        // verify the downstream http dependency that is no longer part of the same trace
+        rddList = mockedIngestion.waitForItems("RemoteDependencyData", 2);
+        rddEnvelope = rddList.get(0);
+        if (operationId.equals(rddEnvelope.getTags().get("ai.operation.id"))) {
+            rddEnvelope = rddList.get(1);
+        }
+        rdd = (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
+
+        assertEquals("HTTP GET", rdd.getName());
+        assertEquals("https://www.bing.com", rdd.getData());
+
+        // sleep a bit and make sure no kafka "requests" or dependencies are reported
+        Thread.sleep(5000);
+        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
+        assertEquals(2, mockedIngestion.getCountForType("RemoteDependencyData"));
+    }
+
+    private static void assertParentChild(String parentId, Envelope parentEnvelope, Envelope childEnvelope) {
+        String operationId = parentEnvelope.getTags().get("ai.operation.id");
+
+        assertNotNull(operationId);
+
+        assertEquals(operationId, childEnvelope.getTags().get("ai.operation.id"));
+        assertEquals(parentId, childEnvelope.getTags().get("ai.operation.parentId"));
+    }
+}

--- a/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
+++ b/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
@@ -66,9 +66,10 @@ public class KafkaTest extends AiSmokeTest {
         assertEquals("HTTP GET", rdd3.getName());
         assertEquals("https://www.bing.com", rdd3.getData());
 
-        assertParentChild(rdd1.getId(), rdEnvelope1, rddEnvelope2);
-        assertParentChild(rdd2.getId(), rddEnvelope1, rdEnvelope2);
-        assertParentChild(rd2.getId(), rddEnvelope2, rddEnvelope3);
+        assertParentChild(rd1.getId(), rdEnvelope1, rddEnvelope1);
+        assertParentChild(rdd1.getId(), rddEnvelope1, rddEnvelope2);
+        assertParentChild(rdd2.getId(), rddEnvelope2, rdEnvelope2);
+        assertParentChild(rd2.getId(), rdEnvelope2, rddEnvelope3);
     }
 
     private static Envelope getRequestEnvelope(List<Envelope> envelopes, String name) {

--- a/test/smoke/testApps/Lettuce/src/main/java/com/microsoft/applicationinsights/smoketestapp/LettuceTestServlet.java
+++ b/test/smoke/testApps/Lettuce/src/main/java/com/microsoft/applicationinsights/smoketestapp/LettuceTestServlet.java
@@ -12,7 +12,8 @@ import io.lettuce.core.api.sync.RedisCommands;
 @WebServlet("/*")
 public class LettuceTestServlet extends HttpServlet {
 
-    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
         try {
             doGetInternal(req);
             resp.getWriter().println("ok");
@@ -32,7 +33,7 @@ public class LettuceTestServlet extends HttpServlet {
         }
     }
 
-    private void lettuce() throws Exception {
+    private void lettuce() {
         String hostname = System.getenv("REDIS");
         RedisClient redisClient = RedisClient.create("redis://" + hostname);
         RedisCommands<String, String> redisCommands = redisClient.connect().sync();

--- a/test/smoke/testApps/Lettuce/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/LettuceDisabledTest.java
+++ b/test/smoke/testApps/Lettuce/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/LettuceDisabledTest.java
@@ -1,0 +1,32 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_redis")
+@WithDependencyContainers(@DependencyContainer(value="redis", portMapping="6379"))
+public class LettuceDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/lettuce")
+    public void lettuce() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+
+        assertTrue(rd.getSuccess());
+        assertEquals("HTTP GET", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
+        // sleep a bit and make sure no lettuce dependencies are reported
+        Thread.sleep(5000);
+        assertEquals(0, mockedIngestion.getCountForType("RemoteDependencyData"));
+    }
+}

--- a/test/smoke/testApps/Lettuce/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/LettuceTest.java
+++ b/test/smoke/testApps/Lettuce/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/LettuceTest.java
@@ -1,4 +1,4 @@
-package com.microsoft.applicationinsights.smoketestapp;
+package com.microsoft.applicationinsights.smoketest;
 
 import java.util.List;
 
@@ -6,27 +6,18 @@ import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
-import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
-import com.microsoft.applicationinsights.smoketest.DependencyContainer;
-import com.microsoft.applicationinsights.smoketest.TargetUri;
-import com.microsoft.applicationinsights.smoketest.UseAgent;
-import com.microsoft.applicationinsights.smoketest.WithDependencyContainers;
-import org.junit.Test;
+import org.junit.*;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 @UseAgent
-@WithDependencyContainers(
-        @DependencyContainer(
-                value = "mongo:4",
-                portMapping = "27017",
-                hostnameEnvironmentVariable = "MONGO")
-)
-public class MongoSmokeTest extends AiSmokeTest {
+@WithDependencyContainers(@DependencyContainer(value="redis", portMapping="6379"))
+public class LettuceTest extends AiSmokeTest {
 
     @Test
-    @TargetUri("/mongo")
-    public void mongo() throws Exception {
+    @TargetUri("/lettuce")
+    public void lettuce() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
 
         Envelope rdEnvelope = rdList.get(0);
@@ -38,11 +29,10 @@ public class MongoSmokeTest extends AiSmokeTest {
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
-        assertTrue(rd.getSuccess());
-        assertEquals("mongodb", rdd.getType());
-        assertTrue(rdd.getTarget().matches("dependency[0-9]+/testdb"));
-        assertEquals("{\"find\": \"test\", \"$db\": \"?\"}", rdd.getName());
         assertTrue(rdd.getSuccess());
+        assertEquals("redis", rdd.getType());
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+"));
+        assertEquals("GET", rdd.getName());
 
         assertParentChild(rd, rdEnvelope, rddEnvelope, "HTTP GET");
     }

--- a/test/smoke/testApps/Micrometer/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/MicrometerDisabledTest.java
+++ b/test/smoke/testApps/Micrometer/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/MicrometerDisabledTest.java
@@ -1,0 +1,19 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_micrometer")
+public class MicrometerDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/test")
+    public void doMostBasicTest() throws Exception {
+        mockedIngestion.waitForItems("RequestData", 1);
+
+        // sleep a bit and make sure no micrometer metrics are reported
+        Thread.sleep(10000);
+        assertEquals(0, mockedIngestion.getCountForType("MetricData"));
+    }
+}

--- a/test/smoke/testApps/MongoDB/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/MongoDisabledTest.java
+++ b/test/smoke/testApps/MongoDB/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/MongoDisabledTest.java
@@ -1,0 +1,41 @@
+package com.microsoft.applicationinsights.smoketestapp;
+
+import java.util.List;
+
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
+import com.microsoft.applicationinsights.smoketest.DependencyContainer;
+import com.microsoft.applicationinsights.smoketest.TargetUri;
+import com.microsoft.applicationinsights.smoketest.UseAgent;
+import com.microsoft.applicationinsights.smoketest.WithDependencyContainers;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+@UseAgent("disabled_mongo")
+@WithDependencyContainers(
+        @DependencyContainer(
+                value = "mongo:4",
+                portMapping = "27017",
+                hostnameEnvironmentVariable = "MONGO")
+)
+public class MongoDisabledTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri("/mongo")
+    public void mongo() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+        Envelope rdEnvelope = rdList.get(0);
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+
+        assertTrue(rd.getSuccess());
+        assertEquals("HTTP GET", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
+        // sleep a bit and make sure no mongo dependencies are reported
+        Thread.sleep(5000);
+        assertEquals(0, mockedIngestion.getCountForType("RemoteDependencyData"));
+    }
+}

--- a/test/smoke/testApps/MongoDB/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/MongoTest.java
+++ b/test/smoke/testApps/MongoDB/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/MongoTest.java
@@ -1,4 +1,4 @@
-package com.microsoft.applicationinsights.smoketest;
+package com.microsoft.applicationinsights.smoketestapp;
 
 import java.util.List;
 
@@ -6,18 +6,27 @@ import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
-import org.junit.*;
+import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
+import com.microsoft.applicationinsights.smoketest.DependencyContainer;
+import com.microsoft.applicationinsights.smoketest.TargetUri;
+import com.microsoft.applicationinsights.smoketest.UseAgent;
+import com.microsoft.applicationinsights.smoketest.WithDependencyContainers;
+import org.junit.Test;
 
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 @UseAgent
-@WithDependencyContainers(@DependencyContainer(value="redis", portMapping="6379"))
-public class LettuceSmokeTest extends AiSmokeTest {
+@WithDependencyContainers(
+        @DependencyContainer(
+                value = "mongo:4",
+                portMapping = "27017",
+                hostnameEnvironmentVariable = "MONGO")
+)
+public class MongoTest extends AiSmokeTest {
 
     @Test
-    @TargetUri("/lettuce")
-    public void lettuce() throws Exception {
+    @TargetUri("/mongo")
+    public void mongo() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
 
         Envelope rdEnvelope = rdList.get(0);
@@ -29,10 +38,11 @@ public class LettuceSmokeTest extends AiSmokeTest {
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
 
+        assertTrue(rd.getSuccess());
+        assertEquals("mongodb", rdd.getType());
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+/testdb"));
+        assertEquals("{\"find\": \"test\", \"$db\": \"?\"}", rdd.getName());
         assertTrue(rdd.getSuccess());
-        assertEquals("redis", rdd.getType());
-        assertTrue(rdd.getTarget().matches("dependency[0-9]+"));
-        assertEquals("GET", rdd.getName());
 
         assertParentChild(rd, rdEnvelope, rddEnvelope, "HTTP GET");
     }

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -135,7 +135,10 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         RemoteDependencyData rdd3 =
                 (RemoteDependencyData) ((Data) rddEnvelope3.getData()).getBaseData();
 
+        assertTrue(rd.getSuccess());
         assertEquals("/SpringBootTest/asyncDependencyCall", rd.getName());
+        assertEquals("200", rd.getResponseCode());
+
         assertEquals("TestController.asyncDependencyCall", rdd1.getName());
         assertEquals("HTTP GET", rdd2.getName());
         assertEquals("https://www.bing.com", rdd2.getData());

--- a/test/smoke/testApps/SpringScheduling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringSchedulingDisabledTest.java
+++ b/test/smoke/testApps/SpringScheduling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringSchedulingDisabledTest.java
@@ -1,7 +1,9 @@
 package com.microsoft.applicationinsights.smoketest;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Predicate;
 import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import com.microsoft.applicationinsights.internal.schemav2.RequestData;
@@ -9,23 +11,22 @@ import org.junit.*;
 
 import static org.junit.Assert.*;
 
-@UseAgent
-public class SpringBootAutoTest extends AiSmokeTest {
+@UseAgent("disabled_springscheduling")
+public class SpringSchedulingDisabledTest extends AiSmokeTest {
 
     @Test
-    @TargetUri("/test")
-    public void doMostBasicTest() throws Exception {
+    @TargetUri("/scheduler")
+    public void fixedRateSchedulerTest() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
-
         Envelope rdEnvelope = rdList.get(0);
-
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
-        // TODO verify browser and other envelope tags somewhere else
-        assertTrue(rdEnvelope.getTags().get("ai.user.userAgent").startsWith("Apache-HttpClient/"));
-
         assertTrue(rd.getSuccess());
-        assertEquals("/SpringBootAuto/test", rd.getName());
+        assertEquals("/SpringScheduling/scheduler", rd.getName());
         assertEquals("200", rd.getResponseCode());
+
+        // sleep a bit and make sure no spring scheduling "requests" are reported
+        Thread.sleep(5000);
+        assertEquals(1, mockedIngestion.getCountForType("RequestData"));
     }
 }

--- a/test/smoke/testApps/WebFlux/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebFluxTest.java
+++ b/test/smoke/testApps/WebFlux/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebFluxTest.java
@@ -38,6 +38,7 @@ public class WebFluxTest extends AiSmokeTest {
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
         assertFalse(rd.getSuccess());
+        assertEquals("/exception", rd.getName());
         assertEquals("500", rd.getResponseCode());
     }
 
@@ -52,6 +53,7 @@ public class WebFluxTest extends AiSmokeTest {
         RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
 
         assertFalse(rd.getSuccess());
+        assertEquals("/futureException", rd.getName());
         assertEquals("500", rd.getResponseCode());
     }
 }


### PR DESCRIPTION
Also adds spring-scheduling and jms to list of instrumentation that can be disabled, resolves #1488.

Also adds smoke tests for configurations with disabled instrumentation.