### PR TITLE
Be consistent with other SDK

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/FeatureStatsbeat.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/FeatureStatsbeat.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class FeatureStatsbeat extends BaseStatsbeat {
 
   private static final String FEATURE_METRIC_NAME = "Feature";
-  private static final String INSTRUMENTATION_METRIC_NAME = "Instrumentation";
 
   private final Set<Feature> featureList = Collections.newSetFromMap(new ConcurrentHashMap<>());
   private final Set<String> instrumentationList =
@@ -68,18 +67,16 @@ public class FeatureStatsbeat extends BaseStatsbeat {
 
   @Override
   protected void send(TelemetryClient telemetryClient) {
-    String metricName;
+    String metricName = FEATURE_METRIC_NAME;
     long encodedLong;
     String featureType;
 
     if (type == FeatureType.FEATURE) {
-      metricName = FEATURE_METRIC_NAME;
       encodedLong = getFeature();
-      featureType = "feature";
+      featureType = "0";
     } else {
-      metricName = INSTRUMENTATION_METRIC_NAME;
       encodedLong = getInstrumentation();
-      featureType = "instrumentation";
+      featureType = "1";
     }
 
     TelemetryItem telemetryItem = createStatsbeatTelemetry(telemetryClient, metricName, 0);

--- a/test/smoke/testApps/Statsbeat/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/StatsbeatSmokeTest.java
+++ b/test/smoke/testApps/Statsbeat/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/StatsbeatSmokeTest.java
@@ -39,7 +39,7 @@ public class StatsbeatSmokeTest extends AiSmokeTest {
   @TargetUri(value = "/index.jsp")
   public void testStatsbeat() throws Exception {
     List<Envelope> metrics =
-        mockedIngestion.waitForItems(getMetricPredicate("Feature"), 1, 70, TimeUnit.SECONDS);
+        mockedIngestion.waitForItems(getMetricPredicate("Feature"), 2, 70, TimeUnit.SECONDS);
 
     MetricData data = (MetricData) ((Data<?>) metrics.get(0).getData()).getBaseData();
     assertNotNull(data.getProperties().get("rp"));
@@ -54,10 +54,7 @@ public class StatsbeatSmokeTest extends AiSmokeTest {
     assertEquals("0", data.getProperties().get("type"));
     assertEquals(9, data.getProperties().size());
 
-    List<Envelope> instrumentationMetrics =
-        mockedIngestion.waitForItems(getMetricPredicate("Feature"), 1, 70, TimeUnit.SECONDS);
-
-    MetricData instrumentationData = (MetricData) ((Data<?>) instrumentationMetrics.get(0).getData()).getBaseData();
+    MetricData instrumentationData = (MetricData) ((Data<?>) metrics.get(1).getData()).getBaseData();
     assertNotNull(instrumentationData.getProperties().get("rp"));
     assertNotNull(instrumentationData.getProperties().get("attach"));
     assertNotNull(instrumentationData.getProperties().get("cikey"));

--- a/test/smoke/testApps/Statsbeat/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/StatsbeatSmokeTest.java
+++ b/test/smoke/testApps/Statsbeat/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/StatsbeatSmokeTest.java
@@ -51,10 +51,11 @@ public class StatsbeatSmokeTest extends AiSmokeTest {
     assertNotNull(data.getProperties().get("version"));
     assertNotNull(data.getProperties().get("feature"));
     assertNotNull(data.getProperties().get("type"));
+    assertEquals("0", data.getProperties().get("type"));
     assertEquals(9, data.getProperties().size());
 
     List<Envelope> instrumentationMetrics =
-        mockedIngestion.waitForItems(getMetricPredicate("Instrumentation"), 1, 70, TimeUnit.SECONDS);
+        mockedIngestion.waitForItems(getMetricPredicate("Feature"), 1, 70, TimeUnit.SECONDS);
 
     MetricData instrumentationData = (MetricData) ((Data<?>) instrumentationMetrics.get(0).getData()).getBaseData();
     assertNotNull(instrumentationData.getProperties().get("rp"));
@@ -66,6 +67,7 @@ public class StatsbeatSmokeTest extends AiSmokeTest {
     assertNotNull(instrumentationData.getProperties().get("version"));
     assertNotNull(instrumentationData.getProperties().get("feature"));
     assertNotNull(instrumentationData.getProperties().get("type"));
+    assertEquals("1", instrumentationData.getProperties().get("type"));
     assertEquals(9, instrumentationData.getProperties().size());
 
     List<Envelope> attachMetrics =


### PR DESCRIPTION
sent type 0 (feature) and 1(instrumentation)
use the same "Feature" metric name for instrumentation. 

This is easier for querying data on the Kusto end and consistent with nodejs SDK.