### PR TITLE
Update submodule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,8 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: Build otel-fork
         working-directory: otel
-        run: ./gradlew publishToMavenLocal --stacktrace
+        # javadoc fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+        run: ./gradlew publishToMavenLocal -x javadoc --stacktrace
       - name: Test
         # TODO enable build cache, either --build-cache here, or org.gradle.caching=true in gradle.properties
         run: ./gradlew check --stacktrace
@@ -89,7 +90,8 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: Build otel-fork
         working-directory: otel
-        run: ./gradlew publishToMavenLocal --stacktrace
+        # javadoc fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+        run: ./gradlew publishToMavenLocal -x javadoc --stacktrace
       - name: Test
         # TODO enable build cache, either --build-cache here, or org.gradle.caching=true in gradle.properties
         run: ./gradlew ${{ matrix.module }}:smokeTest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,8 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: Build otel-fork
         working-directory: otel
-        run: ./gradlew publishToMavenLocal --stacktrace
+        # javadoc fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+        run: ./gradlew publishToMavenLocal -x javadoc --stacktrace
       - name: Test
         # TODO enable build cache, either --build-cache here, or org.gradle.caching=true in gradle.properties
         run: ./gradlew check --stacktrace
@@ -91,7 +92,8 @@ jobs:
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: Build otel-fork
         working-directory: otel
-        run: ./gradlew publishToMavenLocal --stacktrace
+        # javadoc fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+        run: ./gradlew publishToMavenLocal -x javadoc --stacktrace
       - name: Test
         # TODO enable build cache, either --build-cache here, or org.gradle.caching=true in gradle.properties
         run: ./gradlew ${{ matrix.module }}:smokeTest

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -7,6 +7,6 @@ extraction:
       java_version: 11
       build_command: |
         # needs Java 11, otherwise this could be done in before_index
-        ./otel/gradlew --project-dir otel/gradle-plugins publishToMavenLocal
-        ./otel/gradlew --project-dir otel publishToMavenLocal
+        # javadoc fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+        ./otel/gradlew --project-dir otel publishToMavenLocal -x javadoc
         ./gradlew --no-daemon testClasses

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -49,7 +49,8 @@ restore:
     - !!defaultcommand
       name: 'Add OpenTelemetry to MavenLocal'
       command: '.scripts/ot-gradle.cmd'
-      arguments: 'publishToMavenLocal'
+      # javadoc fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
+      arguments: 'publishToMavenLocal -x javadoc'
     - !!defaultcommand
       name: 'Download Dependencies'
       command: '.scripts/gradle.cmd'


### PR DESCRIPTION
build fixes, see #1886

I think LGTM is failing because it uses `.lgtm.yml` from `main` instead of from the PR branch, and the submodule changes require a change to the build, so I think merging this will fix (and same for other PRs built on top of this: #1888, #1889, and #1890)