### PR TITLE
Fix sampling rate recorded for dependencies

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/propagator/DelegatingPropagator.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/propagator/DelegatingPropagator.java
@@ -3,6 +3,11 @@ package com.microsoft.applicationinsights.agent.internal.propagator;
 import java.util.Collection;
 import javax.annotation.Nullable;
 
+import com.microsoft.applicationinsights.agent.Exporter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
@@ -21,8 +26,13 @@ public class DelegatingPropagator implements TextMapPropagator {
     }
 
     public void setUpStandardDelegate() {
+
+        // TODO when should we enable baggage propagation?
+        // currently using modified W3CTraceContextPropagator because "ai-internal-sp" trace state
+        // shouldn't be sent over the wire (at least not yet, and not with that name)
+
         // important that W3CTraceContextPropagator is last, so it will take precedence if both sets of headers are present
-        delegate = TextMapPropagator.composite(AiLegacyPropagator.getInstance(), W3CTraceContextPropagator.getInstance());
+        delegate = TextMapPropagator.composite(AiLegacyPropagator.getInstance(), new ModifiedW3CTraceContextPropagator());
     }
 
     @Override
@@ -38,5 +48,75 @@ public class DelegatingPropagator implements TextMapPropagator {
     @Override
     public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
         return delegate.extract(context, carrier, getter);
+    }
+
+    private static class ModifiedW3CTraceContextPropagator implements TextMapPropagator {
+
+        private final TextMapPropagator delegate = W3CTraceContextPropagator.getInstance();
+
+        @Override
+        public Collection<String> fields() {
+            return delegate.fields();
+        }
+
+        @Override
+        public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
+            // do not propagate sampling percentage downstream YET
+            SpanContext spanContext = Span.fromContext(context).getSpanContext();
+            // sampling percentage should always be present, so no need to optimize with checking if present
+            TraceState traceState = spanContext.getTraceState();
+            TraceState updatedTraceState;
+            if (traceState.size() == 1 && traceState.get(Exporter.SAMPLING_PERCENTAGE_TRACE_STATE) != null) {
+                // this is a common case, worth optimizing
+                updatedTraceState = TraceState.getDefault();
+            } else {
+                updatedTraceState = traceState.toBuilder()
+                        .remove(Exporter.SAMPLING_PERCENTAGE_TRACE_STATE)
+                        .build();
+            }
+            SpanContext updatedSpanContext = new ModifiedSpanContext(spanContext, updatedTraceState);
+            delegate.inject(Context.root().with(Span.wrap(updatedSpanContext)), carrier, setter);
+        }
+
+        @Override
+        public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+            return delegate.extract(context, carrier, getter);
+        }
+    }
+
+    private static class ModifiedSpanContext implements SpanContext {
+
+        private final SpanContext delegate;
+        private final TraceState traceState;
+
+        private ModifiedSpanContext(SpanContext delegate, TraceState traceState) {
+            this.delegate = delegate;
+            this.traceState = traceState;
+        }
+
+        @Override
+        public String getTraceId() {
+            return delegate.getTraceId();
+        }
+
+        @Override
+        public String getSpanId() {
+            return delegate.getSpanId();
+        }
+
+        @Override
+        public TraceFlags getTraceFlags() {
+            return delegate.getTraceFlags();
+        }
+
+        @Override
+        public TraceState getTraceState() {
+            return traceState;
+        }
+
+        @Override
+        public boolean isRemote() {
+            return delegate.isRemote();
+        }
     }
 }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
@@ -13,6 +13,8 @@ public class Samplers {
                 AiSampler.BehaviorIfNoMatchingOverrides.RECORD_AND_SAMPLE);
         // ignoreRemoteParentNotSampled is sometimes needed
         // because .NET SDK always propagates trace flags "00" (not sampled)
+        // NOTE: once we start propagating sampling percentage over the wire, we can use that to know that we can
+        // respect upstream decision for remoteParentNotSampled
         Sampler remoteParentNotSampled = config.preview.ignoreRemoteParentNotSampled ? rootSampler : Sampler.alwaysOff();
         return Sampler.parentBasedBuilder(rootSampler)
                 .setRemoteParentNotSampled(remoteParentNotSampled)

--- a/test/smoke/testApps/Sampling/build.gradle
+++ b/test/smoke/testApps/Sampling/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     testCompile 'com.google.guava:guava:23.0' // VSCODE intellisense bug workaround
 
     testCompile group:'org.hamcrest', name:'hamcrest-library', version:'1.3'
