### PR TITLE
Fix a NullPointerException in appsvc testing env.

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/OshiPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/OshiPerformanceCounter.java
@@ -60,13 +60,13 @@ public class OshiPerformanceCounter implements PerformanceCounter {
             processor = systemInfo.getHardware().getProcessor();
         }
 
-
         long currCollectionTimeMillis = System.currentTimeMillis();
         long currProcessBytes = 0L;
         if (processInfo != null) {
             updateAttributes(processInfo);
             currProcessBytes = getProcessBytes(processInfo);
         }
+
         long currTotalProcessorMillis = getTotalProcessorMillis(processor);
 
         if (prevCollectionTimeMillis != 0) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/OshiPerformanceCounter.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/perfcounter/OshiPerformanceCounter.java
@@ -85,7 +85,7 @@ public class OshiPerformanceCounter implements PerformanceCounter {
     }
 
     private static void updateAttributes(OSProcess processInfo) {
-        if (!processInfo.updateAttributes()) {
+        if (processInfo != null && !processInfo.updateAttributes()) {
             logger.debug("could not update process attributes");
         }
     }


### PR DESCRIPTION
recurring nullpointerexception in AppSvc environment log.

`2021-05-12 20:49:59.904Z ERROR c.m.a.i.p.PerformanceCounterContainer - Exception while reporting performance counter 'JSDK_OshiPerformanceCounter'
java.lang.NullPointerException: null
	at com.microsoft.applicationinsights.internal.perfcounter.OshiPerformanceCounter.updateAttributes(OshiPerformanceCounter.java:88)
	at com.microsoft.applicationinsights.internal.perfcounter.OshiPerformanceCounter.report(OshiPerformanceCounter.java:65)
	at com.microsoft.applicationinsights.internal.perfcounter.PerformanceCounterContainer$1.run(PerformanceCounterContainer.java:231)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)`