### PR TITLE
Bump version to 3.0.3-BETA.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 // Project properties
-version=3.0.3-BETA
+version=3.0.3-BETA.2
 group=com.microsoft.azure


### PR DESCRIPTION
Next version will probably be 3.0.3 (GA), but bumping to 3.0.3-BETA.2 in the meantime so that snapshot builds don't still say 3.0.3-BETA-SNAPSHOT.