### PR TITLE
Add more instrumentation

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/ConfigOverride.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/ConfigOverride.java
@@ -46,6 +46,7 @@ class ConfigOverride {
         }
         if (!config.preview.openTelemetryApiSupport) {
             properties.put("otel.instrumentation.opentelemetry-api.enabled", "false");
+            properties.put("otel.instrumentation.opentelemetry-annotations.enabled", "false");
         }
         properties.put("otel.propagators", DelegatingPropagatorProvider.NAME);
         // AI exporter is configured manually

--- a/agent/instrumentation/build.gradle
+++ b/agent/instrumentation/build.gradle
@@ -26,10 +26,10 @@ dependencies {
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-http-url-connection', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-java-util-logging-spans', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jaxrs-1.0', version: instrumentationVersion
-    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jaxrs-2.0-common', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jaxrs-2.0-jersey-2.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jaxrs-2.0-resteasy-3.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jaxrs-2.0-resteasy-3.1', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jaxrs-2.0-common', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jdbc', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jedis-1.4', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jedis-3.0', version: instrumentationVersion
@@ -37,10 +37,11 @@ dependencies {
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-jms-1.1', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-kafka-clients-0.11', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-kafka-streams-0.11', version: instrumentationVersion
-    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-lettuce-common', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-kotlinx-coroutines', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-lettuce-4.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-lettuce-5.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-lettuce-5.1', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-lettuce-common', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-log4j-spans-1.2', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-log4j-spans-2.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-logback-spans-1.0', version: instrumentationVersion
@@ -48,17 +49,22 @@ dependencies {
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-mongo-3.1', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-mongo-3.7', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-mongo-async-3.3', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-mongo-common', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-netty-4.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-netty-4.1', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-okhttp-3.0', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-opentelemetry-annotations-1.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-opentelemetry-api-1.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-reactor-3.1', version: instrumentationVersion
-    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-servlet-common', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-reactor-netty-0.9', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-reactor-netty-1.0', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-servlet-2.2', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-servlet-3.0', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-servlet-common', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-spring-scheduling-3.1', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-spring-webmvc-3.1', version: instrumentationVersion
     compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-spring-webflux-5.0', version: instrumentationVersion
+    compile group: 'io.opentelemetry.javaagent.instrumentation', name: 'opentelemetry-javaagent-tomcat-7.0', version: instrumentationVersion
 
     // also: jaxrs, spring, struts
 

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -2,7 +2,9 @@ package com.microsoft.applicationinsights.smoketest;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Predicate;
 import com.microsoft.applicationinsights.internal.schemav2.Data;
 import com.microsoft.applicationinsights.internal.schemav2.DataPoint;
 import com.microsoft.applicationinsights.internal.schemav2.DataPointType;
@@ -379,12 +381,25 @@ public class CoreAndFilterTests extends AiSmokeTest {
 
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
-        List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        List<Envelope> edList = mockedIngestion.waitForItems(new Predicate<Envelope>() {
+            @Override
+            public boolean apply(Envelope input) {
+                if (!"ExceptionData".equals(input.getData().getBaseType())) {
+                    return false;
+                }
+                if (!operationId.equals(input.getTags().get("ai.operation.id"))) {
+                    return false;
+                }
+                // lastly, filter out ExceptionData captured from tomcat logger
+                ExceptionData data = (ExceptionData) ((Data<?>) input.getData()).getBaseData();
+                return !data.getProperties().containsKey("LoggerName");
+            }
+        }, 1, 10, TimeUnit.SECONDS);
 
         Envelope edEnvelope = edList.get(0);
 
-        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
-        ExceptionData ed = (ExceptionData) ((Data) edEnvelope.getData()).getBaseData();
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+        ExceptionData ed = (ExceptionData) ((Data<?>) edEnvelope.getData()).getBaseData();
 
         assertFalse(rd.getSuccess());
 

--- a/test/smoke/testApps/OpenTelemetryApiSupport/build.gradle
+++ b/test/smoke/testApps/OpenTelemetryApiSupport/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     }
 
     compile group: 'io.opentelemetry', name: 'opentelemetry-api', version: '0.17.0'
+    compile group: 'io.opentelemetry', name: 'opentelemetry-extension-annotations', version: '0.17.0'
 
     providedCompile 'javax.servlet:javax.servlet-api:3.0.1'
 }

--- a/test/smoke/testApps/OpenTelemetryApiSupport/src/main/java/com/microsoft/ajl/simple/TestController.java
+++ b/test/smoke/testApps/OpenTelemetryApiSupport/src/main/java/com/microsoft/ajl/simple/TestController.java
@@ -1,6 +1,7 @@
 package com.microsoft.ajl.simple;
 
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.extension.annotations.WithSpan;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,13 +13,22 @@ public class TestController {
         return "OK";
     }
 
-
-    @GetMapping("/test")
-    public String test() {
+    @GetMapping("/test-api")
+    public String testApi() {
         Span.current().setAttribute("myattr1", "myvalue1");
         Span.current().setAttribute("myattr2", "myvalue2");
         Span.current().setAttribute("enduser.id", "myuser");
         Span.current().updateName("myspanname");
+        return "OK!";
+    }
+
+    @GetMapping("/test-annotations")
+    public String testAnnotations() {
+        return underAnnotation();
+    }
+
+    @WithSpan
+    private String underAnnotation() {
         return "OK!";
     }
 }

--- a/test/smoke/testApps/OpenTelemetryApiSupport/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiSupportTest.java
+++ b/test/smoke/testApps/OpenTelemetryApiSupport/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiSupportTest.java
@@ -14,8 +14,8 @@ import static org.junit.Assert.*;
 public class OpenTelemetryApiSupportTest extends AiSmokeTest {
 
     @Test
-    @TargetUri("/test")
-    public void doMostBasicTest() throws Exception {
+    @TargetUri("/test-api")
+    public void testApi() throws Exception {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
 
         Envelope rdEnvelope = rdList.get(0);
@@ -24,8 +24,8 @@ public class OpenTelemetryApiSupportTest extends AiSmokeTest {
 
         Envelope rddEnvelope = rddList.get(0);
 
-        RequestData rd = (RequestData) ((Data) rdEnvelope.getData()).getBaseData();
-        RemoteDependencyData rdd = (RemoteDependencyData) ((Data) rddEnvelope.getData()).getBaseData();
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd = (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
 
         // ideally want these on rd, but can't get SERVER span yet
         // see https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1726#issuecomment-731890267
@@ -35,5 +35,51 @@ public class OpenTelemetryApiSupportTest extends AiSmokeTest {
         assertEquals("myspanname", rdd.getName());
 
         assertTrue(rd.getSuccess());
+
+        assertParentChild(rd.getId(), rdEnvelope, rddEnvelope);
+    }
+
+    @Test
+    @TargetUri("/test-annotations")
+    public void testAnnotations() throws Exception {
+        List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
+
+        Envelope rdEnvelope = rdList.get(0);
+        String operationId = rdEnvelope.getTags().get("ai.operation.id");
+        List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 2, operationId);
+
+        Envelope rddEnvelope1 = rddList.get(0);
+        Envelope rddEnvelope2 = rddList.get(1);
+
+        RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
+        RemoteDependencyData rdd1 = (RemoteDependencyData) ((Data<?>) rddEnvelope1.getData()).getBaseData();
+        RemoteDependencyData rdd2 = (RemoteDependencyData) ((Data<?>) rddEnvelope2.getData()).getBaseData();
+
+        if (!rdd1.getName().equals("TestController.testAnnotations")) {
+            RemoteDependencyData rddTemp = rdd1;
+            rdd1 = rdd2;
+            rdd2 = rddTemp;
+
+            Envelope rddEnvelopeTemp = rddEnvelope1;
+            rddEnvelope1 = rddEnvelope2;
+            rddEnvelope2 = rddEnvelopeTemp;
+        }
+
+        assertEquals("TestController.testAnnotations", rdd1.getName());
+        assertEquals("TestController.underAnnotation", rdd2.getName());
+
+        assertTrue(rd.getSuccess());
+
+        assertParentChild(rd.getId(), rdEnvelope, rddEnvelope1);
+        assertParentChild(rdd1.getId(), rddEnvelope1, rddEnvelope2);
+    }
+
+    private static void assertParentChild(String parentId, Envelope parentEnvelope, Envelope childEnvelope) {
+        String operationId = parentEnvelope.getTags().get("ai.operation.id");
+
+        assertNotNull(operationId);
+
+        assertEquals(operationId, childEnvelope.getTags().get("ai.operation.id"));
+        assertEquals(parentId, childEnvelope.getTags().get("ai.operation.parentId"));
     }
 }

--- a/test/smoke/testApps/SpringCloudStream/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringCloudStreamTest.java
+++ b/test/smoke/testApps/SpringCloudStream/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringCloudStreamTest.java
@@ -53,6 +53,10 @@ public class SpringCloudStreamTest extends AiSmokeTest {
             RemoteDependencyData rddTemp = rdd1;
             rdd1 = rdd2;
             rdd2 = rddTemp;
+
+            Envelope rddEnvelopeTemp = rddEnvelope1;
+            rddEnvelope1 = rddEnvelope2;
+            rddEnvelope2 = rddEnvelopeTemp;
         }
 
         assertEquals("/sendMessage", rd1.getName());

--- a/test/smoke/testApps/WebFlux/src/main/java/com/microsoft/ajl/simple/TestController.java
+++ b/test/smoke/testApps/WebFlux/src/main/java/com/microsoft/ajl/simple/TestController.java
@@ -19,15 +19,12 @@ public class TestController {
     @GetMapping("/test/**")
     public Mono<String> test() {
         CompletableFuture<String> completableFuture = new CompletableFuture<>();
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                }
-                completableFuture.complete("hello");
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ignored) {
             }
+            completableFuture.complete("hello");
         });
         return Mono.fromFuture(completableFuture);
     }
@@ -40,15 +37,12 @@ public class TestController {
     @GetMapping("/futureException")
     public Mono<String> futureException() {
         CompletableFuture<String> completableFuture = new CompletableFuture<>();
-        Executors.newSingleThreadExecutor().execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                }
-                completableFuture.completeExceptionally(new RuntimeException("oops!"));
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ignored) {
             }
+            completableFuture.completeExceptionally(new RuntimeException("oops!"));
         });
         return Mono.fromFuture(completableFuture);
     }


### PR DESCRIPTION
Adds the following instrumentation:
* opentelemetry-annotations
* reactor-netty (this is important to spring ecosystem)
* kotlinx-coroutintes (this was split out of java-concurrent instrumentation)
* tomcat (this captures server requests earlier, which can lead to correctly capturing response code in cases where it wasn't previously)

Only added smoke test for `opentelemetry-annotations`. The others I think are ok to only rely on OpenTelemetry tests.