### PR TITLE
Use envelope name as the telemetry name and reduce payload

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/BaseTelemetry.java
@@ -125,7 +125,7 @@ public abstract class BaseTelemetry<T extends Domain> implements Telemetry {
     public void serialize(JsonTelemetryDataSerializer writer) throws IOException {
 
         if (telemetryName == null || telemetryName.isEmpty()) {
-            telemetryName = getTelemetryName(context.getNormalizedInstrumentationKey(), this.getEnvelopName());
+            telemetryName = this.getEnvelopName();
         }
 
         Envelope envelope = new Envelope();
@@ -203,9 +203,4 @@ public abstract class BaseTelemetry<T extends Domain> implements Telemetry {
             return instrumentationKey.replace("-", "").toLowerCase() + ".";
         }
     }
-
-    public static String getTelemetryName(String normalizedInstrumentationKey, String envelopType){
-        return TELEMETRY_NAME_PREFIX + normalizedInstrumentationKey + envelopType;
-    }
-
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/telemetry/BaseTelemetryTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/telemetry/BaseTelemetryTest.java
@@ -114,7 +114,7 @@ public final class BaseTelemetryTest {
         writer.close();
         String asJson = new String(buffer.readByteArray(), Charsets.UTF_8);
 
-        int index = asJson.indexOf("\"name\":\"Microsoft.ApplicationInsights.aif00000000111122223333000000000000.Stub\"");
+        int index = asJson.indexOf("\"name\":\"Stub\"");
         assertTrue(index != -1);
     }
 
@@ -132,7 +132,7 @@ public final class BaseTelemetryTest {
         writer.close();
         String asJson = new String(buffer.readByteArray(), Charsets.UTF_8);
 
-        int index = asJson.indexOf("\"name\":\"Microsoft.ApplicationInsights.Stub\"");
+        int index = asJson.indexOf("\"name\":\"Stub\"");
         assertTrue(index != -1);
     }
 
@@ -149,7 +149,7 @@ public final class BaseTelemetryTest {
         writer.close();
         String asJson = new String(buffer.readByteArray(), Charsets.UTF_8);
 
-        int index = asJson.indexOf("\"name\":\"Microsoft.ApplicationInsights.Stub\"");
+        int index = asJson.indexOf("\"name\":\"Stub\"");
         assertTrue(index != -1);
     }
 


### PR DESCRIPTION
Fix [#9860567](https://msazure.visualstudio.com/One/_sprints/taskboard/TelReachSDKTeam/One/AEP/Cobalt/2105?workitem=9860567)

sample envelopes with this change:
![image](https://user-images.githubusercontent.com/56097766/119028799-be8d6780-b95c-11eb-9d65-043abb254caa.png)
![image](https://user-images.githubusercontent.com/56097766/119028863-ccdb8380-b95c-11eb-9401-41ae413a4fd3.png)
