### PR TITLE
2.x SDK explicit operation id / operation parent id should take precedence

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/instrumentation/sdk/BytecodeUtilImpl.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/instrumentation/sdk/BytecodeUtilImpl.java
@@ -31,6 +31,7 @@ import com.microsoft.applicationinsights.agent.Exporter;
 import com.microsoft.applicationinsights.agent.bootstrap.BytecodeUtil.BytecodeUtilDelegate;
 import com.microsoft.applicationinsights.agent.internal.Global;
 import com.microsoft.applicationinsights.agent.internal.sampling.SamplingScoreGeneratorV2;
+import com.microsoft.applicationinsights.extensibility.context.OperationContext;
 import com.microsoft.applicationinsights.telemetry.Duration;
 import com.microsoft.applicationinsights.telemetry.EventTelemetry;
 import com.microsoft.applicationinsights.telemetry.ExceptionTelemetry;
@@ -238,8 +239,13 @@ public class BytecodeUtilImpl implements BytecodeUtilDelegate {
                 // sampled out
                 return;
             }
-            telemetry.getContext().getOperation().setId(context.getTraceId());
-            telemetry.getContext().getOperation().setParentId(context.getSpanId());
+            OperationContext operation = telemetry.getContext().getOperation();
+            if (operation.getId() == null) {
+                operation.setId(context.getTraceId());
+            }
+            if (operation.getParentId() == null) {
+                operation.setParentId(context.getSpanId());
+            }
             samplingPercentage =
                     Exporter.getSamplingPercentage(context.getTraceState(), Global.getSamplingPercentage(), false);
         } else {

--- a/core/src/main/java/com/microsoft/applicationinsights/extensibility/context/OperationContext.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/extensibility/context/OperationContext.java
@@ -52,6 +52,13 @@ public final class OperationContext {
     }
 
     /**
+     * Get the Operation Parent id
+     */
+    public String getParentId() {
+        return MapUtil.getValueOrNull(tags, ContextTagKeys.getKeys().getOperationParentId());
+    }
+
+    /**
      * Set the Operation Parent id
      * @param parentId
      */

--- a/test/smoke/testApps/CoreAndFilter/src/main/java/com/microsoft/applicationinsights/smoketestapp/SimpleTrackPageViewServlet.java
+++ b/test/smoke/testApps/CoreAndFilter/src/main/java/com/microsoft/applicationinsights/smoketestapp/SimpleTrackPageViewServlet.java
@@ -28,6 +28,8 @@ public class SimpleTrackPageViewServlet extends HttpServlet {
         pvt2.getContext().getCloud().setRole("role-goes-here");
         pvt2.getContext().getCloud().setRoleInstance("role-instance-goes-here");
         pvt2.getContext().getOperation().setName("operation-name-goes-here");
+        pvt2.getContext().getOperation().setId("operation-id-goes-here");
+        pvt2.getContext().getOperation().setParentId("operation-parent-id-goes-here");
         pvt2.getContext().getUser().setId("user-id-goes-here");
         pvt2.getContext().getUser().setAccountId("account-id-goes-here");
         pvt2.getContext().getUser().setUserAgent("user-agent-goes-here");
@@ -49,6 +51,8 @@ public class SimpleTrackPageViewServlet extends HttpServlet {
         otherClient.getContext().getCloud().setRole("role-goes-here");
         otherClient.getContext().getCloud().setRoleInstance("role-instance-goes-here");
         otherClient.getContext().getOperation().setName("operation-name-goes-here");
+        otherClient.getContext().getOperation().setId("operation-id-goes-here");
+        otherClient.getContext().getOperation().setParentId("operation-parent-id-goes-here");
         otherClient.getContext().getUser().setId("user-id-goes-here");
         otherClient.getContext().getUser().setAccountId("account-id-goes-here");
         otherClient.getContext().getUser().setUserAgent("user-agent-goes-here");

--- a/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
+++ b/test/smoke/testApps/CoreAndFilter/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilterTests.java
@@ -255,8 +255,7 @@ public class CoreAndFilterTests extends AiSmokeTest {
         List<Envelope> rdList = mockedIngestion.waitForItems("RequestData", 1);
 
         Envelope rdEnvelope = rdList.get(0);
-        String operationId = rdEnvelope.getTags().get("ai.operation.id");
-        List<Envelope> pvdList = mockedIngestion.waitForItemsInOperation("PageViewData", 3, operationId);
+        List<Envelope> pvdList = mockedIngestion.waitForItems("PageViewData", 3);
         assertEquals(0, mockedIngestion.getCountForType("EventData"));
 
         RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
@@ -330,8 +329,14 @@ public class CoreAndFilterTests extends AiSmokeTest {
         assertTrue(pvdEnvelope3.getTags().get("ai.internal.sdkVersion").startsWith("java:3."));
 
         assertParentChild(rd, rdEnvelope, pvdEnvelope1, "GET /CoreAndFilter/trackPageView");
-        assertParentChild(rd, rdEnvelope, pvdEnvelope2, "GET /CoreAndFilter/trackPageView", "operation-name-goes-here");
-        assertParentChild(rd, rdEnvelope, pvdEnvelope3, "GET /CoreAndFilter/trackPageView", "operation-name-goes-here");
+
+        assertEquals("operation-id-goes-here", pvdEnvelope2.getTags().get("ai.operation.id"));
+        assertEquals("operation-parent-id-goes-here", pvdEnvelope2.getTags().get("ai.operation.parentId"));
+        assertEquals("operation-name-goes-here", pvdEnvelope2.getTags().get("ai.operation.name"));
+
+        assertEquals("operation-id-goes-here", pvdEnvelope3.getTags().get("ai.operation.id"));
+        assertEquals("operation-parent-id-goes-here", pvdEnvelope3.getTags().get("ai.operation.parentId"));
+        assertEquals("operation-name-goes-here", pvdEnvelope3.getTags().get("ai.operation.name"));
     }
 
     @Test


### PR DESCRIPTION
Attaching SNAPSHOT for testing: [applicationinsights-agent-3.1.1-BETA-SNAPSHOT.jar.zip](https://github.com/microsoft/ApplicationInsights-Java/files/6543566/applicationinsights-agent-3.1.1-BETA-SNAPSHOT.jar.zip)
