### PR TITLE
Hotfixes for Linux Consumption Plan

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/LazyConfigurationAccessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/LazyConfigurationAccessor.java
@@ -27,6 +27,7 @@ import com.google.common.base.Strings;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.agent.internal.propagator.DelegatingPropagator;
 import com.microsoft.applicationinsights.agent.internal.sampling.DelegatingSampler;
+import com.microsoft.applicationinsights.agent.internal.wasbootstrap.LoggingConfigurator;
 import io.opentelemetry.instrumentation.api.aisdk.AiLazyConfiguration;
 import io.opentelemetry.instrumentation.api.config.Config;
 import org.slf4j.Logger;
@@ -104,7 +105,7 @@ public class LazyConfigurationAccessor implements AiLazyConfiguration.Accessor {
             LoggerContext loggerContext = (LoggerContext)LoggerFactory.getILoggerFactory();
             List<ch.qos.logback.classic.Logger> loggerList = loggerContext.getLoggerList();
             logger.info("setting APPLICATIONINSIGHTS_SELF_DIAGNOSTICS_LEVEL to {}", loggingLevel);
-            loggerList.stream().forEach(tmpLogger -> tmpLogger.setLevel(Level.toLevel(loggingLevel)));
+            loggerList.stream().forEach(tmpLogger ->  LoggingConfigurator.configureSelfDiagnosticLoggingLevelAtRuntime(tmpLogger, Level.toLevel(loggingLevel)));
             if (Level.toLevel(loggingLevel) == Level.DEBUG) {
                 logger.debug("This should get logged after the logging level update.");
             }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/LoggingConfigurator.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/wasbootstrap/LoggingConfigurator.java
@@ -240,8 +240,10 @@ public class LoggingConfigurator {
         loggerContext.getLogger(ROOT_LOGGER_NAME).setLevel(getOtherLibLevel(level));
     }
 
-    // this is used by LazyConfigurationAccessor for the Linux Consumption Plan
-    // when the logging levels in configureLoggingLevels method is updated, this method needs to be updated at the same time.
+    /**
+     * this is used by LazyConfigurationAccessor for the Linux Consumption Plan
+     * when {@link #configureLoggingLevels()} method is updated, {@link #configureSelfDiagnosticLoggingLevelAtRuntime(Logger, Level)} needs to be updated at the same time.
+     */
     public static void configureSelfDiagnosticLoggingLevelAtRuntime(Logger logger, Level level) {
         switch (logger.getName()) {
             case "org.apache.http":

--- a/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/TelemetryClient.java
@@ -95,10 +95,10 @@ public class TelemetryClient {
      * application session.
      */
     public TelemetryContext getContext() {
-        if (context == null || (context.getInstrumentationKey() != null &&  !context.getInstrumentationKey().equals(configuration.getInstrumentationKey()))) {
+        if (context == null || (configuration.getInstrumentationKey() != null &&  !configuration.getInstrumentationKey().equals(context.getInstrumentationKey()))) {
             // lock and recheck there is still no initialized context. If so, create one.
             synchronized (TELEMETRY_CONTEXT_LOCK) {
-                if (context==null || (context.getInstrumentationKey() != null && !context.getInstrumentationKey().equals(configuration.getInstrumentationKey()))) {
+                if (context==null || (configuration.getInstrumentationKey() != null && !configuration.getInstrumentationKey().equals(context.getInstrumentationKey()))) {
                     context = createInitializedContext();
                 }
             }


### PR DESCRIPTION
- turn off quick pulse when cikey is null
- fix role name in the quick pulse payload
- fix invalid ikey for heartbeat, performance counters
- clean up verbose logging

@trask turn out the fix was one liner.  i did try to make TelemetryClient a singleton, but the tests were broken everywhere. 
This is much simpler and cleaner and it avoids all the merge conflicts later.  