### PR TITLE
Always write to log on startup failure

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/MainEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/MainEntryPoint.java
@@ -21,9 +21,12 @@
 package com.microsoft.applicationinsights.agent.internal.wasbootstrap;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.lang.instrument.Instrumentation;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -158,7 +161,7 @@ public class MainEntryPoint {
                 String tmpDir = System.getProperty("java.io.tmpdir");
                 File file = new File(tmpDir, "applicationinsights.log");
                 try {
-                    FileWriter out = new FileWriter(file);
+                    Writer out = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
                     out.write(message);
                     out.close();
                 } catch (Throwable ignored2) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
@@ -64,6 +64,7 @@ public class ConfigurationBuilder {
     private static final String APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL";
 
     private static final String APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_LEVEL = "APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_LEVEL";
+    public static final String APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_FILE_PATH = "APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_FILE_PATH";
 
     private static final String APPLICATIONINSIGHTS_PREVIEW_OTEL_API_SUPPORT = "APPLICATIONINSIGHTS_PREVIEW_OTEL_API_SUPPORT";
 
@@ -223,6 +224,7 @@ public class ConfigurationBuilder {
         config.sampling.percentage = overlayWithEnvVar(APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE, config.sampling.percentage);
 
         config.selfDiagnostics.level = overlayWithEnvVar(APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_LEVEL, config.selfDiagnostics.level);
+        config.selfDiagnostics.file.path = overlayWithEnvVar(APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_FILE_PATH, config.selfDiagnostics.file.path);
 
         config.preview.openTelemetryApiSupport = overlayWithEnvVar(APPLICATIONINSIGHTS_PREVIEW_OTEL_API_SUPPORT, config.preview.openTelemetryApiSupport);
 
@@ -255,7 +257,7 @@ public class ConfigurationBuilder {
         return value;
     }
 
-    static String overlayWithEnvVar(String name, String defaultValue) {
+    public static String overlayWithEnvVar(String name, String defaultValue) {
         String value = getEnvVar(name);
         return value != null ? value : defaultValue;
     }

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationTest.java
@@ -338,6 +338,16 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void shouldOverrideSelfDiagnosticsFilePath() throws IOException {
+        envVars.set("APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_FILE_PATH", "/tmp/ai.log");
+
+        Configuration configuration = loadConfiguration();
+        ConfigurationBuilder.overlayEnvVars(configuration);
+
+        assertEquals("/tmp/ai.log", configuration.selfDiagnostics.file.path);
+    }
+
+    @Test
     public void shouldOverridePreviewOtelApiSupport() throws IOException {
         envVars.set("APPLICATIONINSIGHTS_PREVIEW_OTEL_API_SUPPORT", "true");
 


### PR DESCRIPTION
Also introduces env var `APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_FILE_PATH`, which can also be helpful in this case for redirecting log file to another location.