### PR TITLE
Sdk name improvements

### DIFF
--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/DiagnosticsHelper.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/DiagnosticsHelper.java
@@ -25,11 +25,9 @@ public class DiagnosticsHelper {
 	public static final String IPA_ETW_PROVIDER_ENABLED_ENV_VAR = "APPLICATIONINSIGHTS_EXTENSION_ETW_PROVIDER_ENABLED";
 
     // visible for testing
-    static volatile boolean appServiceCodeless;
+    static volatile boolean appSvcAttachForLoggingPurposes;
 
-    private static volatile boolean aksCodeless;
-
-    private static volatile boolean functionsCodeless;
+    private static volatile char attachChar;
 
     private static final boolean isWindows;
 
@@ -46,47 +44,40 @@ public class DiagnosticsHelper {
 
     public static void setAgentJarFile(Path agentPath) {
         if (Files.exists(agentPath.resolveSibling("appsvc.codeless"))) {
-            appServiceCodeless = true;
+            appSvcAttachForLoggingPurposes = true;
+            if ("java".equals(System.getenv("FUNCTIONS_WORKER_RUNTIME"))) {
+                attachChar = 'f';
+            } else {
+                attachChar = 'a';
+            }
         } else if (Files.exists(agentPath.resolveSibling("aks.codeless"))) {
-            aksCodeless = true;
+            attachChar = 'k';
         } else if (Files.exists(agentPath.resolveSibling("functions.codeless"))) {
-            functionsCodeless = true;
+            attachChar = 'f';
+        } else if (Files.exists(agentPath.resolveSibling("springcloud.codeless"))) {
+            attachChar = 's';
         }
     }
 
-    public static boolean isAppServiceCodeless() {
-        return appServiceCodeless;
+    public static boolean isAnyAttach() {
+        return attachChar != 0;
     }
 
-    public static boolean isAksCodeless() {
-        return aksCodeless;
+    // returns 0 if not attach
+    public static char attachChar() {
+        return attachChar;
     }
 
-    public static boolean isFunctionsCodeless() {
-        return functionsCodeless;
-    }
-
-    public static boolean isAnyCodelessAttach() {
-        return appServiceCodeless || aksCodeless || functionsCodeless;
+    // this also applies to Azure Functions running on App Services
+    public static boolean isAppSvcAttachForLoggingPurposes() {
+        return appSvcAttachForLoggingPurposes;
     }
 
     public static ApplicationMetadataFactory getMetadataFactory() {
         return METADATA_FACTORY;
     }
 
-	public static String getCodelessResourceType() {
-        if (appServiceCodeless) {
-            return "appsvc";
-        } else if (aksCodeless) {
-            return "aks";
-        } else if (functionsCodeless) {
-            return "functions";
-        }
-        return null;
-	}
-
 	public static boolean isOsWindows() {
         return isWindows;
     }
-
 }

--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/status/StatusFile.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/status/StatusFile.java
@@ -125,7 +125,7 @@ public class StatusFile {
 
     // visible for testing
     static boolean shouldWrite() {
-        return enabled && DiagnosticsHelper.isAppServiceCodeless();
+        return enabled && DiagnosticsHelper.isAppSvcAttachForLoggingPurposes();
     }
 
     public static <T> void putValueAndWrite(String key, T value) {

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/DiagnosticsTestHelper.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/DiagnosticsTestHelper.java
@@ -4,12 +4,12 @@ public class DiagnosticsTestHelper {
     private DiagnosticsTestHelper() {
     }
 
-    public static void setIsAppServiceCodeless(boolean appServiceCodeless) {
-        DiagnosticsHelper.appServiceCodeless = appServiceCodeless;
+    public static void setIsAppSvcAttachForLoggingPurposes(boolean appSvcAttachForLoggingPurposes) {
+        DiagnosticsHelper.appSvcAttachForLoggingPurposes = appSvcAttachForLoggingPurposes;
     }
 
     public static void reset() {
-        setIsAppServiceCodeless(false);
+        setIsAppSvcAttachForLoggingPurposes(false);
     }
 
 }

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsDiagnosticsLogFilterTests.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsDiagnosticsLogFilterTests.java
@@ -17,7 +17,7 @@ public class ApplicationInsightsDiagnosticsLogFilterTests {
 
     @Before
     public void setup() {
-        DiagnosticsTestHelper.setIsAppServiceCodeless(true);
+        DiagnosticsTestHelper.setIsAppSvcAttachForLoggingPurposes(true);
         filter = new ApplicationInsightsDiagnosticsLogFilter();
         mockEvent = mock(ILoggingEvent.class);
         when(mockEvent.getLevel()).thenReturn(Level.ERROR);

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/status/StatusFileTests.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/status/StatusFileTests.java
@@ -129,13 +129,13 @@ public class StatusFileTests {
     @Test
     public void ifEnabledVarHasInvalidValueThenItIsEnabled() throws Exception {
         envVars.set(StatusFile.STATUS_FILE_ENABLED_ENV_VAR, "42");
-        DiagnosticsTestHelper.setIsAppServiceCodeless(true);
+        DiagnosticsTestHelper.setIsAppSvcAttachForLoggingPurposes(true);
         runWriteFileTest(true);
     }
 
     @Test
     public void writesCorrectFile() throws Exception {
-        DiagnosticsTestHelper.setIsAppServiceCodeless(true);
+        DiagnosticsTestHelper.setIsAppSvcAttachForLoggingPurposes(true);
         runWriteFileTest(true);
     }
 
@@ -171,7 +171,7 @@ public class StatusFileTests {
 
     @Test
     public void doesNotWriteIfNotAppService() throws Exception {
-        DiagnosticsTestHelper.setIsAppServiceCodeless(false); // just to be sure
+        DiagnosticsTestHelper.setIsAppSvcAttachForLoggingPurposes(false); // just to be sure
 
         final File tempFolder = this.tempFolder.newFolder();
         StatusFile.directory = tempFolder.getAbsolutePath();
@@ -189,7 +189,7 @@ public class StatusFileTests {
     public void putValueAndWriteOverwritesCurrentFile() throws Exception {
         final String key = "write-test";
         try {
-            DiagnosticsTestHelper.setIsAppServiceCodeless(true);
+            DiagnosticsTestHelper.setIsAppSvcAttachForLoggingPurposes(true);
 
 
             final File tempFolder = this.tempFolder.newFolder();
@@ -210,7 +210,7 @@ public class StatusFileTests {
             assertMapHasExpectedInformation(map, key, value);
 
         } finally {
-            DiagnosticsTestHelper.setIsAppServiceCodeless(false);
+            DiagnosticsTestHelper.setIsAppSvcAttachForLoggingPurposes(false);
             StatusFile.CONSTANT_VALUES.remove(key);
         }
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
@@ -196,16 +196,11 @@ public class AiComponentInstaller implements ComponentInstaller {
 
     @Nullable
     private static String getCodelessSdkNamePrefix() {
-        StringBuilder sdkNamePrefix = new StringBuilder(4);
-        if (DiagnosticsHelper.isAppServiceCodeless()) {
-            sdkNamePrefix.append("a");
-        } else if (DiagnosticsHelper.isAksCodeless()) {
-            sdkNamePrefix.append("k");
-        } else if (DiagnosticsHelper.isFunctionsCodeless()) {
-            sdkNamePrefix.append("f");
-        } else {
+        if (!DiagnosticsHelper.isAnyAttach()) {
             return null;
         }
+        StringBuilder sdkNamePrefix = new StringBuilder(4);
+        sdkNamePrefix.append(DiagnosticsHelper.attachChar());
         if (SystemInformation.INSTANCE.isWindows()) {
             sdkNamePrefix.append("w");
         } else if (SystemInformation.INSTANCE.isUnix()) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/MainEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/MainEntryPoint.java
@@ -154,7 +154,7 @@ public class MainEntryPoint {
     private static Logger configureLogging(SelfDiagnostics selfDiagnostics, Path agentPath) {
         String logbackXml;
         String destination = selfDiagnostics.destination;
-        if (DiagnosticsHelper.isAppServiceCodeless()) {
+        if (DiagnosticsHelper.isAppSvcAttachForLoggingPurposes()) {
             // User-accessible IPA log file. Enabled by default.
             if ("false".equalsIgnoreCase(System.getenv(DiagnosticsHelper.IPA_LOG_FILE_ENABLED_ENV_VAR))) {
                 System.setProperty("ai.config.appender.user-logdir.location", "");

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
@@ -160,11 +160,6 @@ public class ConfigurationBuilder {
             return getConfigurationFromEnvVar(configurationContent, true);
         }
 
-        if (DiagnosticsHelper.isAnyCodelessAttach()) {
-            // codeless attach only supports configuration via environment variables (for now at least)
-            return new Configuration();
-        }
-
         String configPathStr = getConfigPath();
         if (configPathStr != null) {
             Path configPath = agentJarPath.resolveSibling(configPathStr);


### PR DESCRIPTION
Two sdk name improvements:

* use `f*r_java` when running in Azure Functions on App Services (instead of `awr_java`)
* use `s*r_java` when running in Spring Cloud with `springcloud.codeless` marker file

(and removed the restriction on using json files with attach, since spring cloud uses one)