### PR TITLE
Downgrade some info logging to debug level

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/propagator/AiLegacyPropagator.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/propagator/AiLegacyPropagator.java
@@ -94,7 +94,7 @@ public class AiLegacyPropagator implements TextMapPropagator {
         try {
             traceId = legacyOperationId;
         } catch (IllegalArgumentException e) {
-            logger.info("Request-Id root part is not compatible with trace-id.");
+            logger.debug("Request-Id root part is not compatible with trace-id.");
             // see behavior specified at
             // https://github.com/microsoft/ApplicationInsights-Java/issues/1174
             traceId = TraceId.fromLongs(random.nextLong(), random.nextLong());

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionPolicyManager.java
@@ -200,7 +200,7 @@ public final class TransmissionPolicyManager implements TransmissionHandler {
 
         policyState.setCurrentState(TransmissionPolicy.UNBLOCKED);
         suspensionDate = null;
-        logger.info("App throttling is cancelled.");
+        logger.debug("App throttling is cancelled.");
     }
 
     private synchronized void createScheduler() {


### PR DESCRIPTION
Generally preserving info logging (which is logged by default) for startup logging.

These two places can be downgraded to debug level.