### PR TITLE
Respect parent sampled unless override match

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
@@ -180,7 +180,7 @@ public class AiComponentInstaller implements ComponentInstaller {
 
         RpConfiguration rpConfiguration = MainEntryPoint.getRpConfiguration();
         if (rpConfiguration != null) {
-            RpConfigurationPolling.startPolling(rpConfiguration, config.preview.sampling.overrides);
+            RpConfigurationPolling.startPolling(rpConfiguration, config);
         }
     }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
@@ -1,29 +1,30 @@
 package com.microsoft.applicationinsights.agent.internal.sampling;
 
-import java.util.List;
-
-import com.microsoft.applicationinsights.agent.internal.wasbootstrap.configuration.Configuration.SamplingOverride;
+import com.microsoft.applicationinsights.agent.internal.wasbootstrap.configuration.Configuration;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
 public class Samplers {
 
-    public static Sampler getSampler(double samplingPercentage, List<SamplingOverride> overrides) {
-        SamplingOverrides samplingOverrides = new SamplingOverrides(overrides);
-        AiSampler aiSampler = new AiSampler(samplingPercentage, samplingOverrides);
-        return Sampler.parentBasedBuilder(aiSampler)
-                // TODO change the default behavior, and provide preview flag to treat "00" as
-                // for now, we have to override default behavior of "alwaysOff"
-                // because .NET SDK always propagates trace flags "00" (not sampled)
-                .setRemoteParentNotSampled(aiSampler)
+    public static Sampler getSampler(double samplingPercentage, Configuration config) {
+        SamplingOverrides samplingOverrides = new SamplingOverrides(config.preview.sampling.overrides);
+        AiSampler rootSampler = new AiSampler(samplingPercentage, samplingOverrides,
+                AiSampler.BehaviorIfNoMatchingOverrides.USE_DEFAULT_SAMPLING_PERCENTAGE);
+        AiSampler parentSampledSampler = new AiSampler(samplingPercentage, samplingOverrides,
+                AiSampler.BehaviorIfNoMatchingOverrides.RECORD_AND_SAMPLE);
+        // ignoreRemoteParentNotSampled is sometimes needed
+        // because .NET SDK always propagates trace flags "00" (not sampled)
+        Sampler remoteParentNotSampled = config.preview.ignoreRemoteParentNotSampled ? rootSampler : Sampler.alwaysOff();
+        return Sampler.parentBasedBuilder(rootSampler)
+                .setRemoteParentNotSampled(remoteParentNotSampled)
                 // this is the default, just including it for completeness
                 // intentionally not allowing to capture a downstream span when upstream span has not been sampled
                 // because this will lead to broken traces in A (sampled) -> B (not sampled) -> C (sampled)
                 // C will point to parent B, but B will not be exported
                 .setLocalParentNotSampled(Sampler.alwaysOff())
                 // can filter out subtree of sampled trace, by applying sampling override
-                .setRemoteParentSampled(aiSampler)
+                .setRemoteParentSampled(parentSampledSampler)
                 // can filter out subtree of sampled trace, by applying sampling override
-                .setLocalParentSampled(aiSampler)
+                .setLocalParentSampled(parentSampledSampler)
                 .build();
     }
 }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/OpenTelemetryConfigurer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/OpenTelemetryConfigurer.java
@@ -36,7 +36,7 @@ public class OpenTelemetryConfigurer implements SdkTracerProviderConfigurer {
 
         if (config.connectionString != null) {
             DelegatingPropagator.getInstance().setUpStandardDelegate();
-            DelegatingSampler.getInstance().setDelegate(Samplers.getSampler(config.sampling.percentage, config.preview.sampling.overrides));
+            DelegatingSampler.getInstance().setDelegate(Samplers.getSampler(config.sampling.percentage, config));
         } else {
             // in Azure Functions, we configure later on, once we know user has opted in to tracing
             // (note: the default for DelegatingPropagator is to not propagate anything

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/Configuration.java
@@ -171,6 +171,7 @@ public class Configuration {
         // not sure if we'll be able to have different metric intervals in future OpenTelemetry metrics world,
         // so safer to only allow single interval for now
         public int metricIntervalSeconds = 60;
+        public boolean ignoreRemoteParentNotSampled;
         public LiveMetrics liveMetrics = new LiveMetrics();
     }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
@@ -262,6 +262,9 @@ public class ConfigurationBuilder {
         if (rpConfiguration.sampling != null) {
             config.sampling.percentage = rpConfiguration.sampling.percentage;
         }
+        if (rpConfiguration.ignoreRemoteParentNotSampled != null) {
+            config.preview.ignoreRemoteParentNotSampled = rpConfiguration.ignoreRemoteParentNotSampled;
+        }
     }
 
     private static String getConfigPath() {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/RpConfiguration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/RpConfiguration.java
@@ -21,9 +21,10 @@
 
 package com.microsoft.applicationinsights.agent.internal.wasbootstrap.configuration;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.nio.file.Path;
 
-// currently only Azure Spring Cloud uses this
 public class RpConfiguration {
 
     // transient so that Moshi will ignore when binding from json
@@ -33,8 +34,13 @@ public class RpConfiguration {
     public transient long lastModifiedTime;
 
     public String connectionString;
+
     // intentionally null, so that we can tell if rp is providing or not
     public Sampling sampling = new Sampling();
+
+    // this is needed in Azure Functions because .NET SDK always propagates trace flags "00" (not sampled)
+    // null means do not override the users selection
+    public @Nullable Boolean ignoreRemoteParentNotSampled;
 
     public static class Sampling {
 

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/RpConfigurationPollingTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/RpConfigurationPollingTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import com.google.common.io.Resources;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.agent.internal.sampling.DelegatingSampler;
+import com.microsoft.applicationinsights.agent.internal.wasbootstrap.configuration.Configuration;
 import com.microsoft.applicationinsights.agent.internal.wasbootstrap.configuration.ConfigurationBuilder;
 import com.microsoft.applicationinsights.agent.internal.wasbootstrap.configuration.RpConfiguration;
 import org.junit.*;
@@ -59,7 +60,7 @@ public class RpConfigurationPollingTest {
         Global.setSamplingPercentage(ConfigurationBuilder.roundToNearest(rpConfiguration.sampling.percentage));
 
         // when
-        new RpConfigurationPolling(rpConfiguration, Collections.emptyList()).run();
+        new RpConfigurationPolling(rpConfiguration, new Configuration()).run();
 
         // then
         assertEquals("InstrumentationKey=00000000-0000-0000-0000-000000000000", TelemetryConfiguration.getActive().getConnectionString());
@@ -81,7 +82,7 @@ public class RpConfigurationPollingTest {
         envVars.set("APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE", "90");
 
         // when
-        new RpConfigurationPolling(rpConfiguration, Collections.emptyList()).run();
+        new RpConfigurationPolling(rpConfiguration, new Configuration()).run();
 
         // then
         assertEquals("InstrumentationKey=00000000-0000-0000-0000-000000000000", TelemetryConfiguration.getActive().getConnectionString());

--- a/test/smoke/appServers/global-resources/telemetryfiltering2_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/telemetryfiltering2_applicationinsights.json
@@ -1,0 +1,23 @@
+{
+  "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:6060/",
+  "sampling": {
+    "percentage": 50
+  },
+  "preview": {
+    "sampling": {
+      "overrides": [
+        {
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": ".*/login",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 100,
+          "id": "capture all login telemetry"
+        }
+      ]
+    }
+  }
+}

--- a/test/smoke/testApps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
+++ b/test/smoke/testApps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
@@ -21,7 +21,8 @@ public class SamplingTest extends AiSmokeTest {
         Thread.sleep(SECONDS.toMillis(10));
         int requestCount = mockedIngestion.getCountForType("RequestData");
         int eventCount = mockedIngestion.getCountForType("EventData");
-        // super super low chance that number of sampled requests/events is greater than 75
+        // super super low chance that number of sampled requests/events
+        // is less than 25 or greater than 75
         assertThat(requestCount, greaterThanOrEqualTo(25));
         assertThat(eventCount, greaterThanOrEqualTo(25));
         assertThat(requestCount, lessThanOrEqualTo(75));

--- a/test/smoke/testApps/TelemetryFiltering/src/main/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFilteringTestServlet.java
+++ b/test/smoke/testApps/TelemetryFiltering/src/main/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFilteringTestServlet.java
@@ -47,6 +47,11 @@ public class TelemetryFilteringTestServlet extends HttpServlet {
             executeStatement(connection);
             connection.close();
             return 200;
+        } else if (pathInfo.equals("/login")) {
+            Connection connection = getHsqldbConnection();
+            executeStatement(connection);
+            connection.close();
+            return 200;
         } else if (pathInfo.equals("/noisy-jdbc")) {
             Connection connection = getHsqldbConnection();
             executeNoisyStatement(connection);

--- a/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFiltering2SmokeTest.java
+++ b/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFiltering2SmokeTest.java
@@ -1,34 +1,17 @@
 package com.microsoft.applicationinsights.smoketestapp;
 
-import com.google.common.base.Stopwatch;
-import com.microsoft.applicationinsights.internal.schemav2.Data;
-import com.microsoft.applicationinsights.internal.schemav2.Envelope;
-import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
-import com.microsoft.applicationinsights.internal.schemav2.RequestData;
 import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
 import com.microsoft.applicationinsights.smoketest.TargetUri;
 import com.microsoft.applicationinsights.smoketest.UseAgent;
 import org.junit.Test;
-
-import java.util.List;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
 
 @UseAgent("telemetryfiltering2")
 public class TelemetryFiltering2SmokeTest extends AiSmokeTest {
 
     @Test
     @TargetUri(value = "/login", callCount = 100)
-    public void testSampling() {
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        while (mockedIngestion.getCountForType("RequestData") < 100
-                && mockedIngestion.getCountForType("RemoteDependencyData") < 100
-                && stopwatch.elapsed(SECONDS) < 10) {
-        }
-        assertEquals(100, mockedIngestion.getCountForType("RequestData"));
-        assertEquals(100, mockedIngestion.getCountForType("RemoteDependencyData"));
+    public void testSampling() throws Exception {
+        mockedIngestion.waitForItems("RequestData", 100);
+        mockedIngestion.waitForItems("RemoteDependencyData", 100);
     }
 }

--- a/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFiltering2SmokeTest.java
+++ b/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFiltering2SmokeTest.java
@@ -1,0 +1,34 @@
+package com.microsoft.applicationinsights.smoketestapp;
+
+import com.google.common.base.Stopwatch;
+import com.microsoft.applicationinsights.internal.schemav2.Data;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
+import com.microsoft.applicationinsights.internal.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.internal.schemav2.RequestData;
+import com.microsoft.applicationinsights.smoketest.AiSmokeTest;
+import com.microsoft.applicationinsights.smoketest.TargetUri;
+import com.microsoft.applicationinsights.smoketest.UseAgent;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.*;
+
+@UseAgent("telemetryfiltering2")
+public class TelemetryFiltering2SmokeTest extends AiSmokeTest {
+
+    @Test
+    @TargetUri(value = "/login", callCount = 100)
+    public void testSampling() {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        while (mockedIngestion.getCountForType("RequestData") < 100
+                && mockedIngestion.getCountForType("RemoteDependencyData") < 100
+                && stopwatch.elapsed(SECONDS) < 10) {
+        }
+        assertEquals(100, mockedIngestion.getCountForType("RequestData"));
+        assertEquals(100, mockedIngestion.getCountForType("RemoteDependencyData"));
+    }
+}

--- a/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFilteringSmokeTest.java
+++ b/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFilteringSmokeTest.java
@@ -29,9 +29,13 @@ public class TelemetryFilteringSmokeTest extends AiSmokeTest {
         // wait ten more seconds to before checking that we didn't receive too many
         Thread.sleep(SECONDS.toMillis(10));
         int requestCount = mockedIngestion.getCountForType("RequestData");
-        // super super low chance that number of sampled requests is greater than 75
+        int dependencyCount = mockedIngestion.getCountForType("RemoteDependencyData");
+        // super super low chance that number of sampled requests/dependencies
+        // is less than 25 or greater than 75
         assertThat(requestCount, greaterThanOrEqualTo(25));
+        assertThat(dependencyCount, greaterThanOrEqualTo(25));
         assertThat(requestCount, lessThanOrEqualTo(75));
+        assertThat(dependencyCount, lessThanOrEqualTo(75));
     }
 
     @Test


### PR DESCRIPTION
For example, if upstream span decides to sample 100% of `/login` requests, then downstream spans should respect that decision (as long as there is no specific override match for the downstream span), instead of applying the default sampling percentage to the downstream spans.