### PR TITLE
Capture http method in operation name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+# Version 3.1.0
+* Capture http method in the operation name [#1679](https://github.com/microsoft/ApplicationInsights-Java/pull/1679)
+
 # Version 3.0.4-BETA.2
 * Enable users to override iKey, cloud role name and cloud role instance per telemetry [#1630](https://github.com/microsoft/ApplicationInsights-Java/pull/1630).
 * Fix duplicate headers [#1640](https://github.com/microsoft/ApplicationInsights-Java/pull/1640).

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/OpenTelemetryConfigurer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/OpenTelemetryConfigurer.java
@@ -54,8 +54,8 @@ public class OpenTelemetryConfigurer implements SdkTracerProviderConfigurer {
 
                 if (currExporter == null) {
                     currExporter = processorConfig.type == ProcessorType.attribute ?
-                            new ExporterWithAttributeProcessor(processorConfig, new Exporter(telemetryClient, config.preview.httpMethodInOperationName)) :
-                            new ExporterWithSpanProcessor(processorConfig, new Exporter(telemetryClient, config.preview.httpMethodInOperationName));
+                            new ExporterWithAttributeProcessor(processorConfig, new Exporter(telemetryClient)) :
+                            new ExporterWithSpanProcessor(processorConfig, new Exporter(telemetryClient));
 
                 } else {
                     currExporter = processorConfig.type == ProcessorType.attribute ?
@@ -67,7 +67,7 @@ public class OpenTelemetryConfigurer implements SdkTracerProviderConfigurer {
             tracerProvider.addSpanProcessor(SimpleSpanProcessor.create(currExporter));
 
         } else {
-            tracerProvider.addSpanProcessor(SimpleSpanProcessor.create(new Exporter(telemetryClient, config.preview.httpMethodInOperationName)));
+            tracerProvider.addSpanProcessor(SimpleSpanProcessor.create(new Exporter(telemetryClient)));
         }
     }
 }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/Configuration.java
@@ -136,6 +136,7 @@ public class Configuration {
     public static class MicrometerInstrumentation {
         public boolean enabled = true;
         // this is just here to detect if using this old undocumented setting in order to give a helpful error message
+        @Deprecated
         public int reportingIntervalSeconds = 60;
     }
 
@@ -176,7 +177,8 @@ public class Configuration {
         // ignoreRemoteParentNotSampled is currently needed
         // because .NET SDK always propagates trace flags "00" (not sampled)
         public boolean ignoreRemoteParentNotSampled = true;
-        // TODO consider turning this on by default in 3.1.0
+        // this is just here to detect if using this old setting in order to give a helpful message
+        @Deprecated
         public boolean httpMethodInOperationName;
         public LiveMetrics liveMetrics = new LiveMetrics();
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/configuration/ConfigurationBuilder.java
@@ -95,6 +95,10 @@ public class ConfigurationBuilder {
                             " (and note that metricIntervalSeconds applies to all auto-collected metrics," +
                             " not only micrometer)"));
         }
+        if (config.preview.httpMethodInOperationName) {
+            configurationWarnMessages.add(new ConfigurationWarnMessage(
+                    "\"httpMethodInOperationName\" preview setting is now the (one and only) default behavior"));
+        }
         overlayEnvVars(config);
         applySamplingPercentageRounding(config);
         // rp configuration should always be last (so it takes precedence)

--- a/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
+++ b/agent/exporter/src/main/java/com/microsoft/applicationinsights/agent/Exporter.java
@@ -128,11 +128,8 @@ public class Exporter implements SpanExporter {
 
     private final TelemetryClient telemetryClient;
 
-    private final boolean httpMethodInOperationName;
-
-    public Exporter(TelemetryClient telemetryClient, boolean httpMethodInOperationName) {
+    public Exporter(TelemetryClient telemetryClient) {
         this.telemetryClient = telemetryClient;
-        this.httpMethodInOperationName = httpMethodInOperationName;
     }
 
     /**
@@ -623,7 +620,7 @@ public class Exporter implements SpanExporter {
 
     private String getTelemetryName(SpanData span) {
         String name = span.getName();
-        if (!httpMethodInOperationName || !name.startsWith("/")) {
+        if (!name.startsWith("/")) {
             return name;
         }
         String httpMethod = span.getAttributes().get(SemanticAttributes.HTTP_METHOD);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 // Project properties
-version=3.0.4-BETA.3
+version=3.1.0
 group=com.microsoft.azure

--- a/test/smoke/appServers/global-resources/azuresdk_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/azuresdk_applicationinsights.json
@@ -1,7 +1,6 @@
 {
   "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://host.docker.internal:6060/",
   "preview": {
-    "httpMethodInOperationName": true,
     "instrumentation": {
       "azureSdk": {
         "enabled": true

--- a/test/smoke/appServers/global-resources/customdimensions_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/customdimensions_applicationinsights.json
@@ -4,8 +4,5 @@
     "test": "value",
     "home": "${HOME}",
     "service.version": "123"
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/custominstrumentation_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/custominstrumentation_applicationinsights.json
@@ -1,7 +1,6 @@
 {
   "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://host.docker.internal:6060/",
   "preview": {
-    "httpMethodInOperationName": true,
     "customInstrumentation": [
       {
         "className": "com.microsoft.applicationinsights.smoketestapp.TargetObject",

--- a/test/smoke/appServers/global-resources/default_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/default_applicationinsights.json
@@ -3,8 +3,5 @@
   "role": {
     "name": "testrolename",
     "instance": "testroleinstance"
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_cassandra_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_cassandra_applicationinsights.json
@@ -4,8 +4,5 @@
     "cassandra": {
       "enabled": false
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_jdbc_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_jdbc_applicationinsights.json
@@ -4,8 +4,5 @@
     "jdbc": {
       "enabled": false
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_jms_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_jms_applicationinsights.json
@@ -4,8 +4,5 @@
     "jms": {
       "enabled": false
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_kafka_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_kafka_applicationinsights.json
@@ -4,8 +4,5 @@
     "kafka": {
       "enabled": false
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_micrometer_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_micrometer_applicationinsights.json
@@ -6,7 +6,6 @@
     }
   },
   "preview": {
-    "httpMethodInOperationName": true,
     "metricIntervalSeconds": 5
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_mongo_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_mongo_applicationinsights.json
@@ -4,8 +4,5 @@
     "mongo": {
       "enabled": false
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_redis_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_redis_applicationinsights.json
@@ -4,8 +4,5 @@
     "redis": {
       "enabled": false
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/disabled_springscheduling_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/disabled_springscheduling_applicationinsights.json
@@ -4,8 +4,5 @@
     "springScheduling": {
       "enabled": false
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/fastheartbeat_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/fastheartbeat_applicationinsights.json
@@ -2,8 +2,5 @@
   "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://host.docker.internal:6060/",
   "heartbeat": {
     "intervalSeconds": 30
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/fastmetrics_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/fastmetrics_applicationinsights.json
@@ -2,8 +2,5 @@
   "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://host.docker.internal:6060/",
   "preview": {
     "metricIntervalSeconds": 5
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/logging_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/logging_applicationinsights.json
@@ -4,8 +4,5 @@
     "logging": {
       "level": "warn"
     }
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/micrometer_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/micrometer_applicationinsights.json
@@ -1,7 +1,6 @@
 {
   "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://host.docker.internal:6060/",
   "preview": {
-    "httpMethodInOperationName": true,
     "metricIntervalSeconds": 5
   }
 }

--- a/test/smoke/appServers/global-resources/opentelemetryapisupport_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/opentelemetryapisupport_applicationinsights.json
@@ -5,7 +5,6 @@
     "instance": "testroleinstance"
   },
   "preview": {
-    "httpMethodInOperationName": true,
     "openTelemetryApiSupport": true
   }
 }

--- a/test/smoke/appServers/global-resources/sampling_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/sampling_applicationinsights.json
@@ -2,8 +2,5 @@
   "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://host.docker.internal:6060/",
   "sampling": {
     "percentage": 50
-  },
-  "preview": {
-    "httpMethodInOperationName": true
   }
 }

--- a/test/smoke/appServers/global-resources/telemetryfiltering2_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/telemetryfiltering2_applicationinsights.json
@@ -4,7 +4,6 @@
     "percentage": 50
   },
   "preview": {
-    "httpMethodInOperationName": true,
     "sampling": {
       "overrides": [
         {

--- a/test/smoke/appServers/global-resources/telemetryfiltering_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/telemetryfiltering_applicationinsights.json
@@ -4,7 +4,6 @@
     "percentage": 100
   },
   "preview": {
-    "httpMethodInOperationName": true,
     "sampling": {
       "overrides": [
         {

--- a/test/smoke/appServers/global-resources/telemetryprocessors_applicationinsights.json
+++ b/test/smoke/appServers/global-resources/telemetryprocessors_applicationinsights.json
@@ -1,7 +1,6 @@
 {
     "connectionString": "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint=http://host.docker.internal:6060/",
     "preview": {
-      "httpMethodInOperationName": true,
       "processors" : [
         {
           "type": "attribute",


### PR DESCRIPTION
Bumping version to 3.1.0 since this is a significant change, will add "Upgrade from 3.0" page to official doc site to mention this.