### PR TITLE
Always capture operation_Id on trace/exception

### DIFF
--- a/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
+++ b/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
@@ -324,9 +324,10 @@ public class Exporter implements SpanExporter {
 
         TraceTelemetry telemetry = new TraceTelemetry(message, toSeverityLevel(level));
 
-        if (SpanId.isValid(span.getParentSpanId())) {
-            telemetry.getContext().getOperation().setId(span.getTraceId());
-            telemetry.getContext().getOperation().setParentId(span.getParentSpanId());
+        telemetry.getContext().getOperation().setId(span.getTraceId());
+        String parentSpanId = span.getParentSpanId();
+        if (SpanId.isValid(parentSpanId)) {
+            telemetry.getContext().getOperation().setParentId(parentSpanId);
         }
 
         setLoggerProperties(telemetry.getProperties(), level, loggerName);
@@ -346,9 +347,10 @@ public class Exporter implements SpanExporter {
 
         telemetry.setTimestamp(new Date());
 
-        if (SpanId.isValid(span.getParentSpanId())) {
-            telemetry.getContext().getOperation().setId(span.getTraceId());
-            telemetry.getContext().getOperation().setParentId(span.getParentSpanId());
+        telemetry.getContext().getOperation().setId(span.getTraceId());
+        String parentSpanId = span.getParentSpanId();
+        if (SpanId.isValid(parentSpanId)) {
+            telemetry.getContext().getOperation().setParentId(parentSpanId);
         }
 
         telemetry.getData().setExceptions(Exceptions.minimalParse(errorStack));


### PR DESCRIPTION
Previously, we didn't capture operation_Id on trace/exception records when there was no parent, because there was nothing that it needed to be correlated with.

But it's a bit weird to explain why some trace/exception records don't have an operation_Id.

Opening this as a draft pending discussion with others.