### PR TITLE
Fix netty ByteBuf leak

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/httpclient/LazyHttpClient.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/httpclient/LazyHttpClient.java
@@ -147,6 +147,13 @@ public class LazyHttpClient implements HttpClient {
     return getDelegate().send(request, context);
   }
 
+  // need to consume response, otherwise get netty ByteBuf leak warnings:
+  // io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before
+  // it's garbage-collected (see https://github.com/Azure/azure-sdk-for-java/issues/10467)
+  public static void consumeResponseBody(HttpResponse response) {
+    response.getBody().subscribe();
+  }
+
   private static HttpPipelinePolicy getAuthenticationPolicy(
       Configuration.AadAuthentication configuration) {
     switch (configuration.type) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/quickpulse/QuickPulseDataSender.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/quickpulse/QuickPulseDataSender.java
@@ -24,6 +24,7 @@ package com.microsoft.applicationinsights.agent.internal.quickpulse;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
+import com.microsoft.applicationinsights.agent.internal.httpclient.LazyHttpClient;
 import java.util.concurrent.ArrayBlockingQueue;
 
 class QuickPulseDataSender implements Runnable {
@@ -57,7 +58,14 @@ class QuickPulseDataSender implements Runnable {
 
       long sendTime = System.nanoTime();
       try (HttpResponse response = httpPipeline.send(post).block()) {
-        if (response != null && networkHelper.isSuccess(response)) {
+        if (response == null) {
+          // this shouldn't happen, the mono should complete with a response or a failure
+          throw new AssertionError("http response mono returned empty");
+        }
+        // response body is not consumed below
+        LazyHttpClient.consumeResponseBody(response);
+
+        if (networkHelper.isSuccess(response)) {
           QuickPulseHeaderInfo quickPulseHeaderInfo =
               networkHelper.getQuickPulseHeaderInfo(response);
           switch (quickPulseHeaderInfo.getQuickPulseStatus()) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
@@ -202,6 +202,10 @@ public class TelemetryChannel {
         .subscribe(
             response -> {
               parseResponseCode(response.getStatusCode(), byteBuffers, byteBuffers);
+              // need to consume response, otherwise get netty ByteBuf leak warnings:
+              // io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before
+              // it's garbage-collected
+              response.getBody().subscribe();
             },
             error -> {
               StatsbeatModule.get().getNetworkStatsbeat().incrementRequestFailureCount();

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
@@ -202,10 +202,7 @@ public class TelemetryChannel {
         .subscribe(
             response -> {
               parseResponseCode(response.getStatusCode(), byteBuffers, byteBuffers);
-              // need to consume response, otherwise get netty ByteBuf leak warnings:
-              // io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before
-              // it's garbage-collected
-              response.getBody().subscribe();
+              LazyHttpClient.consumeResponseBody(response);
             },
             error -> {
               StatsbeatModule.get().getNetworkStatsbeat().incrementRequestFailureCount();


### PR DESCRIPTION
Fixes an issue that started in 3.2.0-BETA.1 after swapping out ingestion http client with Azure SDK / reactor netty.

```
ERROR io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
```