### PR TITLE
Update azure sdk preview config

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/ConfigOverride.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/ConfigOverride.java
@@ -46,7 +46,7 @@ class ConfigOverride {
             properties.put("otel.instrumentation.opentelemetry-api.enabled", "false");
             properties.put("otel.instrumentation.opentelemetry-annotations.enabled", "false");
         }
-        if (!config.preview.azureSdkInstrumentation) {
+        if (!config.preview.instrumentation.azureSdk.enabled) {
             properties.put("otel.instrumentation.azure-sdk.enabled", "false");
         }
         properties.put("otel.propagators", DelegatingPropagatorProvider.NAME);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/Configuration.java
@@ -167,7 +167,7 @@ public class Configuration {
         public SamplingPreview sampling = new SamplingPreview();
         public List<ProcessorConfig> processors = new ArrayList<>();
         public boolean openTelemetryApiSupport;
-        public boolean azureSdkInstrumentation;
+        public PreviewInstrumentation instrumentation = new PreviewInstrumentation();
         // applies to perf counters, default custom metrics, jmx metrics, and micrometer metrics
         // not sure if we'll be able to have different metric intervals in future OpenTelemetry metrics world,
         // so safer to only allow single interval for now
@@ -178,6 +178,14 @@ public class Configuration {
         public LiveMetrics liveMetrics = new LiveMetrics();
 
         public ProfilerConfiguration profiler = new ProfilerConfiguration();
+    }
+
+    public static class PreviewInstrumentation {
+        public AzureSdkInstrumentation azureSdk = new AzureSdkInstrumentation();
+    }
+
+    public static class AzureSdkInstrumentation {
+        public boolean enabled;
     }
 
     public static class LiveMetrics {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
@@ -67,7 +67,7 @@ public class ConfigurationBuilder {
     public static final String APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_FILE_PATH = "APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_FILE_PATH";
 
     private static final String APPLICATIONINSIGHTS_PREVIEW_OTEL_API_SUPPORT = "APPLICATIONINSIGHTS_PREVIEW_OTEL_API_SUPPORT";
-    private static final String APPLICATIONINSIGHTS_PREVIEW_AZURE_SDK_INSTRUMENTATION = "APPLICATIONINSIGHTS_PREVIEW_AZURE_SDK_INSTRUMENTATION";
+    private static final String APPLICATIONINSIGHTS_PREVIEW_INSTRUMENTATION_AZURE_SDK_ENABLED = "APPLICATIONINSIGHTS_PREVIEW_INSTRUMENTATION_AZURE_SDK_ENABLED";
 
     private static final String APPLICATIONINSIGHTS_PREVIEW_LIVE_METRICS_ENABLED = "APPLICATIONINSIGHTS_PREVIEW_LIVE_METRICS_ENABLED";
 
@@ -254,7 +254,7 @@ public class ConfigurationBuilder {
                 (int) overlayWithEnvVar(APPLICATIONINSIGHTS_PREVIEW_METRIC_INTERVAL_SECONDS, config.preview.metricIntervalSeconds);
 
         config.preview.openTelemetryApiSupport = overlayWithEnvVar(APPLICATIONINSIGHTS_PREVIEW_OTEL_API_SUPPORT, config.preview.openTelemetryApiSupport);
-        config.preview.azureSdkInstrumentation = overlayWithEnvVar(APPLICATIONINSIGHTS_PREVIEW_AZURE_SDK_INSTRUMENTATION, config.preview.azureSdkInstrumentation);
+        config.preview.instrumentation.azureSdk.enabled = overlayWithEnvVar(APPLICATIONINSIGHTS_PREVIEW_INSTRUMENTATION_AZURE_SDK_ENABLED, config.preview.instrumentation.azureSdk.enabled);
 
         config.preview.liveMetrics.enabled = overlayWithEnvVar(APPLICATIONINSIGHTS_PREVIEW_LIVE_METRICS_ENABLED, config.preview.liveMetrics.enabled);
 

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationTest.java
@@ -359,12 +359,12 @@ public class ConfigurationTest {
 
     @Test
     public void shouldOverridePreviewAzureSdkInstrumentation() throws IOException {
-        envVars.set("APPLICATIONINSIGHTS_PREVIEW_AZURE_SDK_INSTRUMENTATION", "true");
+        envVars.set("APPLICATIONINSIGHTS_PREVIEW_INSTRUMENTATION_AZURE_SDK_ENABLED", "true");
 
         Configuration configuration = loadConfiguration();
         ConfigurationBuilder.overlayEnvVars(configuration);
 
-        assertTrue(configuration.preview.azureSdkInstrumentation);
+        assertTrue(configuration.preview.instrumentation.azureSdk.enabled);
     }
 
     @Test

--- a/test/smoke/appServers/global-resources/azuresdk_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/azuresdk_applicationinsights.json
@@ -1,6 +1,10 @@
 {
   "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://fakeingestion:6060/",
   "preview": {
-    "azureSdkInstrumentation": true
+    "instrumentation": {
+      "azureSdk": {
+        "enabled": true
+      }
+    }
   }
 }


### PR DESCRIPTION
Improved the new preview config option to be consistent with non-preview options:

```
{
  "preview": {
    "instrumentation": {
      "azureSdk": {
        "enabled": true
      }
    }
  }
}
```