### PR TITLE
Truncate exception telemetry's parsedStack when there is a deep stack trace exceeding 65536 bytes

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
@@ -217,14 +217,6 @@ public class AiComponentInstaller implements ComponentInstaller {
 
         // initialize StatsbeatModule
         StatsbeatModule.initialize(telemetryClient, config.internal.statsbeat.intervalSeconds, config.internal.statsbeat.featureIntervalSeconds);
-
-        try {
-            doDeepStack();
-        } catch (StackOverflowError ex) {
-            ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(ex);
-            exceptionTelemetry.setSeverityLevel(SeverityLevel.Error);
-            telemetryClient.track(exceptionTelemetry);
-        }
     }
 
     private static GcEventMonitor.GcEventMonitorConfiguration formGcEventMonitorConfiguration(Configuration.GcEventConfiguration gcEvents) {
@@ -338,11 +330,5 @@ public class AiComponentInstaller implements ComponentInstaller {
         paramXml.setName(name);
         paramXml.setValue(value);
         return paramXml;
-    }
-
-    private static final AtomicLong stackDepth = new AtomicLong();
-    private static void doDeepStack() {
-        startupLogger.debug("############# current stack depth: {}", stackDepth.incrementAndGet());
-        doDeepStack();
     }
 }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/AiComponentInstaller.java
@@ -61,8 +61,6 @@ import com.microsoft.applicationinsights.internal.statsbeat.StatsbeatModule;
 import com.microsoft.applicationinsights.internal.system.SystemInformation;
 import com.microsoft.applicationinsights.internal.util.PropertyHelper;
 import com.microsoft.applicationinsights.profiler.config.ServiceProfilerServiceConfig;
-import com.microsoft.applicationinsights.telemetry.ExceptionTelemetry;
-import com.microsoft.applicationinsights.telemetry.SeverityLevel;
 import io.opentelemetry.instrumentation.api.aisdk.AiLazyConfiguration;
 import io.opentelemetry.javaagent.spi.ComponentInstaller;
 import org.apache.http.HttpHost;
@@ -71,12 +69,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/StackFrame.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/schemav2/StackFrame.java
@@ -60,6 +60,18 @@ public class StackFrame
      */
     private int line;
 
+    public String getMethod() {
+        return method;
+    }
+
+    public String getAssembly() {
+        return assembly;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
     /**
      * Initializes a new instance of the StackFrame class.
      */

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
@@ -230,6 +230,7 @@ public final class ExceptionTelemetry extends BaseSampleSourceTelemetry<Exceptio
      * @param stackFrame
      * @return the stack frame length for only the strings in the stack frame.
      */
+     // this is the same logic used to limit length on the Breeze side
     private static int getStackFrameLength(StackFrame stackFrame)
     {
         int stackFrameLength = (stackFrame.getMethod() == null ? 0 : stackFrame.getMethod().length())

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
@@ -25,6 +25,8 @@ import com.google.common.base.Strings;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionData;
 import com.microsoft.applicationinsights.internal.schemav2.ExceptionDetails;
 import com.microsoft.applicationinsights.internal.schemav2.StackFrame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +36,9 @@ import java.util.concurrent.ConcurrentMap;
  * Telemetry type used to track exceptions sent to Azure Application Insights.
  */
 public final class ExceptionTelemetry extends BaseSampleSourceTelemetry<ExceptionData> {
+
+    private static final int MAX_PARSED_STACK_LENGTH = 32768; // Breeze will reject parsedStack exceeding 65536 bytes. Each char is 2 bytes long.
+    private static final Logger logger = LoggerFactory.getLogger(ExceptionTelemetry.class);
     private Double samplingPercentage;
     private final ExceptionData data;
     private Throwable throwable;
@@ -171,12 +176,12 @@ public final class ExceptionTelemetry extends BaseSampleSourceTelemetry<Exceptio
         }
 
         StackTraceElement[] trace = exception.getStackTrace();
-
+        exceptionDetails.setHasFullStack(true);
         if (trace != null && trace.length > 0) {
             List<StackFrame> stack = exceptionDetails.getParsedStack();
 
             // We need to present the stack trace in reverse order.
-
+            int stackLength = 0;
             for (int idx = 0; idx < trace.length; idx++) {
                 StackTraceElement elem = trace[idx];
 
@@ -198,10 +203,15 @@ public final class ExceptionTelemetry extends BaseSampleSourceTelemetry<Exceptio
                     frame.setMethod(elem.getMethodName());
                 }
 
+                stackLength += getStackFrameLength(frame);
+                if (stackLength > MAX_PARSED_STACK_LENGTH) {
+                    exceptionDetails.setHasFullStack(false);
+                    logger.debug("parsedStack is exceeding 65536 bytes capacity. It is truncated from full {} frames to partial {} frames.", trace.length, stack.size());
+                    break;
+                }
+
                 stack.add(frame);
             }
-
-            exceptionDetails.setHasFullStack(true); // TODO: sanitize and trim exception stack trace.
         }
 
         return exceptionDetails;
@@ -214,5 +224,18 @@ public final class ExceptionTelemetry extends BaseSampleSourceTelemetry<Exceptio
     @Override
     public String getBaseTypeName() {
         return BASE_TYPE;
+    }
+
+    /***
+     * Gets the stack frame length for only the strings in the stack frame.
+     * @param stackFrame
+     * @return
+     */
+    private static int getStackFrameLength(StackFrame stackFrame)
+    {
+        int stackFrameLength = (stackFrame.getMethod() == null ? 0 : stackFrame.getMethod().length())
+                + (stackFrame.getAssembly() == null ? 0 : stackFrame.getAssembly().length())
+                + (stackFrame.getFileName() == null ? 0 : stackFrame.getFileName().length());
+        return stackFrameLength;
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/telemetry/ExceptionTelemetry.java
@@ -227,9 +227,8 @@ public final class ExceptionTelemetry extends BaseSampleSourceTelemetry<Exceptio
     }
 
     /***
-     * Gets the stack frame length for only the strings in the stack frame.
      * @param stackFrame
-     * @return
+     * @return the stack frame length for only the strings in the stack frame.
      */
     private static int getStackFrameLength(StackFrame stackFrame)
     {


### PR DESCRIPTION
2021-05-20 17:44:13.245-07 DEBUG c.m.applicationinsights.agent - ############# current stack depth: 8943
2021-05-20 17:44:13.266-07 DEBUG c.m.a.telemetry.ExceptionTelemetry - parsedStack is exceeding 65536 bytes capacity. It is truncated from full **1024** frames to partial **308** frames.
@trask method call depth (8943) does not equal to the number of stack frames (total 1024). What i showed you earlier in Fiddler is the full stack.

When we add stack frame to ExceptionTelemetry, it's already in the reversed order.

Fix #482 