### PR TITLE
Suppress redis encoding events

### DIFF
--- a/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
+++ b/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
@@ -616,6 +616,12 @@ public class Exporter implements SpanExporter {
 
     private void exportEvents(SpanData span, Double samplingPercentage) {
         for (EventData event : span.getEvents()) {
+            boolean lettuce51 =
+                    span.getInstrumentationLibraryInfo().getName().equals("io.opentelemetry.javaagent.lettuce-5.1");
+            if (lettuce51 && event.getName().startsWith("redis.encode.")) {
+                // special case as these are noisy and come from the underlying library itself
+                continue;
+            }
             EventTelemetry telemetry = new EventTelemetry(event.getName());
             String operationId = span.getTraceId();
             telemetry.getContext().getOperation().setId(operationId);

--- a/test/smoke/testApps/AzureSdk/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/AzureSdkDisabledTest.java
+++ b/test/smoke/testApps/AzureSdk/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/AzureSdkDisabledTest.java
@@ -21,6 +21,7 @@ public class AzureSdkDisabledTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/AzureSdk/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/AzureSdkTest.java
+++ b/test/smoke/testApps/AzureSdk/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/AzureSdkTest.java
@@ -21,6 +21,7 @@ public class AzureSdkTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 2, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope1 = rddList.get(0);
         Envelope rddEnvelope2 = rddList.get(1);

--- a/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JedisTest.java
+++ b/test/smoke/testApps/CachingCalculator/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JedisTest.java
@@ -23,6 +23,7 @@ public class JedisTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/Cassandra/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/CassandraTest.java
+++ b/test/smoke/testApps/Cassandra/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/CassandraTest.java
@@ -33,6 +33,7 @@ public class CassandraTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -52,6 +52,7 @@ public class CoreAndFilterTests extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -114,6 +115,7 @@ public class CoreAndFilterTests extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 3, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope1 = edList.get(0);
         Envelope edEnvelope2 = edList.get(1);
@@ -255,6 +257,7 @@ public class CoreAndFilterTests extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> pvdList = mockedIngestion.waitForItemsInOperation("PageViewData", 3, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
@@ -337,6 +340,7 @@ public class CoreAndFilterTests extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> pvdList = mockedIngestion.waitForItemsInOperation("PageViewData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope pvdEnvelope = pvdList.get(0);
 

--- a/test/smoke/testApps/HttpClients/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/HttpClientSmokeTest.java
+++ b/test/smoke/testApps/HttpClients/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/HttpClientSmokeTest.java
@@ -24,6 +24,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -51,6 +52,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -78,6 +80,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -105,6 +108,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -132,6 +136,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -160,6 +165,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -187,6 +193,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -214,6 +221,7 @@ public class HttpClientSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsDisabledTest.java
+++ b/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsDisabledTest.java
@@ -22,6 +22,8 @@ public class JmsDisabledTest extends AiSmokeTest {
 
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
+
         Envelope rddEnvelope = rddList.get(0);
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
 

--- a/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsTest.java
+++ b/test/smoke/testApps/JMS/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/JmsTest.java
@@ -21,6 +21,7 @@ public class JmsTest extends AiSmokeTest {
         Envelope rdEnvelope1 = getRequestEnvelope(rdList, "/sendMessage");
         String operationId = rdEnvelope1.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 3, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rdEnvelope2 = getRequestEnvelope(rdList, "message process");
         Envelope rddEnvelope1 = getDependencyEnvelope(rddList, "HelloController.sendMessage");

--- a/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
+++ b/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
@@ -47,6 +47,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -75,6 +76,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -103,6 +105,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -135,6 +138,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -165,6 +169,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -267,6 +272,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -295,6 +301,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -323,6 +330,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -350,6 +358,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -379,6 +388,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -408,6 +418,7 @@ public class JdbcTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaDisabledTest.java
+++ b/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaDisabledTest.java
@@ -40,6 +40,8 @@ public class KafkaDisabledTest extends AiSmokeTest {
 
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
+
         Envelope rddEnvelope = rddList.get(0);
         RemoteDependencyData rdd = (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
 

--- a/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
+++ b/test/smoke/testApps/Kafka/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/KafkaTest.java
@@ -39,6 +39,7 @@ public class KafkaTest extends AiSmokeTest {
         Envelope rdEnvelope1 = getRequestEnvelope(rdList, "/sendMessage");
         String operationId = rdEnvelope1.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 3, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rdEnvelope2 = getRequestEnvelope(rdList, "mytopic process");
         Envelope rddEnvelope1 = getDependencyEnvelope(rddList, "HelloController.sendMessage");

--- a/test/smoke/testApps/Lettuce/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/LettuceTest.java
+++ b/test/smoke/testApps/Lettuce/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/LettuceTest.java
@@ -22,6 +22,7 @@ public class LettuceTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/MongoDB/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/MongoTest.java
+++ b/test/smoke/testApps/MongoDB/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/MongoTest.java
@@ -32,6 +32,7 @@ public class MongoTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/OpenTelemetryApiSupport/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiSupportDisabledTest.java
+++ b/test/smoke/testApps/OpenTelemetryApiSupport/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiSupportDisabledTest.java
@@ -21,6 +21,7 @@ public class OpenTelemetryApiSupportDisabledTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/OpenTelemetryApiSupport/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiSupportTest.java
+++ b/test/smoke/testApps/OpenTelemetryApiSupport/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiSupportTest.java
@@ -21,6 +21,7 @@ public class OpenTelemetryApiSupportTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 
@@ -51,6 +52,7 @@ public class OpenTelemetryApiSupportTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 2, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope1 = rddList.get(0);
         Envelope rddEnvelope2 = rddList.get(1);

--- a/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
+++ b/test/smoke/testApps/SpringBootTest/src/smokeTest/java/com/springbootstartertest/smoketest/SpringbootSmokeTest.java
@@ -108,6 +108,7 @@ public class SpringbootSmokeTest extends AiSmokeTest {
                 return !data.getProperties().containsKey("LoggerName");
             }
         }, 2, 10, TimeUnit.SECONDS);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
         Envelope edEnvelope1 = edList.get(0);
@@ -138,6 +139,7 @@ public class SpringbootSmokeTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 3, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope1 = rddList.get(0);
         Envelope rddEnvelope2 = rddList.get(1);

--- a/test/smoke/testApps/SpringCloudStream/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringCloudStreamTest.java
+++ b/test/smoke/testApps/SpringCloudStream/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SpringCloudStreamTest.java
@@ -39,6 +39,7 @@ public class SpringCloudStreamTest extends AiSmokeTest {
         Envelope rdEnvelope1 = rdList.get(0);
         String operationId = rdEnvelope1.getTags().get("ai.operation.id");
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 2, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rdEnvelope2 = rdList.get(1);
         Envelope rddEnvelope1 = rddList.get(0);

--- a/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFilteringSmokeTest.java
+++ b/test/smoke/testApps/TelemetryFiltering/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/TelemetryFilteringSmokeTest.java
@@ -61,6 +61,7 @@ public class TelemetryFilteringSmokeTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         List<Envelope> rddList = mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope rddEnvelope = rddList.get(0);
 

--- a/test/smoke/testApps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
+++ b/test/smoke/testApps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
@@ -55,6 +55,7 @@ public class TraceJavaUtilLoggingTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope = edList.get(0);
 

--- a/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -66,6 +66,7 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope = edList.get(0);
 

--- a/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
+++ b/test/smoke/testApps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j1_2Test.java
@@ -72,6 +72,7 @@ public class TraceLog4j1_2Test extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope = edList.get(0);
 

--- a/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -67,6 +67,7 @@ public class TraceLog4j2Test extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope = edList.get(0);
 

--- a/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/test/smoke/testApps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -73,6 +73,7 @@ public class TraceLog4j2Test extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope = edList.get(0);
 

--- a/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -61,6 +61,7 @@ public class TraceLogBackTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope = edList.get(0);
 

--- a/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/test/smoke/testApps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -67,6 +67,7 @@ public class TraceLogBackTest extends AiSmokeTest {
         Envelope rdEnvelope = rdList.get(0);
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
         List<Envelope> edList = mockedIngestion.waitForItemsInOperation("ExceptionData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         Envelope edEnvelope = edList.get(0);
 

--- a/test/smoke/testApps/WebFlux/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebFluxTest.java
+++ b/test/smoke/testApps/WebFlux/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/WebFluxTest.java
@@ -21,6 +21,7 @@ public class WebFluxTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
@@ -39,6 +40,7 @@ public class WebFluxTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
@@ -57,6 +59,7 @@ public class WebFluxTest extends AiSmokeTest {
         String operationId = rdEnvelope.getTags().get("ai.operation.id");
 
         mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
+        assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 


### PR DESCRIPTION
These events are pretty noisy, and not necessary, so it's reasonable to suppress them. Plus they also don't correspond to any OTel semantic conventions.

Resolves #1586