### PR TITLE
Fix bug in initialising JFR integration when used with older Java 8

### DIFF
--- a/agent/agent-profiler/agent-service-profiler/gradle/dependency-locks/compileClasspath.lockfile
+++ b/agent/agent-profiler/agent-service-profiler/gradle/dependency-locks/compileClasspath.lockfile
@@ -14,7 +14,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.2
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.2
 com.fasterxml.jackson:jackson-bom:2.12.2
 com.fasterxml.woodstox:woodstox-core:6.2.4
-com.microsoft.jfr:jfr-streaming:1.1.0
+com.microsoft.jfr:jfr-streaming:1.2.0
 com.microsoft.rest.v2:client-runtime:2.1.1
 com.squareup.moshi:moshi-adapters:1.9.3
 com.squareup.moshi:moshi:1.9.3

--- a/agent/agent-profiler/agent-service-profiler/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/agent/agent-profiler/agent-service-profiler/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -14,7 +14,7 @@ com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.2
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.2
 com.fasterxml.jackson:jackson-bom:2.12.2
 com.fasterxml.woodstox:woodstox-core:6.2.4
-com.microsoft.jfr:jfr-streaming:1.1.0
+com.microsoft.jfr:jfr-streaming:1.2.0
 com.microsoft.rest.v2:client-runtime:2.1.1
 com.squareup.moshi:moshi-adapters:1.9.3
 com.squareup.moshi:moshi:1.9.3

--- a/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
+++ b/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
@@ -33,6 +33,7 @@ import com.microsoft.jfr.JfrStreamingException;
 import com.microsoft.jfr.Recording;
 import com.microsoft.jfr.RecordingConfiguration;
 import com.microsoft.jfr.RecordingOptions;
+import com.microsoft.jfr.dcmd.FlightRecorderDiagnosticCommandConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,7 +140,12 @@ public class JfrProfiler implements ProfilerConfigurationHandler, Profiler {
         try {
             // connect to mbeans
             MBeanServerConnection mBeanServer = ManagementFactory.getPlatformMBeanServer();
-            flightRecorderConnection = FlightRecorderConnection.connect(mBeanServer);
+            try {
+                flightRecorderConnection = FlightRecorderConnection.connect(mBeanServer);
+            } catch (JfrStreamingException | InstanceNotFoundException jfrStreamingException) {
+                // Possibly an older JVM, try using Diagnostic command
+                flightRecorderConnection = FlightRecorderDiagnosticCommandConnection.connect(mBeanServer);
+            }
         } catch (Exception e) {
             LOGGER.error("Failed to connect to mbean", e);
             return false;

--- a/agent/instrumentation/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/agent/instrumentation/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -28,7 +28,6 @@ io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-caching:1.0.0
 io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-jaxws-2.0-axis2-1.6:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-jaxws-2.0-cxf-3.0:1.0.0+ai.patch.1-alpha
-io.opentelemetry.instrumentation:opentelemetry-jaxws-common:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-lettuce-5.1:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-netty-4.1:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:1.0.0+ai.patch.1-alpha
@@ -60,6 +59,7 @@ io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0-axi
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0-cxf-3.0:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0-metro-2.2:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0:1.0.0+ai.patch.1-alpha
+io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-common:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jdbc:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jedis-1.4:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jedis-3.0:1.0.0+ai.patch.1-alpha

--- a/agent/instrumentation/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/agent/instrumentation/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -28,6 +28,7 @@ io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-caching:1.0.0
 io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-jaxws-2.0-axis2-1.6:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-jaxws-2.0-cxf-3.0:1.0.0+ai.patch.1-alpha
+io.opentelemetry.instrumentation:opentelemetry-jaxws-common:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-lettuce-5.1:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-netty-4.1:1.0.0+ai.patch.1-alpha
 io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:1.0.0+ai.patch.1-alpha
@@ -59,7 +60,6 @@ io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0-axi
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0-cxf-3.0:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0-metro-2.2:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-2.0:1.0.0+ai.patch.1-alpha
-io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jaxws-common:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jdbc:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jedis-1.4:1.0.0+ai.patch.1-alpha
 io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jedis-3.0:1.0.0+ai.patch.1-alpha

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
 
             azureStorageBlob                 : "12.11.0-beta.3",
             azureClientRuntime               : "2.1.1",
-            microsoftJfrStreaming            : "1.1.0",
+            microsoftJfrStreaming            : "1.2.0",
 
             // TODO remove dependency on guava
             guava                            : "30.1.1-jre",


### PR DESCRIPTION
Older Java 8s do not have the Mxbean that we used to control JFR. This fixes the initialisation where if the Mxbean is not available it will try using the alternate Diagnostic Command method.