### PR TITLE
Fix attach statsbeat duplicates when computer resumes from sleep

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/BaseStatsbeat.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/BaseStatsbeat.java
@@ -44,7 +44,7 @@ abstract class BaseStatsbeat {
 
     BaseStatsbeat(TelemetryClient telemetryClient, long interval) {
         this.telemetryClient = telemetryClient;
-        scheduledExecutor.scheduleAtFixedRate(new StatsbeatSender(), interval, interval, TimeUnit.SECONDS);
+        scheduledExecutor.scheduleWithFixedDelay(new StatsbeatSender(), interval, interval, TimeUnit.SECONDS);
     }
 
     protected abstract void send();

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/Instrumentations.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/Instrumentations.java
@@ -21,6 +21,9 @@
 
 package com.microsoft.applicationinsights.internal.statsbeat;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Base64;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -31,6 +34,7 @@ import java.util.Set;
 // because instrumentations may be more dynamic than features
 class Instrumentations {
 
+    private static final Logger logger = LoggerFactory.getLogger(Instrumentations.class);
     private static final Map<String, Integer> INSTRUMENTATION_MAP;
 
     static {
@@ -99,8 +103,12 @@ class Instrumentations {
     static String encode(Set<String> instrumentations) {
         BitSet bitSet = new BitSet(64);
         for (String instrumentation : instrumentations) {
-            int index = INSTRUMENTATION_MAP.get(instrumentation);
-            bitSet.set(index);
+            Integer index = INSTRUMENTATION_MAP.get(instrumentation);
+            if (index != null) {
+                bitSet.set(index);
+            } else {
+                logger.debug("{} is not part of INSTRUMENTATION_MAP.", instrumentation);
+            }
         }
 
         return Base64.getEncoder().withoutPadding().encodeToString(bitSet.toByteArray());

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/util/ExceptionStats.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/util/ExceptionStats.java
@@ -68,7 +68,7 @@ public class ExceptionStats {
         if (!firstFailure.getAndSet(true)) {
             // log the first time we see an exception as soon as it occurs, along with full stack trace
             logger.warn(introMessage + " " + warningMessage + " (future failures will be aggregated and logged once every " + intervalSeconds / 60 + " minutes)", exception);
-            scheduledExecutor.scheduleAtFixedRate(new ExceptionStatsLogger(), intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+            scheduledExecutor.scheduleWithFixedDelay(new ExceptionStatsLogger(), intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
             return;
         }
 


### PR DESCRIPTION
This also fixed an NullPointerException when trying to retrieve a custom instrumentation name from the Statsbeat instrumentation map. 

Using scheduleWithFixedDelay, I can no longer reproduce the duplicate attach Statsbeat with the same timestamp.