### PR TITLE
Fix GHA branch name

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   setup-smoke-test-matrix:


### PR DESCRIPTION
Noticed that the CI build (on merge) wasn't running GHA.