### PR TITLE
fix instrumental jdbc sybase

### DIFF
--- a/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -17,8 +17,10 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -52,6 +54,18 @@ public class PreparedStatementInstrumentation implements TypeInstrumentation {
         @Advice.Local("otelRequest") DbRequest request,
         @Advice.Local("otelContext") Context context,
         @Advice.Local("otelScope") Scope scope) {
+		
+      // Connection#getMetaData() may execute a Statement or PreparedStatement to retrieve DB info
+      // this happens before the DB CLIENT span is started (and put in the current context), so this
+      // instrumentation runs again and the shouldStartSpan() check always returns true - and so on
+      // until we get a StackOverflowError
+      // using CallDepth prevents this, because this check happens before Connection#getMetadata()
+      // is called - the first recursive Statement call is just skipped and we do not create a span
+      // for it
+      if (CallDepthThreadLocalMap.getCallDepth(Statement.class).getAndIncrement() > 0) {
+        return;
+      }
+		
       Context parentContext = currentContext();
       request = DbRequest.create(statement);
 
@@ -72,6 +86,7 @@ public class PreparedStatementInstrumentation implements TypeInstrumentation {
       if (scope == null) {
         return;
       }
+      CallDepthThreadLocalMap.reset(Statement.class);
 
       scope.close();
       instrumenter().end(context, request, null, throwable);


### PR DESCRIPTION
Fix jdbc instrumentation
Recursive statements inside Connection#getMetaData

Connection#getMetaData() may execute a Statement or PreparedStatement to retrieve DB info. This happens before the DB CLIENT span is started (and put in the current context), so this instrumentation runs again and the shouldStartSpan() check always returns true - and so on until we get a StackOverflowError using CallDepth prevents this, because this check happens before Connection#getMetadata() is called - the first recursive Statement call is just skipped and we do not create a span for it