### PR TITLE
Fix for jdbc target and duplicate headers

### DIFF
--- a/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
+++ b/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
@@ -509,15 +509,29 @@ public class Exporter implements SpanExporter {
 
     private static int getDefaultPortForDbSystem(String dbSystem) {
         switch (dbSystem) {
-            // TODO replace these with constants from OpenTelemetry API after upgrading to 0.10.0
-            // TODO add these default ports to the OpenTelemetry database semantic conventions spec
-            // TODO need to add more default ports once jdbc instrumentation reports net.peer.*
-            case "mongodb":
+            // jdbc default ports are from io.opentelemetry.javaagent.instrumentation.jdbc.JdbcConnectionUrlParser
+            // TODO make these ports constants (at least in JdbcConnectionUrlParser) so they can be used here
+            case SemanticAttributes.DbSystemValues.MONGODB:
                 return 27017;
-            case "cassandra":
+            case SemanticAttributes.DbSystemValues.CASSANDRA:
                 return 9042;
-            case "redis":
+            case SemanticAttributes.DbSystemValues.REDIS:
                 return 6379;
+            case SemanticAttributes.DbSystemValues.MARIADB:
+            case SemanticAttributes.DbSystemValues.MYSQL:
+                return 3306;
+            case SemanticAttributes.DbSystemValues.MSSQL:
+                return 1433;
+            case SemanticAttributes.DbSystemValues.DB2:
+                return 50000;
+            case SemanticAttributes.DbSystemValues.ORACLE:
+                return 1521;
+            case SemanticAttributes.DbSystemValues.H2:
+                return 8082;
+            case SemanticAttributes.DbSystemValues.DERBY:
+                return 1527;
+            case SemanticAttributes.DbSystemValues.POSTGRESQL:
+                return 5432;
             default:
                 return 0;
         }

--- a/test/smoke/testApps/Jdbc/build.gradle
+++ b/test/smoke/testApps/Jdbc/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'war'
 
 dependencies {
     implementation group: 'org.hsqldb', name: 'hsqldb', version: '2.3.6' // 2.4.0+ requires Java 8+
-    implementation group: 'mysql', name: 'mysql-connector-java', version: '5.1.43' // the old agent did not support 8.x
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '5.1.49'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.16.jre7'
     implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '8.4.1.jre8'
     implementation group: 'com.google.guava', name: 'guava', version: '27.1-android'

--- a/test/smoke/testApps/Jdbc/src/main/java/com/microsoft/applicationinsights/smoketestapp/JdbcTestServlet.java
+++ b/test/smoke/testApps/Jdbc/src/main/java/com/microsoft/applicationinsights/smoketestapp/JdbcTestServlet.java
@@ -21,6 +21,7 @@ import org.hsqldb.jdbc.JDBCDriver;
 @WebServlet("/*")
 public class JdbcTestServlet extends HttpServlet {
 
+    @Override
     public void init() throws ServletException {
         try {
             setupHsqldb();
@@ -282,7 +283,7 @@ public class JdbcTestServlet extends HttpServlet {
 
     private static Connection getMysqlConnection() throws Exception {
         String hostname = System.getenv("MYSQL");
-        return DriverManager.getConnection("jdbc:mysql://" + hostname + "/mysql?autoReconnect=true&useSSL=true&verifyServerCertificate=false", "root", "password");
+        return DriverManager.getConnection("jdbc:mysql://" + hostname + "/mysql?autoReconnect=true&useSSL=true&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3&verifyServerCertificate=false", "root", "password");
     }
 
     private static Connection getPostgresConnection() throws Exception {

--- a/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
+++ b/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
@@ -220,7 +220,8 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc where xyz = ?"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("mysql", rdd.getTarget()); // not the best test, because this is both the db.name and db.system
+        // not the best test, because this is both the db.name and db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+/mysql"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());
@@ -255,7 +256,8 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("mysql", rdd.getTarget()); // not the best test, because this is both the db.name and db.system
+        // not the best test, because this is both the db.name and db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+/mysql"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());
@@ -284,7 +286,8 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc where xyz = ?"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("postgres", rdd.getTarget()); // not the best test, because this is both the db.name and db.system
+        // not the best test, because this is both the db.name and db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+/postgres"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());
@@ -313,7 +316,8 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("postgres", rdd.getTarget()); // not the best test, because this is both the db.name and db.system
+        // not the best test, because this is both the db.name and db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+/postgres"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());
@@ -341,7 +345,7 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc where xyz = ?"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("mssql", rdd.getTarget()); // this is the db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());
@@ -370,7 +374,7 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("mssql", rdd.getTarget()); // this is the db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());
@@ -400,7 +404,7 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc where xyz = ?"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("oracle", rdd.getTarget()); // this is the db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+"));
         assertEquals("select * from abc where xyz = ?", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());
@@ -430,7 +434,7 @@ public class JdbcTest extends AiSmokeTest {
 
         assertTrue(rdd.getName().startsWith("select * from abc"));
         assertEquals("SQL", rdd.getType());
-        assertEquals("oracle", rdd.getTarget()); // this is the db.system
+        assertTrue(rdd.getTarget().matches("dependency[0-9]+"));
         assertEquals("select * from abc", rdd.getData());
         assertTrue(rdd.getProperties().isEmpty());
         assertTrue(rdd.getSuccess());


### PR DESCRIPTION
Update otel fork submodule, see: #1645

Updates Jdbc smoke tests due to the new (better) target attribute.

Fixes an unrelated issue where the Jdbc smoke tests just started failing due to recent update in mysql image that requires enabling TLSv1.3 in the driver

Resolves #1640

Attaching SNAPSHOT release from this PR: [applicationinsights-agent-3.0.4-BETA-SNAPSHOT.jar.zip](https://github.com/microsoft/ApplicationInsights-Java/files/6362473/applicationinsights-agent-3.0.4-BETA-SNAPSHOT.jar.zip)
