### PR TITLE
Fix Linux diagnostic log missing language column

### DIFF
--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsJsonLayout.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsJsonLayout.java
@@ -75,6 +75,7 @@ public class ApplicationInsightsJsonLayout extends JsonLayout {
           value == null || value.isEmpty() ? UNKNOWN_VALUE : value,
           jsonMap);
     }
+    jsonMap.put("language", "java");
     return jsonMap;
   }
 

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsJsonLayoutTests.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsJsonLayoutTests.java
@@ -95,11 +95,12 @@ class ApplicationInsightsJsonLayoutTests {
     ourLayout.valueFinders.add(mockFinder);
 
     Map<String, Object> jsonMap = ourLayout.toJsonMap(logEvent);
-
+    Map<String, Object> propertyMap = (Map<String, Object>) jsonMap.get(CUSTOM_FIELDS_PROP_NAME);
     verify(mockFinder, atLeastOnce()).getName();
     verify(mockFinder, atLeastOnce()).getValue();
-    assertThat((Map<String, Object>) jsonMap.get(CUSTOM_FIELDS_PROP_NAME))
-        .containsEntry(key, value);
+    assertThat(propertyMap).containsEntry(key, value);
+    assertThat(propertyMap).containsKey("language");
+    assertThat(propertyMap.get("language")).isEqualTo("java");
   }
 
   @Test

--- a/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsJsonLayoutTests.java
+++ b/agent/agent-bootstrap/src/test/java/com/microsoft/applicationinsights/agent/bootstrap/diagnostics/log/ApplicationInsightsJsonLayoutTests.java
@@ -99,8 +99,7 @@ class ApplicationInsightsJsonLayoutTests {
     verify(mockFinder, atLeastOnce()).getName();
     verify(mockFinder, atLeastOnce()).getValue();
     assertThat(propertyMap).containsEntry(key, value);
-    assertThat(propertyMap).containsKey("language");
-    assertThat(propertyMap.get("language")).isEqualTo("java");
+    assertThat(propertyMap).containsEntry("language", "java");
   }
 
   @Test


### PR DESCRIPTION
App Service linux diagnostic log is missing language column because we didn't provide that. 
it's hard to distinguish logs from node.js and dotnetcore since they all have language column populated.