### PR TITLE
Fix some todo

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileCache.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileCache.java
@@ -34,7 +34,7 @@ public class LocalFileCache {
    * a system property that can be customized via the command line. TODO (heya) need to uniquely
    * identify each app and figure out how to retrieve data from the disk for each app.
    */
-  private static final Queue<String> persistedFilesCache = new ConcurrentLinkedDeque<>();
+  private final Queue<String> persistedFilesCache = new ConcurrentLinkedDeque<>();
 
   // Track the newly persisted filename to the concurrent hashmap.
   void addPersistedFilenameToMap(String filename) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
@@ -34,11 +34,11 @@ public class LocalFileLoader {
   private static final Logger logger = LoggerFactory.getLogger(LocalFileLoader.class);
 
   private final LocalFileCache localFileCache;
-  private final boolean isStatsbeat;
+  private final File telemetryFolder;
 
-  public LocalFileLoader(LocalFileCache localFileCache, boolean isStatsbeat) {
+  public LocalFileLoader(LocalFileCache localFileCache, File telemetryFolder) {
     this.localFileCache = localFileCache;
-    this.isStatsbeat = isStatsbeat;
+    this.telemetryFolder = telemetryFolder;
   }
 
   // Load ByteBuffer from persisted files on disk in FIFO order.
@@ -50,7 +50,7 @@ public class LocalFileLoader {
 
     File tempFile =
         PersistenceHelper.renameFileExtension(
-            filenameToBeLoaded, PersistenceHelper.TEMPORARY_FILE_EXTENSION, isStatsbeat);
+            filenameToBeLoaded, PersistenceHelper.TEMPORARY_FILE_EXTENSION, telemetryFolder);
     if (tempFile == null) {
       return null;
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
@@ -34,9 +34,11 @@ public class LocalFileLoader {
   private static final Logger logger = LoggerFactory.getLogger(LocalFileLoader.class);
 
   private final LocalFileCache localFileCache;
+  private final boolean isStatsbeat;
 
-  public LocalFileLoader(LocalFileCache localFileCache) {
+  public LocalFileLoader(LocalFileCache localFileCache, boolean isStatsbeat) {
     this.localFileCache = localFileCache;
+    this.isStatsbeat = isStatsbeat;
   }
 
   // Load ByteBuffer from persisted files on disk in FIFO order.
@@ -48,7 +50,7 @@ public class LocalFileLoader {
 
     File tempFile =
         PersistenceHelper.renameFileExtension(
-            filenameToBeLoaded, PersistenceHelper.TEMPORARY_FILE_EXTENSION);
+            filenameToBeLoaded, PersistenceHelper.TEMPORARY_FILE_EXTENSION, isStatsbeat);
     if (tempFile == null) {
       return null;
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriter.java
@@ -36,8 +36,9 @@ public final class LocalFileWriter {
   private static final Logger logger = LoggerFactory.getLogger(LocalFileWriter.class);
 
   private final LocalFileCache localFileCache;
+  private final boolean isStatsbeat;
 
-  public LocalFileWriter(LocalFileCache localFileCache) {
+  public LocalFileWriter(LocalFileCache localFileCache, boolean isStatsbeat) {
     if (!PersistenceHelper.DEFAULT_FOLDER.exists()) {
       PersistenceHelper.DEFAULT_FOLDER.mkdir();
     }
@@ -49,15 +50,16 @@ public final class LocalFileWriter {
           PersistenceHelper.DEFAULT_FOLDER + " must exist and have read and write permissions.");
     }
 
+    this.isStatsbeat = isStatsbeat;
     this.localFileCache = localFileCache;
   }
 
   public boolean writeToDisk(List<ByteBuffer> buffers) {
-    if (!PersistenceHelper.maxFileSizeExceeded()) {
+    if (!PersistenceHelper.maxFileSizeExceeded(isStatsbeat)) {
       return false;
     }
 
-    File tempFile = PersistenceHelper.createTempFile();
+    File tempFile = PersistenceHelper.createTempFile(isStatsbeat);
     if (tempFile == null) {
       return false;
     }
@@ -68,7 +70,7 @@ public final class LocalFileWriter {
 
     File permanentFile =
         PersistenceHelper.renameFileExtension(
-            tempFile.getName(), PersistenceHelper.PERMANENT_FILE_EXTENSION);
+            tempFile.getName(), PersistenceHelper.PERMANENT_FILE_EXTENSION, isStatsbeat);
     if (permanentFile == null) {
       return false;
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriter.java
@@ -36,30 +36,19 @@ public final class LocalFileWriter {
   private static final Logger logger = LoggerFactory.getLogger(LocalFileWriter.class);
 
   private final LocalFileCache localFileCache;
-  private final boolean isStatsbeat;
+  private final File telemetryFolder;
 
-  public LocalFileWriter(LocalFileCache localFileCache, boolean isStatsbeat) {
-    if (!PersistenceHelper.DEFAULT_FOLDER.exists()) {
-      PersistenceHelper.DEFAULT_FOLDER.mkdir();
-    }
-
-    if (!PersistenceHelper.DEFAULT_FOLDER.exists()
-        || !PersistenceHelper.DEFAULT_FOLDER.canRead()
-        || !PersistenceHelper.DEFAULT_FOLDER.canWrite()) {
-      throw new IllegalArgumentException(
-          PersistenceHelper.DEFAULT_FOLDER + " must exist and have read and write permissions.");
-    }
-
-    this.isStatsbeat = isStatsbeat;
+  public LocalFileWriter(LocalFileCache localFileCache, File telemetryFolder) {
+    this.telemetryFolder = telemetryFolder;
     this.localFileCache = localFileCache;
   }
 
   public boolean writeToDisk(List<ByteBuffer> buffers) {
-    if (!PersistenceHelper.maxFileSizeExceeded(isStatsbeat)) {
+    if (!PersistenceHelper.maxFileSizeExceeded(telemetryFolder)) {
       return false;
     }
 
-    File tempFile = PersistenceHelper.createTempFile(isStatsbeat);
+    File tempFile = PersistenceHelper.createTempFile(telemetryFolder);
     if (tempFile == null) {
       return false;
     }
@@ -70,7 +59,7 @@ public final class LocalFileWriter {
 
     File permanentFile =
         PersistenceHelper.renameFileExtension(
-            tempFile.getName(), PersistenceHelper.PERMANENT_FILE_EXTENSION, isStatsbeat);
+            tempFile.getName(), PersistenceHelper.PERMANENT_FILE_EXTENSION, telemetryFolder);
     if (permanentFile == null) {
       return false;
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/PersistenceHelper.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/PersistenceHelper.java
@@ -39,6 +39,8 @@ final class PersistenceHelper {
   private static final long MAX_FILE_SIZE_IN_BYTES = 52428800; // 50MB
   static final String PERMANENT_FILE_EXTENSION = ".trn";
   static final String TEMPORARY_FILE_EXTENSION = ".tmp";
+  static final String TELEMETRIES_FOLDER = "telemetries";
+  static final String STATSBEAT_FOLDER = "statsbeat";
 
   /**
    * Windows: C:\Users\{USER_NAME}\AppData\Local\Temp\applicationinsights Linux:
@@ -48,11 +50,11 @@ final class PersistenceHelper {
   static final File DEFAULT_FOLDER =
       new File(LocalFileSystemUtils.getTempDir(), "applicationinsights");
 
-  static File createTempFile() {
+  static File createTempFile(boolean isStatsbeat) {
     File file = null;
     try {
       String prefix = System.currentTimeMillis() + "-";
-      file = File.createTempFile(prefix, null, DEFAULT_FOLDER);
+      file = File.createTempFile(prefix, null, getDefaultFolder(isStatsbeat));
     } catch (IOException ex) {
       logger.error("Fail to create a temp file.", ex);
       // TODO (heya) track number of failures to create a temp file via Statsbeat
@@ -62,9 +64,10 @@ final class PersistenceHelper {
   }
 
   /** Rename the given file's file extension. */
-  static File renameFileExtension(String filename, String fileExtension) {
-    File sourceFile = new File(DEFAULT_FOLDER, filename);
-    File tempFile = new File(DEFAULT_FOLDER, FilenameUtils.getBaseName(filename) + fileExtension);
+  static File renameFileExtension(String filename, String fileExtension, boolean isStatsbeat) {
+    File defaultFolder = getDefaultFolder(isStatsbeat);
+    File sourceFile = new File(defaultFolder, filename);
+    File tempFile = new File(defaultFolder, FilenameUtils.getBaseName(filename) + fileExtension);
     try {
       FileUtils.moveFile(sourceFile, tempFile);
     } catch (IOException ex) {
@@ -80,8 +83,8 @@ final class PersistenceHelper {
    * Before a list of {@link ByteBuffer} can be persisted to disk, need to make sure capacity has
    * not been reached yet.
    */
-  static boolean maxFileSizeExceeded() {
-    long size = getTotalSizeOfPersistedFiles();
+  static boolean maxFileSizeExceeded(boolean isStatsbeat) {
+    long size = getTotalSizeOfPersistedFiles(isStatsbeat);
     if (size >= MAX_FILE_SIZE_IN_BYTES) {
       logger.warn(
           "Local persistent storage capacity has been reached. It's currently at {} KB. Telemetry will be lost.",
@@ -92,14 +95,34 @@ final class PersistenceHelper {
     return true;
   }
 
-  private static long getTotalSizeOfPersistedFiles() {
-    if (!DEFAULT_FOLDER.exists()) {
+  static File getDefaultFolder(boolean isStatsbeat) {
+    File subdirectory;
+    if (isStatsbeat) {
+      subdirectory= new File(DEFAULT_FOLDER, STATSBEAT_FOLDER);
+    } else {
+      subdirectory = new File(DEFAULT_FOLDER, TELEMETRIES_FOLDER);
+    }
+
+    if (!subdirectory.exists()) {
+      subdirectory.mkdir();
+    }
+
+    if (!subdirectory.exists() || !subdirectory.canRead() || !subdirectory.canWrite()) {
+      throw new IllegalArgumentException("subdirectory must exist and have read and write permissions.");
+    }
+
+    return subdirectory;
+  }
+
+  private static long getTotalSizeOfPersistedFiles(boolean isStatsbeat) {
+    File defaultFolder = getDefaultFolder(isStatsbeat);
+    if (!defaultFolder.exists()) {
       return 0;
     }
 
     long sum = 0;
     Collection<File> files =
-        FileUtils.listFiles(DEFAULT_FOLDER, new String[] {PERMANENT_FILE_EXTENSION}, false);
+        FileUtils.listFiles(defaultFolder, new String[] {PERMANENT_FILE_EXTENSION}, false);
     for (File file : files) {
       sum += file.length();
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/PersistenceHelper.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/PersistenceHelper.java
@@ -98,7 +98,7 @@ final class PersistenceHelper {
   static File getDefaultFolder(boolean isStatsbeat) {
     File subdirectory;
     if (isStatsbeat) {
-      subdirectory= new File(DEFAULT_FOLDER, STATSBEAT_FOLDER);
+      subdirectory = new File(DEFAULT_FOLDER, STATSBEAT_FOLDER);
     } else {
       subdirectory = new File(DEFAULT_FOLDER, TELEMETRIES_FOLDER);
     }
@@ -108,7 +108,8 @@ final class PersistenceHelper {
     }
 
     if (!subdirectory.exists() || !subdirectory.canRead() || !subdirectory.canWrite()) {
-      throw new IllegalArgumentException("subdirectory must exist and have read and write permissions.");
+      throw new IllegalArgumentException(
+          "subdirectory must exist and have read and write permissions.");
     }
 
     return subdirectory;

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/PersistenceHelper.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/PersistenceHelper.java
@@ -43,6 +43,7 @@ final class PersistenceHelper {
   /**
    * Windows: C:\Users\{USER_NAME}\AppData\Local\Temp\applicationinsights Linux:
    * /var/temp/applicationinsights We will store all persisted files in this folder for all apps.
+   * TODO it is a good security practice to purge data after 24 hours in this folder.
    */
   static final File DEFAULT_FOLDER =
       new File(LocalFileSystemUtils.getTempDir(), "applicationinsights");

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/AttachStatsbeat.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/AttachStatsbeat.java
@@ -56,7 +56,7 @@ class AttachStatsbeat extends BaseStatsbeat {
         createStatsbeatTelemetry(telemetryClient, ATTACH_METRIC_NAME, 0);
     TelemetryUtil.getProperties(statsbeatTelemetry.getData().getBaseData())
         .put("rpId", resourceProviderId);
-    telemetryClient.trackAsync(statsbeatTelemetry);
+    telemetryClient.trackStatsbeatAsync(statsbeatTelemetry);
   }
 
   /** Returns the unique identifier of the resource provider. */

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/AttachStatsbeat.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/AttachStatsbeat.java
@@ -78,8 +78,7 @@ class AttachStatsbeat extends BaseStatsbeat {
       ResourceProvider resourceProvider, MetadataInstanceResponse response) {
     switch (resourceProvider) {
       case RP_APPSVC:
-        // Linux App Services doesn't have WEBSITE_HOME_STAMPNAME yet.
-        // TODO (heya) make a feature request for Linux App Services Team to support this.
+        // Linux App Services doesn't have WEBSITE_HOME_STAMPNAME yet. An ask has been submitted.
         return System.getenv(WEBSITE_SITE_NAME) + "/" + System.getenv(WEBSITE_HOME_STAMPNAME);
       case RP_FUNCTIONS:
         return System.getenv(WEBSITE_HOSTNAME);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/AzureMetadataService.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/AzureMetadataService.java
@@ -64,7 +64,6 @@ class AzureMetadataService implements Runnable {
     // Querying Azure Metadata Service is required for every 15 mins since VM id will get updated
     // frequently.
     // Starting and restarting a VM will generate a new VM id each time.
-    // TODO (heya) need to confirm if restarting VM will also restart the Java Agent
     scheduledExecutor.scheduleWithFixedDelay(this, interval, interval, TimeUnit.SECONDS);
   }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/FeatureStatsbeat.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/FeatureStatsbeat.java
@@ -51,7 +51,7 @@ class FeatureStatsbeat extends BaseStatsbeat {
         createStatsbeatTelemetry(telemetryClient, FEATURE_METRIC_NAME, 0);
     TelemetryUtil.getProperties(statsbeatTelemetry.getData().getBaseData())
         .put("feature", String.valueOf(getFeature()));
-    telemetryClient.trackAsync(statsbeatTelemetry);
+    telemetryClient.trackStatsbeatAsync(statsbeatTelemetry);
   }
 
   void trackAadEnabled(boolean aadEnabled) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/NetworkStatsbeat.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/NetworkStatsbeat.java
@@ -66,7 +66,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
               telemetryClient, REQUEST_SUCCESS_COUNT_METRIC_NAME, local.requestSuccessCount.get());
       TelemetryUtil.getProperties(requestSuccessCountSt.getData().getBaseData())
           .put(INSTRUMENTATION_CUSTOM_DIMENSION, instrumentation);
-      telemetryClient.trackAsync(requestSuccessCountSt);
+      telemetryClient.trackStatsbeatAsync(requestSuccessCountSt);
     }
 
     if (local.requestFailureCount.get() != 0) {
@@ -75,7 +75,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
               telemetryClient, REQUEST_FAILURE_COUNT_METRIC_NAME, local.requestFailureCount.get());
       TelemetryUtil.getProperties(requestFailureCountSt.getData().getBaseData())
           .put(INSTRUMENTATION_CUSTOM_DIMENSION, instrumentation);
-      telemetryClient.trackAsync(requestFailureCountSt);
+      telemetryClient.trackStatsbeatAsync(requestFailureCountSt);
     }
 
     double durationAvg = local.getRequestDurationAvg();
@@ -84,7 +84,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
           createStatsbeatTelemetry(telemetryClient, REQUEST_DURATION_METRIC_NAME, durationAvg);
       TelemetryUtil.getProperties(requestDurationSt.getData().getBaseData())
           .put(INSTRUMENTATION_CUSTOM_DIMENSION, instrumentation);
-      telemetryClient.trackAsync(requestDurationSt);
+      telemetryClient.trackStatsbeatAsync(requestDurationSt);
     }
 
     if (local.retryCount.get() != 0) {
@@ -93,7 +93,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
               telemetryClient, RETRY_COUNT_METRIC_NAME, local.retryCount.get());
       TelemetryUtil.getProperties(retryCountSt.getData().getBaseData())
           .put(INSTRUMENTATION_CUSTOM_DIMENSION, instrumentation);
-      telemetryClient.trackAsync(retryCountSt);
+      telemetryClient.trackStatsbeatAsync(retryCountSt);
     }
 
     if (local.throttlingCount.get() != 0) {
@@ -102,7 +102,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
               telemetryClient, THROTTLE_COUNT_METRIC_NAME, local.throttlingCount.get());
       TelemetryUtil.getProperties(throttleCountSt.getData().getBaseData())
           .put(INSTRUMENTATION_CUSTOM_DIMENSION, instrumentation);
-      telemetryClient.trackAsync(throttleCountSt);
+      telemetryClient.trackStatsbeatAsync(throttleCountSt);
     }
 
     if (local.exceptionCount.get() != 0) {
@@ -111,7 +111,7 @@ public class NetworkStatsbeat extends BaseStatsbeat {
               telemetryClient, EXCEPTION_COUNT_METRIC_NAME, local.exceptionCount.get());
       TelemetryUtil.getProperties(exceptionCountSt.getData().getBaseData())
           .put(INSTRUMENTATION_CUSTOM_DIMENSION, instrumentation);
-      telemetryClient.trackAsync(exceptionCountSt);
+      telemetryClient.trackStatsbeatAsync(exceptionCountSt);
     }
   }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/EndpointProvider.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/EndpointProvider.java
@@ -41,6 +41,7 @@ public class EndpointProvider {
   private volatile URL liveEndpointUrl;
   private volatile URL profilerEndpoint;
   private volatile URL snapshotEndpoint;
+  private volatile URL statsbeatEndpoint;
   private volatile URL statsbeatEndpointUrl;
 
   public EndpointProvider() {
@@ -50,7 +51,8 @@ public class EndpointProvider {
       liveEndpointUrl = buildLiveUri(new URL(DefaultEndpoints.LIVE_ENDPOINT));
       profilerEndpoint = new URL(DefaultEndpoints.PROFILER_ENDPOINT);
       snapshotEndpoint = new URL(DefaultEndpoints.SNAPSHOT_ENDPOINT);
-      statsbeatEndpointUrl = ingestionEndpointUrl;
+      statsbeatEndpoint = new URL(DefaultEndpoints.INGESTION_ENDPOINT);
+      statsbeatEndpointUrl = buildIngestionUrl(ingestionEndpointUrl);
     } catch (MalformedURLException e) {
       throw new IllegalStateException("ConnectionString.Defaults are invalid", e);
     }
@@ -124,12 +126,18 @@ public class EndpointProvider {
     }
   }
 
+  public URL getStatsbeatEndpoint(){
+    return statsbeatEndpoint;
+  }
+
   void setStatsbeatEndpoint(URL statsbeatEndpoint) {
     try {
       this.statsbeatEndpointUrl = buildIngestionUrl(statsbeatEndpoint);
     } catch (MalformedURLException e) {
       throw new IllegalStateException("could not construct statsbeat ingestion endpoint uri", e);
     }
+
+    this.statsbeatEndpoint = statsbeatEndpoint;
   }
 
   public URL getProfilerEndpoint() {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/EndpointProvider.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/EndpointProvider.java
@@ -68,7 +68,6 @@ public class EndpointProvider {
     return ingestionEndpointUrl;
   }
 
-  // TODO (heya) this looks unused?
   public URL getStatsbeatEndpointUrl() {
     return statsbeatEndpointUrl;
   }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/EndpointProvider.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/EndpointProvider.java
@@ -126,7 +126,7 @@ public class EndpointProvider {
     }
   }
 
-  public URL getStatsbeatEndpoint(){
+  public URL getStatsbeatEndpoint() {
     return statsbeatEndpoint;
   }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryClient.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryClient.java
@@ -221,7 +221,7 @@ public class TelemetryClient {
           LocalFileWriter localFileWriter = new LocalFileWriter(localFileCache, true);
           TelemetryChannel channel =
               TelemetryChannel.create(
-                  endpointProvider.getStatsbeatEndpointUrl(), aadAuthentication, localFileWriter);
+                  endpointProvider.getStatsbeatEndpoint(), aadAuthentication, localFileWriter);
           LocalFileSender.start(localFileLoader, channel);
           statsbeatChannelBatcher = BatchSpanProcessor.builder(channel).build();
         }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryClient.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryClient.java
@@ -58,7 +58,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TelemetryClient {
 
-  // TODO (heya) can you confirm these are the same as used in 3.1.1?
   private static final String EVENT_TELEMETRY_NAME = "Event";
   private static final String EXCEPTION_TELEMETRY_NAME = "Exception";
   private static final String MESSAGE_TELEMETRY_NAME = "Message";

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.agent.internal.localstorage;
 
+import static com.microsoft.applicationinsights.agent.internal.localstorage.PersistenceHelper.DEFAULT_FOLDER;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -81,11 +82,15 @@ public class IntegrationTests {
   public void cleanup() {
     Queue<String> queue = localFileCache.getPersistedFilesCache();
     String filename;
+    File folder = PersistenceHelper.getDefaultFolder(false);
     while ((filename = queue.poll()) != null) {
-      File tempFile = new File(PersistenceHelper.getDefaultFolder(false), filename);
+      File tempFile = new File(folder, filename);
       assertThat(tempFile.exists()).isTrue();
       assertThat(tempFile.delete()).isTrue();
     }
+
+    assertThat(folder.delete()).isTrue();
+    assertThat(DEFAULT_FOLDER.delete()).isTrue();
   }
 
   @Test

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
@@ -89,8 +89,13 @@ public class IntegrationTests {
       assertThat(tempFile.delete()).isTrue();
     }
 
-    assertThat(folder.delete()).isTrue();
-    assertThat(DEFAULT_FOLDER.delete()).isTrue();
+    if (folder.exists()) {
+      assertThat(folder.delete()).isTrue();
+    }
+
+    if (DEFAULT_FOLDER.exists()) {
+      assertThat(DEFAULT_FOLDER.delete()).isTrue();
+    }
   }
 
   @Test

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
@@ -21,7 +21,6 @@
 
 package com.microsoft.applicationinsights.agent.internal.localstorage;
 
-import static com.microsoft.applicationinsights.agent.internal.localstorage.PersistenceHelper.DEFAULT_FOLDER;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -46,13 +45,12 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import reactor.core.publisher.Mono;
 
 public class IntegrationTests {
@@ -60,6 +58,8 @@ public class IntegrationTests {
   private TelemetryChannel telemetryChannel;
   private LocalFileCache localFileCache;
   private LocalFileLoader localFileLoader;
+
+  @TempDir File tempFolder;
 
   @BeforeEach
   public void setup() throws MalformedURLException {
@@ -74,28 +74,8 @@ public class IntegrationTests {
         new TelemetryChannel(
             pipelineBuilder.build(),
             new URL("http://foo.bar"),
-            new LocalFileWriter(localFileCache, false));
-    localFileLoader = new LocalFileLoader(localFileCache, false);
-  }
-
-  @AfterEach
-  public void cleanup() {
-    Queue<String> queue = localFileCache.getPersistedFilesCache();
-    String filename;
-    File folder = PersistenceHelper.getDefaultFolder(false);
-    while ((filename = queue.poll()) != null) {
-      File tempFile = new File(folder, filename);
-      assertThat(tempFile.exists()).isTrue();
-      assertThat(tempFile.delete()).isTrue();
-    }
-
-    if (folder.exists()) {
-      assertThat(folder.delete()).isTrue();
-    }
-
-    if (DEFAULT_FOLDER.exists()) {
-      assertThat(DEFAULT_FOLDER.delete()).isTrue();
-    }
+            new LocalFileWriter(localFileCache, tempFolder));
+    localFileLoader = new LocalFileLoader(localFileCache, tempFolder);
   }
 
   @Test

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
@@ -21,7 +21,6 @@
 
 package com.microsoft.applicationinsights.agent.internal.localstorage;
 
-import static com.microsoft.applicationinsights.agent.internal.localstorage.PersistenceHelper.DEFAULT_FOLDER;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -74,8 +73,8 @@ public class IntegrationTests {
         new TelemetryChannel(
             pipelineBuilder.build(),
             new URL("http://foo.bar"),
-            new LocalFileWriter(localFileCache));
-    localFileLoader = new LocalFileLoader(localFileCache);
+            new LocalFileWriter(localFileCache, false));
+    localFileLoader = new LocalFileLoader(localFileCache, false);
   }
 
   @AfterEach
@@ -83,7 +82,7 @@ public class IntegrationTests {
     Queue<String> queue = localFileCache.getPersistedFilesCache();
     String filename;
     while ((filename = queue.poll()) != null) {
-      File tempFile = new File(DEFAULT_FOLDER, filename);
+      File tempFile = new File(PersistenceHelper.getDefaultFolder(false), filename);
       assertThat(tempFile.exists()).isTrue();
       assertThat(tempFile.delete()).isTrue();
     }

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -21,7 +21,6 @@
 
 package com.microsoft.applicationinsights.agent.internal.localstorage;
 
-import static com.microsoft.applicationinsights.agent.internal.localstorage.PersistenceHelper.DEFAULT_FOLDER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,13 +38,12 @@ import java.util.zip.GZIPOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 public class LocalFileLoaderTests {
 
   private static final String BYTE_BUFFERS_TEST_FILE = "read-transmission.txt";
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final File PERSISTED_FILE = new File(DEFAULT_FOLDER, BYTE_BUFFERS_TEST_FILE);
+  private static final File PERSISTED_FILE = new File(PersistenceHelper.getDefaultFolder(false), BYTE_BUFFERS_TEST_FILE);
 
   @AfterEach
   public void cleanup() {
@@ -70,7 +68,7 @@ public class LocalFileLoaderTests {
     LocalFileCache localFileCache = new LocalFileCache();
     localFileCache.addPersistedFilenameToMap(BYTE_BUFFERS_TEST_FILE);
 
-    LocalFileLoader localFileLoader = new LocalFileLoader(localFileCache);
+    LocalFileLoader localFileLoader = new LocalFileLoader(localFileCache, false);
     String bytesString = readTelemetriesFromDiskToString(localFileLoader);
 
     String[] stringArray = bytesString.split("\n");
@@ -143,10 +141,10 @@ public class LocalFileLoaderTests {
   public void testWriteAndReadRandomText() {
     String text = "hello world";
     LocalFileCache cache = new LocalFileCache();
-    LocalFileWriter writer = new LocalFileWriter(cache);
+    LocalFileWriter writer = new LocalFileWriter(cache, false);
     writer.writeToDisk(singletonList(ByteBuffer.wrap(text.getBytes(UTF_8))));
 
-    LocalFileLoader loader = new LocalFileLoader(cache);
+    LocalFileLoader loader = new LocalFileLoader(cache, false);
     String bytesString = readTelemetriesFromDiskToString(loader);
     assertThat(bytesString).isEqualTo(text);
   }
@@ -172,11 +170,11 @@ public class LocalFileLoaderTests {
     // write gzipped bytes[] to disk
     byte[] result = byteArrayOutputStream.toByteArray();
     LocalFileCache cache = new LocalFileCache();
-    LocalFileWriter writer = new LocalFileWriter(cache);
+    LocalFileWriter writer = new LocalFileWriter(cache, false);
     writer.writeToDisk(singletonList(ByteBuffer.wrap(result)));
 
     // read gzipped byte[] from disk
-    LocalFileLoader loader = new LocalFileLoader(cache);
+    LocalFileLoader loader = new LocalFileLoader(cache, false);
     byte[] bytes = readTelemetriesFromDiskToBytes(loader);
 
     // ungzip

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -39,6 +39,7 @@ import java.util.zip.GZIPOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 public class LocalFileLoaderTests {
 
@@ -152,7 +153,12 @@ public class LocalFileLoaderTests {
 
   @Test
   public void testWriteGzipRawByte() throws IOException {
-    String text = "hello world";
+    String text = "1. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore \n"
+        + "2. magna aliquyam erat, sed diam voluptua. \n"
+        + "3. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum \n"
+        + "4. dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore\n"
+        + "5. magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, \n"
+        + "6. no sea takimata sanctus est Lorem ipsum dolor sit amet.";
 
     // gzip
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -174,8 +180,7 @@ public class LocalFileLoaderTests {
 
     // ungzip
     ByteArrayInputStream inputStream = new ByteArrayInputStream(result);
-    // TODO (heya) does ungzip need to be larger?
-    byte[] ungzip = new byte[bytes.length];
+    byte[] ungzip = new byte[bytes.length * 3];
     int read;
     try (GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream)) {
       read = gzipInputStream.read(ungzip, 0, ungzip.length);

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.agent.internal.localstorage;
 
+import static com.microsoft.applicationinsights.agent.internal.localstorage.PersistenceHelper.DEFAULT_FOLDER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +52,9 @@ public class LocalFileLoaderTests {
     if (PERSISTED_FILE.exists()) {
       assertThat(PERSISTED_FILE.delete()).isTrue();
     }
+
+    assertThat(PersistenceHelper.getDefaultFolder(false).delete()).isTrue();
+    assertThat(DEFAULT_FOLDER.delete()).isTrue();
   }
 
   @Test

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -43,7 +43,8 @@ public class LocalFileLoaderTests {
 
   private static final String BYTE_BUFFERS_TEST_FILE = "read-transmission.txt";
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final File PERSISTED_FILE = new File(PersistenceHelper.getDefaultFolder(false), BYTE_BUFFERS_TEST_FILE);
+  private static final File PERSISTED_FILE =
+      new File(PersistenceHelper.getDefaultFolder(false), BYTE_BUFFERS_TEST_FILE);
 
   @AfterEach
   public void cleanup() {

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -153,12 +153,13 @@ public class LocalFileLoaderTests {
 
   @Test
   public void testWriteGzipRawByte() throws IOException {
-    String text = "1. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore \n"
-        + "2. magna aliquyam erat, sed diam voluptua. \n"
-        + "3. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum \n"
-        + "4. dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore\n"
-        + "5. magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, \n"
-        + "6. no sea takimata sanctus est Lorem ipsum dolor sit amet.";
+    String text =
+        "1. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore \n"
+            + "2. magna aliquyam erat, sed diam voluptua. \n"
+            + "3. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum \n"
+            + "4. dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore\n"
+            + "5. magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, \n"
+            + "6. no sea takimata sanctus est Lorem ipsum dolor sit amet.";
 
     // gzip
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -38,23 +38,38 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class LocalFileLoaderTests {
 
   private static final String BYTE_BUFFERS_TEST_FILE = "read-transmission.txt";
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final File PERSISTED_FILE =
-      new File(PersistenceHelper.getDefaultFolder(false), BYTE_BUFFERS_TEST_FILE);
+  private File persistedFile;
+
+  @BeforeEach
+  public void setup() {
+    if (!PersistenceHelper.DEFAULT_FOLDER.exists()) {
+      PersistenceHelper.DEFAULT_FOLDER.mkdir();
+    }
+
+    persistedFile = new File(PersistenceHelper.getDefaultFolder(false), BYTE_BUFFERS_TEST_FILE);
+  }
 
   @AfterEach
   public void cleanup() {
-    if (PERSISTED_FILE.exists()) {
-      assertThat(PERSISTED_FILE.delete()).isTrue();
+    if (persistedFile.exists()) {
+      assertThat(persistedFile.delete()).isTrue();
     }
 
-    assertThat(PersistenceHelper.getDefaultFolder(false).delete()).isTrue();
-    assertThat(DEFAULT_FOLDER.delete()).isTrue();
+    File defaultFolder = PersistenceHelper.getDefaultFolder(false);
+    if (defaultFolder.exists()) {
+      assertThat(defaultFolder.delete()).isTrue();
+    }
+
+    if (DEFAULT_FOLDER.exists()) {
+      assertThat(DEFAULT_FOLDER.delete()).isTrue();
+    }
   }
 
   @Test
@@ -65,10 +80,10 @@ public class LocalFileLoaderTests {
     /*
      * move this file to {@link DEFAULT_FOlDER} if it doesn't exist yet.
      */
-    if (!PERSISTED_FILE.exists()) {
-      FileUtils.moveFile(sourceFile, PERSISTED_FILE);
+    if (!persistedFile.exists()) {
+      FileUtils.moveFile(sourceFile, persistedFile);
     }
-    assertThat(PERSISTED_FILE.exists()).isTrue();
+    assertThat(persistedFile.exists()).isTrue();
 
     LocalFileCache localFileCache = new LocalFileCache();
     localFileCache.addPersistedFilenameToMap(BYTE_BUFFERS_TEST_FILE);

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -108,9 +108,9 @@ public class LocalFileLoaderTests {
       JsonNode metrics = baseData.get("metrics");
 
       if (i < 7) { // metrics is only applicable to Metric Telemetry type
-        verifyMetricsName(i, metrics.get(0).get("name").asText());
+        assertThat(metrics.get(0).get("name").asText()).isEqualTo(expectedMetricsName(i));
         assertThat(metrics.get(0).get("kind").asInt()).isEqualTo(0);
-        verifyMetricsValue(i, metrics.get(0).get("value").asInt());
+        assertThat(metrics.get(0).get("value").asInt()).isEqualTo(expectedMetricsValue(i));
       }
 
       if (i == 7) { // Message
@@ -267,68 +267,46 @@ public class LocalFileLoaderTests {
         .isEqualTo("http://localhost:8080/webjars/jquery/2.2.4/jquery.min.js");
   }
 
-  private static void verifyMetricsName(int index, String actualName) {
-    String expectedName;
+  private static String expectedMetricsName(int index) {
     switch (index) {
       case 0:
-        expectedName = "jvm_threads_states";
-        break;
+        return "jvm_threads_states";
       case 1:
-        expectedName = "hikaricp_connections_max";
-        break;
+        return "hikaricp_connections_max";
       case 2:
-        expectedName = "process_uptime";
-        break;
+        return "process_uptime";
       case 3:
-        expectedName = "jvm_memory_used";
-        break;
+        return "jvm_memory_used";
       case 4:
-        expectedName = "jvm_threads_live";
-        break;
+        return "jvm_threads_live";
       case 5:
-        expectedName = "jdbc_connections_min";
-        break;
+        return "jdbc_connections_min";
       case 6:
-        expectedName = "Request Success Count";
-        break;
+        return "Request Success Count";
       default:
-        expectedName = null;
-        break;
+        throw new AssertionError("Unexpected index: " + index);
     }
-
-    assertThat(actualName).isEqualTo(expectedName);
   }
 
-  private static void verifyMetricsValue(int index, int actualValue) {
-    int expectedValue;
+  private static int expectedMetricsValue(int index) {
     switch (index) {
       case 0:
-        expectedValue = 3;
-        break;
+        return 3;
       case 1:
-        expectedValue = 10;
-        break;
+        return 10;
       case 2:
-        expectedValue = 3131610;
-        break;
+        return 3131610;
       case 3:
-        expectedValue = 12958128;
-        break;
+        return 12958128;
       case 4:
-        expectedValue = 150;
-        break;
+        return 150;
       case 5:
-        expectedValue = 110;
-        break;
+        return 110;
       case 6:
-        expectedValue = 2;
-        break;
+        return 2;
       default:
-        expectedValue = 0;
-        break;
+        throw new AssertionError("Unexpected index: " + index);
     }
-
-    assertThat(actualValue).isEqualTo(expectedValue);
   }
 
   private static void verifyProperties(int index, JsonNode properties) {
@@ -359,9 +337,12 @@ public class LocalFileLoaderTests {
         assertThat(properties.get("SourceType").asText()).isEqualTo("Logger");
         return;
       case 2:
-      default:
-        // all good
+      case 8:
+      case 9:
+        assertThat(properties).isNull();
         return;
+      default:
+        throw new AssertionError("Unexpected index " + index);
     }
   }
 

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -366,10 +366,9 @@ public class LocalFileLoaderTests {
         assertThat(properties.get("SourceType").asText()).isEqualTo("Logger");
         return;
       case 2:
-        // TODO (heya) should we delete this case?
-        return;
       default:
         // all good
+        return;
     }
   }
 

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.agent.internal.localstorage;
 
+import static com.microsoft.applicationinsights.agent.internal.localstorage.PersistenceHelper.DEFAULT_FOLDER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,11 +70,15 @@ public class LocalFileWriterTests {
   public void cleanup() {
     Queue<String> queue = localFileCache.getPersistedFilesCache();
     String filename;
+    File defaultFolder = PersistenceHelper.getDefaultFolder(false);
     while ((filename = queue.poll()) != null) {
-      File tempFile = new File(PersistenceHelper.getDefaultFolder(false), filename);
+      File tempFile = new File(defaultFolder, filename);
       assertThat(tempFile.exists()).isTrue();
       assertThat(tempFile.delete()).isTrue();
     }
+
+    assertThat(defaultFolder.delete()).isTrue();
+    assertThat(DEFAULT_FOLDER.delete()).isTrue();
   }
 
   @Test

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
@@ -21,7 +21,6 @@
 
 package com.microsoft.applicationinsights.agent.internal.localstorage;
 
-import static com.microsoft.applicationinsights.agent.internal.localstorage.PersistenceHelper.DEFAULT_FOLDER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +70,7 @@ public class LocalFileWriterTests {
     Queue<String> queue = localFileCache.getPersistedFilesCache();
     String filename;
     while ((filename = queue.poll()) != null) {
-      File tempFile = new File(DEFAULT_FOLDER, filename);
+      File tempFile = new File(PersistenceHelper.getDefaultFolder(false), filename);
       assertThat(tempFile.exists()).isTrue();
       assertThat(tempFile.delete()).isTrue();
     }
@@ -99,14 +98,14 @@ public class LocalFileWriterTests {
 
     assertThat(byteBuffers.size()).isEqualTo(10);
 
-    LocalFileWriter writer = new LocalFileWriter(localFileCache);
+    LocalFileWriter writer = new LocalFileWriter(localFileCache, false);
     assertThat(writer.writeToDisk(byteBuffers)).isTrue();
     assertThat(localFileCache.getPersistedFilesCache().size()).isEqualTo(1);
   }
 
   @Test
   public void testWriteRawByteArray() {
-    LocalFileWriter writer = new LocalFileWriter(localFileCache);
+    LocalFileWriter writer = new LocalFileWriter(localFileCache, false);
     assertThat(writer.writeToDisk(singletonList(buffer))).isTrue();
     assertThat(localFileCache.getPersistedFilesCache().size()).isEqualTo(1);
   }
@@ -121,7 +120,7 @@ public class LocalFileWriterTests {
       executorService.execute(
           () -> {
             for (int j = 0; j < 10; j++) {
-              LocalFileWriter writer = new LocalFileWriter(localFileCache);
+              LocalFileWriter writer = new LocalFileWriter(localFileCache,false);
               writer.writeToDisk(singletonList(ByteBuffer.wrap(telemetry.getBytes(UTF_8))));
             }
           });

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
@@ -120,7 +120,7 @@ public class LocalFileWriterTests {
       executorService.execute(
           () -> {
             for (int j = 0; j < 10; j++) {
-              LocalFileWriter writer = new LocalFileWriter(localFileCache,false);
+              LocalFileWriter writer = new LocalFileWriter(localFileCache, false);
               writer.writeToDisk(singletonList(ByteBuffer.wrap(telemetry.getBytes(UTF_8))));
             }
           });

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileWriterTests.java
@@ -77,8 +77,13 @@ public class LocalFileWriterTests {
       assertThat(tempFile.delete()).isTrue();
     }
 
-    assertThat(defaultFolder.delete()).isTrue();
-    assertThat(DEFAULT_FOLDER.delete()).isTrue();
+    if (defaultFolder.exists()) {
+      assertThat(defaultFolder.delete()).isTrue();
+    }
+
+    if (DEFAULT_FOLDER.exists()) {
+      assertThat(DEFAULT_FOLDER.delete()).isTrue();
+    }
   }
 
   @Test

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/telemetry/ConnectionStringParsingTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/telemetry/ConnectionStringParsingTests.java
@@ -206,7 +206,8 @@ class ConnectionStringParsingTests {
     final String liveHost = "https://live.example.com";
     URL expectedLiveEndpoint = new URL(liveHost + "/" + EndpointProvider.LIVE_URL_PATH);
     String statsbeatEndpoint = "https://statsbeat.example.com";
-    URL expectedStatsbeatEndpoint = new URL(statsbeatEndpoint + "/" + EndpointProvider.INGESTION_URL_PATH);
+    URL expectedStatsbeatEndpoint =
+        new URL(statsbeatEndpoint + "/" + EndpointProvider.INGESTION_URL_PATH);
 
     String cs =
         "InstrumentationKey="
@@ -226,7 +227,8 @@ class ConnectionStringParsingTests {
         .isEqualTo(expectedLiveEndpoint);
 
     ConnectionString.updateStatsbeatConnectionString(ikey, statsbeatEndpoint, telemetryClient);
-    assertThat(telemetryClient.getEndpointProvider().getStatsbeatEndpointUrl()).isEqualTo(expectedStatsbeatEndpoint);
+    assertThat(telemetryClient.getEndpointProvider().getStatsbeatEndpointUrl())
+        .isEqualTo(expectedStatsbeatEndpoint);
   }
 
   @Test

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/telemetry/ConnectionStringParsingTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/telemetry/ConnectionStringParsingTests.java
@@ -205,6 +205,9 @@ class ConnectionStringParsingTests {
         new URL("https://ingestion.example.com/" + EndpointProvider.INGESTION_URL_PATH);
     final String liveHost = "https://live.example.com";
     URL expectedLiveEndpoint = new URL(liveHost + "/" + EndpointProvider.LIVE_URL_PATH);
+    String statsbeatEndpoint = "https://statsbeat.example.com";
+    URL expectedStatsbeatEndpoint = new URL(statsbeatEndpoint + "/" + EndpointProvider.INGESTION_URL_PATH);
+
     String cs =
         "InstrumentationKey="
             + ikey
@@ -221,6 +224,9 @@ class ConnectionStringParsingTests {
         .isEqualTo(expectedIngestionEndpointUrl);
     assertThat(telemetryClient.getEndpointProvider().getLiveEndpointUrl())
         .isEqualTo(expectedLiveEndpoint);
+
+    ConnectionString.updateStatsbeatConnectionString(ikey, statsbeatEndpoint, telemetryClient);
+    assertThat(telemetryClient.getEndpointProvider().getStatsbeatEndpointUrl()).isEqualTo(expectedStatsbeatEndpoint);
   }
 
   @Test


### PR DESCRIPTION
- send statsbeat in a different batch because its endpoint is not the same as the customer iKey.
- persist statsbeat on disk under "statsbeat" subfolder
- persist regular telemetries on disk under "telemetries" subfolder
- address other todo(s).