### PR TITLE
Misc logging improvements

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/LoggingConfigurator.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/LoggingConfigurator.java
@@ -269,7 +269,7 @@ public class LoggingConfigurator {
   private Encoder<ILoggingEvent> createEncoder() {
     PatternLayoutEncoder encoder = new PatternLayoutEncoder();
     encoder.setContext(loggerContext);
-    encoder.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSSX} %-5level %logger{36} - %msg%n");
+    encoder.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %-5level %logger{36} - %msg%n");
     encoder.start();
     return encoder;
   }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/LoggingConfigurator.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/LoggingConfigurator.java
@@ -113,7 +113,11 @@ public class LoggingConfigurator {
 
     // App Services windows environments use ETW to consume internal diagnostics logging events and
     // to send those logging events to an internal kusto store for internal alerting and diagnostics
-    if (DiagnosticsHelper.isOsWindows()) {
+    //
+    // applicationinsights.testing.etw.disabled setting is useful for local testing of app services
+    // diagnostic logging without building the etw dll locally
+    if (DiagnosticsHelper.isOsWindows()
+        && !Boolean.getBoolean("applicationinsights.testing.etw.disabled")) {
       rootLogger.addAppender(configureEtwAppender());
     }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/MainEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/MainEntryPoint.java
@@ -22,6 +22,7 @@
 package com.microsoft.applicationinsights.agent.internal.init;
 
 import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.DiagnosticsHelper;
+import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.PidFinder;
 import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.SdkVersionFinder;
 import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.status.StatusFile;
 import com.microsoft.applicationinsights.agent.internal.common.FriendlyException;
@@ -89,7 +90,10 @@ public class MainEntryPoint {
       AiComponentInstaller.setInstrumentation(instrumentation);
       AgentInstaller.installBytebuddyAgent(
           instrumentation, ConfigOverride.getConfig(configuration), false);
-      startupLogger.info("ApplicationInsights Java Agent {} started successfully", version);
+      startupLogger.info(
+          "ApplicationInsights Java Agent {} started successfully (PID {})",
+          version,
+          new PidFinder().getValue());
       success = true;
       LoggerFactory.getLogger(DiagnosticsHelper.DIAGNOSTICS_LOGGER_NAME)
           .info("Application Insights Codeless Agent {} Attach Successful", version);


### PR DESCRIPTION
Three changes:

* Adds PID to startup message. This will help support customers who need to take a thread/heap dump for any reason.
* Clearer timezone identifier on logs (`-07:00` instead of `-07`)
* `applicationinsights.testing.etw.disabled` just for use during testing (I've needed this twice now, so committing it now)