### PR TITLE
Update submodule

### DIFF
--- a/agent/agent-tooling/build.gradle
+++ b/agent/agent-tooling/build.gradle
@@ -64,8 +64,8 @@ dependencies {
     compile 'org.slf4j:jcl-over-slf4j:1.7.30'
 
     compile(project(':agent:exporter'))
-    compile 'io.opentelemetry:opentelemetry-sdk-extension-tracing-incubator:0.17.0-alpha'
-    compile 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:0.17.0-alpha'
+    compile 'io.opentelemetry:opentelemetry-sdk-extension-tracing-incubator:1.0.0-alpha'
+    compile 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.0.0-alpha'
 
     compileOnly(project(':agent:agent-bootstrap'))
     testCompile(project(':agent:agent-bootstrap'))

--- a/agent/exporter/build.gradle
+++ b/agent/exporter/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.opentelemetry:opentelemetry-sdk:0.17.0'
+    compile 'io.opentelemetry:opentelemetry-sdk:1.0.0'
 
     // this is needed in order to access AiAppId for appId exchange data
     compileOnly group: 'io.opentelemetry.instrumentation', name: 'opentelemetry-instrumentation-api', version: '0.17.0+ai.patch.1-alpha'

--- a/test/smoke/testApps/OpenTelemetryApiSupport/build.gradle
+++ b/test/smoke/testApps/OpenTelemetryApiSupport/build.gradle
@@ -19,8 +19,8 @@ dependencies {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
     }
 
-    compile group: 'io.opentelemetry', name: 'opentelemetry-api', version: '0.17.0'
-    compile group: 'io.opentelemetry', name: 'opentelemetry-extension-annotations', version: '0.17.0'
+    compile group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.0.0'
+    compile group: 'io.opentelemetry', name: 'opentelemetry-extension-annotations', version: '1.0.0'
 
     providedCompile 'javax.servlet:javax.servlet-api:3.0.1'
 }


### PR DESCRIPTION
Updates to the latest otel-java-instrumentation (in preparation for otel-java-instrumentation 1.0.0 next week).

Includes a fix (https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2430) that is needed for #1513.