### PR TITLE
Fix sporadic CI failure

### DIFF
--- a/test/smoke/testApps/Sampling/src/main/java/com/microsoft/applicationinsights/smoketestapp/SimpleSamplingServlet.java
+++ b/test/smoke/testApps/Sampling/src/main/java/com/microsoft/applicationinsights/smoketestapp/SimpleSamplingServlet.java
@@ -25,9 +25,6 @@ public class SimpleSamplingServlet extends HttpServlet {
             throws IOException {
         ServletFuncs.getRenderedHtml(request, response);
 
-        CloseableHttpClient httpClient = HttpClientBuilder.create().disableAutomaticRetries().build();
-        httpClient.execute(new HttpGet("https://www.bing.com")).close();
-
         client.trackEvent(new EventTelemetry("Event Test " + count.getAndIncrement()));
     }
 }

--- a/test/smoke/testApps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
+++ b/test/smoke/testApps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
@@ -24,22 +24,16 @@ public class SamplingTest extends AiSmokeTest {
         Thread.sleep(SECONDS.toMillis(10));
 
         List<Envelope> requestEnvelopes = mockedIngestion.getItemsEnvelopeDataType("RequestData");
-        List<Envelope> dependencyEnvelopes = mockedIngestion.getItemsEnvelopeDataType("RemoteDependencyData");
         List<Envelope> eventEnvelopes = mockedIngestion.getItemsEnvelopeDataType("EventData");
         // super super low chance that number of sampled requests/dependencies/events
         // is less than 25 or greater than 75
         assertThat(requestEnvelopes.size(), greaterThanOrEqualTo(25));
         assertThat(requestEnvelopes.size(), lessThanOrEqualTo(75));
-        assertThat(dependencyEnvelopes.size(), greaterThanOrEqualTo(25));
-        assertThat(dependencyEnvelopes.size(), lessThanOrEqualTo(75));
         assertThat(eventEnvelopes.size(), greaterThanOrEqualTo(25));
         assertThat(eventEnvelopes.size(), lessThanOrEqualTo(75));
 
         for (Envelope requestEnvelope : requestEnvelopes) {
             assertEquals(50, requestEnvelope.getSampleRate(), 0);
-        }
-        for (Envelope dependencyEnvelope : dependencyEnvelopes) {
-            assertEquals(50, dependencyEnvelope.getSampleRate(), 0);
         }
         for (Envelope eventEnvelope : eventEnvelopes) {
             assertEquals(50, eventEnvelope.getSampleRate(), 0);
@@ -47,7 +41,6 @@ public class SamplingTest extends AiSmokeTest {
 
         for (Envelope requestEnvelope : requestEnvelopes) {
             String operationId = requestEnvelope.getTags().get("ai.operation.id");
-            mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
             mockedIngestion.waitForItemsInOperation("EventData", 1, operationId);
         }
     }


### PR DESCRIPTION
Resolves #1620

The problem is that the sampling test sends 100 requests in rapid succession, and the downstream dependency connection to www.bing.com sometimes fails. The downstream dependency test is not really needed, as the test already has downstream custom event to make sure sampling affects downstream spans.