### PR TITLE
Send instrumentation and feature as UTF-8 strings for Statsbeat

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/Feature.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/Feature.java
@@ -21,7 +21,6 @@
 
 package com.microsoft.applicationinsights.internal.statsbeat;
 
-import java.util.Base64;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,12 +57,17 @@ enum Feature {
         return feature != null ? feature : Feature.JAVA_VENDOR_OTHER;
     }
 
-    static String encode(Set<Feature> features) {
+    static long encode(Set<Feature> features) {
         BitSet bitSet = new BitSet(64);
         for (Feature feature : features) {
             bitSet.set(feature.bitmapIndex);
         }
 
-        return Base64.getEncoder().withoutPadding().encodeToString(bitSet.toByteArray());
+        long[] longArray = bitSet.toLongArray();
+        if (longArray.length > 0) {
+            return longArray[0];
+        }
+
+        return 0L;
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/FeatureStatsbeat.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/FeatureStatsbeat.java
@@ -42,9 +42,9 @@ class FeatureStatsbeat extends BaseStatsbeat {
     }
 
     /**
-     * @return a base 64 encoded string of a 64-bit long that represents a list of features enabled. Each bitfield maps to a feature.
+     * @return a long that represents a list of features enabled. Each bitfield maps to a feature.
      */
-    String getFeature() {
+    long getFeature() {
         return Feature.encode(featureList);
     }
 

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/Instrumentations.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/Instrumentations.java
@@ -24,7 +24,6 @@ package com.microsoft.applicationinsights.internal.statsbeat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Base64;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -99,8 +98,8 @@ class Instrumentations {
         INSTRUMENTATION_MAP.put("io.opentelemetry.javaagent.tomcat-7.0", 57);
     }
 
-    // encode BitSet to a base64 encoded string
-    static String encode(Set<String> instrumentations) {
+    // encode BitSet to a long
+    static long encode(Set<String> instrumentations) {
         BitSet bitSet = new BitSet(64);
         for (String instrumentation : instrumentations) {
             Integer index = INSTRUMENTATION_MAP.get(instrumentation);
@@ -111,6 +110,11 @@ class Instrumentations {
             }
         }
 
-        return Base64.getEncoder().withoutPadding().encodeToString(bitSet.toByteArray());
+        long[] longArray = bitSet.toLongArray();
+        if (longArray.length > 0) {
+            return longArray[0];
+        }
+
+        return 0L;
     }
 }

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/NetworkStatsbeat.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/NetworkStatsbeat.java
@@ -58,7 +58,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
         }
 
         // send instrumentation as an UTF-8 string
-        String instrumentation = Long.toString(Instrumentations.encode(local.instrumentationList));
+        String instrumentation = String.valueOf(Instrumentations.encode(local.instrumentationList));
 
         if (local.requestSuccessCount.get() != 0) {
             MetricTelemetry requestSuccessCountSt = createStatsbeatTelemetry(REQUEST_SUCCESS_COUNT_METRIC_NAME, local.requestSuccessCount.get());

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/NetworkStatsbeat.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/statsbeat/NetworkStatsbeat.java
@@ -57,8 +57,8 @@ public class NetworkStatsbeat extends BaseStatsbeat {
             current = new IntervalMetrics();
         }
 
-        // send instrumentation as a base64 encoded string instead of the UTF-8 string
-        String instrumentation = Instrumentations.encode(local.instrumentationList);
+        // send instrumentation as an UTF-8 string
+        String instrumentation = Long.toString(Instrumentations.encode(local.instrumentationList));
 
         if (local.requestSuccessCount.get() != 0) {
             MetricTelemetry requestSuccessCountSt = createStatsbeatTelemetry(REQUEST_SUCCESS_COUNT_METRIC_NAME, local.requestSuccessCount.get());
@@ -137,7 +137,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
     }
 
     // only used by tests
-    String getInstrumentationAsBase64EncodedString() {
+    long getInstrumentation() {
         return Instrumentations.encode(current.instrumentationList);
     }
 

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/FeatureTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/FeatureTest.java
@@ -1,0 +1,23 @@
+package com.microsoft.applicationinsights.internal.statsbeat;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class FeatureTest {
+
+    private static final Set<Feature> features = Collections.singleton(Feature.JAVA_VENDOR_ZULU);
+
+    private static final long EXPECTED_FEATURE = 2L;
+
+    @Test
+    public void tesEncodeAndDecodeFeature() {
+        long number = Feature.encode(features);
+        assertEquals(EXPECTED_FEATURE, number);
+        Set<Feature> result = StatsbeatTestUtils.decodeFeature(number);
+        assertEquals(features, result);
+    }
+}

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/InstrumentationsTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/InstrumentationsTest.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
-public class StatsbeatHelperTest {
+public class InstrumentationsTest {
 
     private static final Set<String> instrumentations;
     static {
@@ -20,23 +20,11 @@ public class StatsbeatHelperTest {
 
     private static final long EXPECTED_INSTRUMENTATION = (long)(Math.pow(2, 13) + Math.pow(2, 21) + Math.pow(2, 57)); // Exponents are keys from StatsbeatHelper.INSTRUMENTATION_MAP.)
 
-    private static final Set<Feature> features = Collections.singleton(Feature.JAVA_VENDOR_ZULU);
-
-    private static final long EXPECTED_FEATURE = 2L;
-
     @Test
     public void testEncodeAndDecodeInstrumentations() {
         long longVal = Instrumentations.encode(instrumentations);
         assertEquals(EXPECTED_INSTRUMENTATION, longVal);
         Set<String> result = StatsbeatTestUtils.decodeInstrumentations(longVal);
         assertEquals(instrumentations, result);
-    }
-
-    @Test
-    public void tesEncodeAndDecodeFeature() {
-        long number = Feature.encode(features);
-        assertEquals(EXPECTED_FEATURE, number);
-        Set<Feature> result = StatsbeatTestUtils.decodeFeature(number);
-        assertEquals(features, result);
     }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/NetworkStatsbeatTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/NetworkStatsbeatTest.java
@@ -25,7 +25,7 @@ public class NetworkStatsbeatTest {
         networkStatsbeat.addInstrumentation("io.opentelemetry.javaagent.jdbc");
         networkStatsbeat.addInstrumentation("io.opentelemetry.javaagent.tomcat-7.0");
         networkStatsbeat.addInstrumentation("io.opentelemetry.javaagent.http-url-connection");
-        assertEquals((long)(Math.pow(2, 13) + Math.pow(2, 21) + Math.pow(2, 57)), StatsbeatTestUtils.convertBase64EncodedStringToLong(networkStatsbeat.getInstrumentationAsBase64EncodedString())); // Exponents are keys from StatsbeatHelper.INSTRUMENTATION_MAP.)
+        assertEquals((long)(Math.pow(2, 13) + Math.pow(2, 21) + Math.pow(2, 57)), networkStatsbeat.getInstrumentation()); // Exponents are keys from StatsbeatHelper.INSTRUMENTATION_MAP.)
     }
 
     @Test

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/StatsbeatHelperTest.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/StatsbeatHelperTest.java
@@ -26,17 +26,17 @@ public class StatsbeatHelperTest {
 
     @Test
     public void testEncodeAndDecodeInstrumentations() {
-        String base64EncodedString = Instrumentations.encode(instrumentations);
-        assertEquals(EXPECTED_INSTRUMENTATION, StatsbeatTestUtils.convertBase64EncodedStringToLong(base64EncodedString));
-        Set<String> result = StatsbeatTestUtils.decodeInstrumentations(base64EncodedString);
+        long longVal = Instrumentations.encode(instrumentations);
+        assertEquals(EXPECTED_INSTRUMENTATION, longVal);
+        Set<String> result = StatsbeatTestUtils.decodeInstrumentations(longVal);
         assertEquals(instrumentations, result);
     }
 
     @Test
     public void tesEncodeAndDecodeFeature() {
-        String base64String = Feature.encode(features);
-        assertEquals(EXPECTED_FEATURE, StatsbeatTestUtils.convertBase64EncodedStringToLong(base64String));
-        Set<Feature> result = StatsbeatTestUtils.decodeFeature(base64String);
+        long number = Feature.encode(features);
+        assertEquals(EXPECTED_FEATURE, number);
+        Set<Feature> result = StatsbeatTestUtils.decodeFeature(number);
         assertEquals(features, result);
     }
 }

--- a/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/StatsbeatTestUtils.java
+++ b/core/src/test/java/com/microsoft/applicationinsights/internal/statsbeat/StatsbeatTestUtils.java
@@ -1,6 +1,5 @@
 package com.microsoft.applicationinsights.internal.statsbeat;
 
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -81,16 +80,15 @@ public final class StatsbeatTestUtils {
         FEATURE_MAP_DECODING.put(5, Feature.JAVA_VENDOR_OTHER);
     }
 
-    static Set<String> decodeInstrumentations(String based64String) {
-        return decode(based64String, INSTRUMENTATION_MAP_DECODING);
+    static Set<String> decodeInstrumentations(long number) {
+        return decode(number, INSTRUMENTATION_MAP_DECODING);
     }
 
-    static Set<Feature> decodeFeature(String based64String) {
-        return decode(based64String, FEATURE_MAP_DECODING);
+    static Set<Feature> decodeFeature(long num) {
+        return decode(num, FEATURE_MAP_DECODING);
     }
 
-    private static <E> Set<E> decode(String based64String, Map<Integer, E> decodedMap) {
-        long num = convertBase64EncodedStringToLong(based64String);
+    private static <E> Set<E> decode(long num, Map<Integer, E> decodedMap) {
         Set<E> result = new HashSet<>();
         for(Map.Entry<Integer, E> entry: decodedMap.entrySet()) {
             double value = entry.getKey();
@@ -100,18 +98,5 @@ public final class StatsbeatTestUtils {
             }
         }
         return result;
-    }
-
-    // convert base64 encoded string to long
-    static long convertBase64EncodedStringToLong(String base64EncodedString) {
-        byte[] bytes = Base64.getDecoder().decode(base64EncodedString.getBytes());
-        long result = 0;
-        for (int i = 0; i < bytes.length; i++) {
-            result += ((long) bytes[i] & 0xffL) << (8 * i); // use Big Endian Byte Order.
-        }
-        return result;
-    }
-
-    private StatsbeatTestUtils() {
     }
 }


### PR DESCRIPTION
kusto doesn't support converting base64 encoded string back to long.  
need to send it as UTF-8 string for instrumentation and feature.