### PR TITLE
Support system properties for the main "coordinates"

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationLogger.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationLogger.java
@@ -1,0 +1,80 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.agent.internal.configuration;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+
+class ConfigurationLogger {
+
+  // cannot use logger before loading configuration, so need to store warning messages locally until
+  // logger is initialized
+  private final List<Message> messages = new CopyOnWriteArrayList<>();
+
+  void warn(String message, Object... args) {
+    messages.add(new Message(ConfigurationLogLevel.WARN, message, args));
+  }
+
+  void debug(String message, Object... args) {
+    messages.add(new Message(ConfigurationLogLevel.DEBUG, message, args));
+  }
+
+  void log(Logger logger) {
+    for (Message message : messages) {
+      message.log(logger);
+    }
+  }
+
+  private static class Message {
+    private final ConfigurationLogLevel level;
+    private final String message;
+    private final Object[] args;
+
+    private Message(ConfigurationLogLevel level, String message, Object... args) {
+      this.level = level;
+      this.message = message;
+      this.args = args;
+    }
+
+    private void log(Logger logger) {
+      level.log(logger, message, args);
+    }
+  }
+
+  private enum ConfigurationLogLevel {
+    WARN {
+      @Override
+      public void log(Logger logger, String message, Object... args) {
+        logger.warn(message, args);
+      }
+    },
+    DEBUG {
+      @Override
+      public void log(Logger logger, String message, Object... args) {
+        logger.debug(message, args);
+      }
+    };
+
+    public abstract void log(Logger logger, String message, Object... args);
+  }
+}

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationTest.java
@@ -47,11 +47,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 @ExtendWith(SystemStubsExtension.class)
 class ConfigurationTest {
 
   @SystemStub EnvironmentVariables envVars = new EnvironmentVariables();
+  @SystemStub SystemProperties systemProperties = new SystemProperties();
 
   private static Configuration loadConfiguration() throws IOException {
     return loadConfiguration("applicationinsights.json");
@@ -270,7 +272,7 @@ class ConfigurationTest {
   }
 
   @Test
-  void shouldOverrideConnectionString() throws IOException {
+  void shouldOverrideConnectionStringWithEnvVar() throws IOException {
     envVars.set(
         "APPLICATIONINSIGHTS_CONNECTION_STRING",
         "InstrumentationKey=11111111-1111-1111-1111-111111111111");
@@ -283,14 +285,69 @@ class ConfigurationTest {
   }
 
   @Test
-  void shouldOverrideRoleName() throws IOException {
+  void shouldOverrideConnectionStringWithSysProp() throws IOException {
+    systemProperties.set(
+        "applicationinsights.connection.string",
+        "InstrumentationKey=11111111-1111-1111-1111-111111111111");
+
+    Configuration configuration = loadConfiguration();
+    ConfigurationBuilder.overlayEnvVars(configuration);
+
+    assertThat(configuration.connectionString)
+        .isEqualTo("InstrumentationKey=11111111-1111-1111-1111-111111111111");
+  }
+
+  @Test
+  void shouldOverrideConnectionStringWithBothEnvVarAndSysProp() throws IOException {
+    envVars.set(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=11111111-1111-1111-1111-111111111111");
+    systemProperties.set(
+        "applicationinsights.connection.string",
+        "InstrumentationKey=22222222-2222-2222-2222-222222222222");
+
+    Configuration configuration = loadConfiguration();
+    ConfigurationBuilder.overlayEnvVars(configuration);
+
+    assertThat(configuration.connectionString)
+        .isEqualTo("InstrumentationKey=22222222-2222-2222-2222-222222222222");
+  }
+
+  @Test
+  void shouldOverrideRoleNameWithEnvVar() throws IOException {
     envVars.set("APPLICATIONINSIGHTS_ROLE_NAME", "role name from env");
+
     envVars.set("WEBSITE_SITE_NAME", "Role Name From Website Env");
 
     Configuration configuration = loadConfiguration();
     ConfigurationBuilder.overlayEnvVars(configuration);
 
     assertThat(configuration.role.name).isEqualTo("role name from env");
+  }
+
+  @Test
+  void shouldOverrideRoleNameWithSysProp() throws IOException {
+    systemProperties.set("applicationinsights.role.name", "role name from sys");
+
+    envVars.set("WEBSITE_SITE_NAME", "Role Name From Website Env");
+
+    Configuration configuration = loadConfiguration();
+    ConfigurationBuilder.overlayEnvVars(configuration);
+
+    assertThat(configuration.role.name).isEqualTo("role name from sys");
+  }
+
+  @Test
+  void shouldOverrideRoleNameWithBothEnvVarAndSysProp() throws IOException {
+    envVars.set("APPLICATIONINSIGHTS_ROLE_NAME", "role name from env");
+    systemProperties.set("applicationinsights.role.name", "role name from sys");
+
+    envVars.set("WEBSITE_SITE_NAME", "Role Name From Website Env");
+
+    Configuration configuration = loadConfiguration();
+    ConfigurationBuilder.overlayEnvVars(configuration);
+
+    assertThat(configuration.role.name).isEqualTo("role name from sys");
   }
 
   @Test
@@ -325,14 +382,40 @@ class ConfigurationTest {
   }
 
   @Test
-  void shouldOverrideRoleInstance() throws IOException {
+  void shouldOverrideRoleInstanceWithEnvVar() throws IOException {
     envVars.set("APPLICATIONINSIGHTS_ROLE_INSTANCE", "role instance from env");
+
     envVars.set("WEBSITE_INSTANCE_ID", "role instance from website env");
 
     Configuration configuration = loadConfiguration();
     ConfigurationBuilder.overlayEnvVars(configuration);
 
     assertThat(configuration.role.instance).isEqualTo("role instance from env");
+  }
+
+  @Test
+  void shouldOverrideRoleInstanceWithSysProp() throws IOException {
+    systemProperties.set("applicationinsights.role.instance", "role instance from sys");
+
+    envVars.set("WEBSITE_INSTANCE_ID", "role instance from website env");
+
+    Configuration configuration = loadConfiguration();
+    ConfigurationBuilder.overlayEnvVars(configuration);
+
+    assertThat(configuration.role.instance).isEqualTo("role instance from sys");
+  }
+
+  @Test
+  void shouldOverrideRoleInstanceWithBothEnvVarAndSysProp() throws IOException {
+    envVars.set("APPLICATIONINSIGHTS_ROLE_INSTANCE", "role instance from env");
+    systemProperties.set("applicationinsights.role.instance", "role instance from sys");
+
+    envVars.set("WEBSITE_INSTANCE_ID", "role instance from website env");
+
+    Configuration configuration = loadConfiguration();
+    ConfigurationBuilder.overlayEnvVars(configuration);
+
+    assertThat(configuration.role.instance).isEqualTo("role instance from sys");
   }
 
   @Test


### PR DESCRIPTION
Resolves #1684

Supports system properties for the main "coordinates":
* applicationinsights.connection.string
* applicationinsights.role.name
* applicationinsights.role.instance

Also logs warning if using undocumented `APPLICATIONINSIGHTS_JMX_METRICS` (planning to remove support for this undocumented env var in the future).

Also renames `APPLICATIONINSIGHTS_PROFILER_ENABLED` to `APPLICATIONINSIGHTS_PREVIEW_PROFILER_ENABLED` (cc: @johnoliver).