### PR TITLE
Fix live metrics roles

### DIFF
--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataFetcher.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulseDataFetcher.java
@@ -67,18 +67,18 @@ final class DefaultQuickPulseDataFetcher implements QuickPulseDataFetcher {
         sdkVersion = getCurrentSdkVersion();
         final StringBuilder sb = new StringBuilder();
 
-        if (!LocalStringsUtils.isNullOrEmpty(roleName)) {
-            roleName = "\"" + roleName + "\"";
-        }
-
         sb.append("[{");
-        formatDocuments(sb);
-        sb.append("\"Instance\": \"").append(instanceName).append("\",");
-        sb.append("\"InstrumentationKey\": \"").append(ikey).append("\",");
-        sb.append("\"InvariantVersion\": ").append(QuickPulse.QP_INVARIANT_VERSION).append(",");
-        sb.append("\"MachineName\": \"").append(machineName).append("\",");
-        sb.append("\"RoleName\": ").append(roleName).append(",");
-        sb.append("\"StreamId\": \"").append(quickPulseId).append("\",");
+        sb.append("\"Documents\":[],");
+        sb.append("\"Instance\":\"").append(instanceName).append("\",");
+        sb.append("\"InstrumentationKey\":\"").append(ikey).append("\",");
+        sb.append("\"InvariantVersion\":").append(QuickPulse.QP_INVARIANT_VERSION).append(",");
+        sb.append("\"MachineName\":\"").append(machineName).append("\",");
+        if (LocalStringsUtils.isNullOrEmpty(roleName)) {
+            sb.append("\"RoleName\":null,");
+        } else {
+            sb.append("\"RoleName\":\"").append(roleName).append("\",");
+        }
+        sb.append("\"StreamId\":\"").append(quickPulseId).append("\",");
         postPrefix = sb.toString();
         if (logger.isTraceEnabled()) {
             logger.trace("{} using endpoint {}", DefaultQuickPulseDataFetcher.class.getSimpleName(), getQuickPulseEndpoint());
@@ -143,18 +143,14 @@ final class DefaultQuickPulseDataFetcher implements QuickPulseDataFetcher {
     private ByteArrayEntity buildPostEntity(QuickPulseDataCollector.FinalCounters counters) {
         StringBuilder sb = new StringBuilder(postPrefix);
         formatMetrics(counters, sb);
-        sb.append("\"Timestamp\": \"\\/Date(");
+        sb.append("\"Timestamp\":\"\\/Date(");
         long ms = System.currentTimeMillis();
         sb.append(ms);
         sb.append(")\\/\",");
-        sb.append("\"Version\": \"");
+        sb.append("\"Version\":\"");
         sb.append(sdkVersion);
         sb.append("\"}]");
         return new ByteArrayEntity(sb.toString().getBytes());
-    }
-
-    private void formatDocuments(StringBuilder sb) {
-        sb.append("\"Documents\": [] ,");
     }
 
     private void formatSingleMetric(StringBuilder sb, String metricName, double metricValue, int metricWeight, Boolean includeComma) {

--- a/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
+++ b/core/src/main/java/com/microsoft/applicationinsights/internal/quickpulse/DefaultQuickPulsePingSender.java
@@ -131,20 +131,24 @@ final class DefaultQuickPulsePingSender implements QuickPulsePingSender {
         if (pingPrefix == null) {
             roleName = TelemetryConfiguration.getActive().getRoleName();
 
-            if (!LocalStringsUtils.isNullOrEmpty(roleName)) {
-                roleName = "\"" + roleName + "\"";
-            }
+            StringBuilder sb = new StringBuilder();
 
-            pingPrefix = "{" +
-                    "\"Documents\": null," +
-                    "\"Instance\":\"" + instanceName + "\"," +
-                    "\"InstrumentationKey\": null," +
-                    "\"InvariantVersion\": " + QuickPulse.QP_INVARIANT_VERSION + "," +
-                    "\"MachineName\":\"" + machineName + "\"," +
-                    "\"RoleName\":" + roleName + "," +
-                    "\"Metrics\": null," +
-                    "\"StreamId\": \"" + quickPulseId + "\"," +
-                    "\"Timestamp\": \"\\/Date(";
+            sb.append("{");
+            sb.append("\"Documents\":null,");
+            sb.append("\"Instance\":\"").append(instanceName).append("\",");
+            sb.append("\"InstrumentationKey\":null,");
+            sb.append("\"InvariantVersion\":").append(QuickPulse.QP_INVARIANT_VERSION).append(",");
+            sb.append("\"MachineName\":\"").append(machineName).append("\",");
+            if (LocalStringsUtils.isNullOrEmpty(roleName)) {
+                sb.append("\"RoleName\":null,");
+            } else {
+                sb.append("\"RoleName\":\"").append(roleName).append("\",");
+            }
+            sb.append("\"StreamId\":\"").append(quickPulseId).append("\",");
+            sb.append("\"Metrics\":null,");
+            sb.append("\"Timestamp\":\"\\/Date(");
+
+            pingPrefix = sb.toString();
         }
         return pingPrefix;
     }


### PR DESCRIPTION
Regression in 3.1.1, live metrics role names show up both quoted and unquoted (should only show up unquoted).

https://portal.microsofticm.com/imp/v3/incidents/details/246058224/home