+
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.7'
 }
 
 tasks.withType(JavaCompile) {

--- a/test/smoke/testApps/Sampling/src/main/java/com/microsoft/ajl/simplecalc/SimpleSamplingServlet.java
+++ b/test/smoke/testApps/Sampling/src/main/java/com/microsoft/ajl/simplecalc/SimpleSamplingServlet.java
@@ -10,6 +10,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.telemetry.EventTelemetry;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 @WebServlet(description = "sends 100 event telemetry items with different op ids", urlPatterns = { "/sampling" })
 public class SimpleSamplingServlet extends HttpServlet {
@@ -21,7 +24,10 @@ public class SimpleSamplingServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
         ServletFuncs.getRenderedHtml(request, response);
-        client.trackTrace("Trace Test.");
+
+        CloseableHttpClient httpClient = HttpClientBuilder.create().disableAutomaticRetries().build();
+        httpClient.execute(new HttpGet("https://www.bing.com")).close();
+
         client.trackEvent(new EventTelemetry("Event Test " + count.getAndIncrement()));
     }
 }

--- a/test/smoke/testApps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
+++ b/test/smoke/testApps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
@@ -1,6 +1,9 @@
 package com.microsoft.applicationinsights.smoketest;
 
+import java.util.List;
+
 import com.google.common.base.Stopwatch;
+import com.microsoft.applicationinsights.internal.schemav2.Envelope;
 import org.junit.*;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -17,15 +20,35 @@ public class SamplingTest extends AiSmokeTest {
         Stopwatch stopwatch = Stopwatch.createStarted();
         while (mockedIngestion.getCountForType("RequestData") < 25 && stopwatch.elapsed(SECONDS) < 10) {
         }
-        // wait ten more seconds to before checking that we didn't receive too many
+        // wait ten more seconds before checking that we didn't receive too many
         Thread.sleep(SECONDS.toMillis(10));
-        int requestCount = mockedIngestion.getCountForType("RequestData");
-        int eventCount = mockedIngestion.getCountForType("EventData");
-        // super super low chance that number of sampled requests/events
+
+        List<Envelope> requestEnvelopes = mockedIngestion.getItemsEnvelopeDataType("RequestData");
+        List<Envelope> dependencyEnvelopes = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
+        List<Envelope> eventEnvelopes = mockedIngestion.getItemsEnvelopeDataType("EventData");
+        // super super low chance that number of sampled requests/dependencies/events
         // is less than 25 or greater than 75
-        assertThat(requestCount, greaterThanOrEqualTo(25));
-        assertThat(eventCount, greaterThanOrEqualTo(25));
-        assertThat(requestCount, lessThanOrEqualTo(75));
-        assertThat(eventCount, lessThanOrEqualTo(75));
+        assertThat(requestEnvelopes.size(), greaterThanOrEqualTo(25));
+        assertThat(requestEnvelopes.size(), lessThanOrEqualTo(75));
+        assertThat(dependencyEnvelopes.size(), greaterThanOrEqualTo(25));
+        assertThat(dependencyEnvelopes.size(), lessThanOrEqualTo(75));
+        assertThat(eventEnvelopes.size(), greaterThanOrEqualTo(25));
+        assertThat(eventEnvelopes.size(), lessThanOrEqualTo(75));
+
+        for (Envelope requestEnvelope : requestEnvelopes) {
+            assertEquals(50, requestEnvelope.getSampleRate(), 0);
+        }
+        for (Envelope dependencyEnvelope : dependencyEnvelopes) {
+            assertEquals(50, dependencyEnvelope.getSampleRate(), 0);
+        }
+        for (Envelope eventEnvelope : eventEnvelopes) {
+            assertEquals(50, eventEnvelope.getSampleRate(), 0);
+        }
+
+        for (Envelope requestEnvelope : requestEnvelopes) {
+            String operationId = requestEnvelope.getTags().get("ai.operation.id");
+            mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+            mockedIngestion.waitForItemsInOperation("EventData", 1, operationId);
+        }
     }
 }


### PR DESCRIPTION
Refreshed #1477

We do have a need for variable sampling percentages now with [sampling overrides](https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-sampling-overrides), so I think it makes sense to go ahead with using trace state, even if it's a bit hacky until the OTel spec is (hopefully) completed, at which time we can propagate the trace state over the wire too.