### PR TITLE
Handle weird folder names

### DIFF
--- a/agent/agent-bootstrap/gradle.lockfile
+++ b/agent/agent-bootstrap/gradle.lockfile
@@ -3,8 +3,8 @@
 # This file is expected to be part of source control.
 ch.qos.logback.contrib:logback-json-classic:0.1.5=runtimeClasspath
 ch.qos.logback.contrib:logback-json-core:0.1.5=runtimeClasspath
-ch.qos.logback:logback-classic:1.2.3=runtimeClasspath
-ch.qos.logback:logback-core:1.2.3=runtimeClasspath
+ch.qos.logback:logback-classic:1.2.6=runtimeClasspath
+ch.qos.logback:logback-core:1.2.6=runtimeClasspath
 com.google.code.findbugs:jsr305:3.0.2=runtimeClasspath
 com.google.guava:guava-bom:30.1.1-jre=runtimeClasspath
 com.squareup.moshi:moshi:1.11.0=runtimeClasspath
@@ -24,5 +24,5 @@ io.opentelemetry:opentelemetry-bom:1.7.0=runtimeClasspath
 io.opentelemetry:opentelemetry-context:1.7.0=runtimeClasspath
 io.opentelemetry:opentelemetry-semconv:1.7.0-alpha=runtimeClasspath
 org.junit:junit-bom:5.7.2=runtimeClasspath
-org.slf4j:slf4j-api:1.7.30=runtimeClasspath
+org.slf4j:slf4j-api:1.7.32=runtimeClasspath
 empty=

--- a/agent/agent-tooling/gradle.lockfile
+++ b/agent/agent-tooling/gradle.lockfile
@@ -3,8 +3,8 @@
 # This file is expected to be part of source control.
 ch.qos.logback.contrib:logback-json-classic:0.1.5=runtimeClasspath
 ch.qos.logback.contrib:logback-json-core:0.1.5=runtimeClasspath
-ch.qos.logback:logback-classic:1.2.3=runtimeClasspath
-ch.qos.logback:logback-core:1.2.3=runtimeClasspath
+ch.qos.logback:logback-classic:1.2.6=runtimeClasspath
+ch.qos.logback:logback-core:1.2.6=runtimeClasspath
 com.azure:azure-core-http-netty:1.11.0=runtimeClasspath
 com.azure:azure-core:1.21.0=runtimeClasspath
 com.azure:azure-identity:1.3.6=runtimeClasspath

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/LoggingConfigurator.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/LoggingConfigurator.java
@@ -32,7 +32,6 @@ import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.encoder.Encoder;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
-import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
@@ -43,6 +42,7 @@ import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.log.Applica
 import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.log.ApplicationInsightsJsonLayout;
 import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.log.MoshiJsonFormatter;
 import com.microsoft.applicationinsights.agent.internal.configuration.Configuration;
+import com.microsoft.applicationinsights.agent.internal.logbackpatch.FixedWindowRollingPolicy;
 import java.nio.file.Path;
 import org.slf4j.LoggerFactory;
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FileNamePattern.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FileNamePattern.java
@@ -1,0 +1,26 @@
+package com.microsoft.applicationinsights.agent.internal.logbackpatch;
+
+import ch.qos.logback.core.Context;
+
+public class FileNamePattern extends ch.qos.logback.core.rolling.helper.FileNamePattern {
+
+  public FileNamePattern(String patternArg, Context contextArg) {
+    super(patternArg, contextArg);
+  }
+
+  @Override
+  public void setPattern(String pattern) {
+    super.setPattern(escapeDirectory(pattern));
+  }
+
+  // visible for testing
+  static String escapeDirectory(String pattern) {
+    int index = pattern.lastIndexOf('/');
+    if (index == -1) {
+      return pattern;
+    }
+    String directory = pattern.substring(0, index + 1);
+    String file = pattern.substring(index + 1);
+    return directory.replace("%", "\\%") + file;
+  }
+}

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FileNamePattern.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FileNamePattern.java
@@ -1,3 +1,24 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
 package com.microsoft.applicationinsights.agent.internal.logbackpatch;
 
 import ch.qos.logback.core.Context;

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicy.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicy.java
@@ -19,6 +19,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+// Includes work from:
 /*
  * Logback: the reliable, generic, fast and flexible logging framework. Copyright (C) 1999-2015,
  * QOS.ch. All rights reserved.

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicy.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicy.java
@@ -1,0 +1,215 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Logback: the reliable, generic, fast and flexible logging framework. Copyright (C) 1999-2015,
+ * QOS.ch. All rights reserved.
+ *
+ * <p>This program and the accompanying materials are dual-licensed under either the terms of the
+ * Eclipse Public License v1.0 as published by the Eclipse Foundation
+ *
+ * <p>or (per the licensee's choosing)
+ *
+ * <p>under the terms of the GNU Lesser General Public License version 2.1 as published by the Free
+ * Software Foundation.
+ */
+package com.microsoft.applicationinsights.agent.internal.logbackpatch;
+
+import static ch.qos.logback.core.CoreConstants.CODES_URL;
+
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.rolling.RollingPolicyBase;
+import ch.qos.logback.core.rolling.RolloverFailure;
+import ch.qos.logback.core.rolling.helper.CompressionMode;
+import ch.qos.logback.core.rolling.helper.Compressor;
+import ch.qos.logback.core.rolling.helper.FileFilterUtil;
+import ch.qos.logback.core.rolling.helper.IntegerTokenConverter;
+import ch.qos.logback.core.rolling.helper.RenameUtil;
+import java.io.File;
+import java.util.Date;
+
+// copied from ch.qos.logback.core.rolling.FixedWindowRollingPolicy
+// in order to support weird file directories like
+@SuppressWarnings({"MethodCanBeStatic", "EmptyBlockTag", "ThrowsUncheckedException"})
+public class FixedWindowRollingPolicy extends RollingPolicyBase {
+
+  FileNamePattern fileNamePattern;
+  FileNamePattern zipEntryFileNamePattern;
+
+  static final String FNP_NOT_SET =
+      "The \"FileNamePattern\" property must be set before using FixedWindowRollingPolicy. ";
+  static final String PRUDENT_MODE_UNSUPPORTED =
+      "See also " + CODES_URL + "#tbr_fnp_prudent_unsupported";
+  static final String SEE_PARENT_FN_NOT_SET =
+      "Please refer to " + CODES_URL + "#fwrp_parentFileName_not_set";
+  int maxIndex;
+  int minIndex;
+  RenameUtil util = new RenameUtil();
+  Compressor compressor;
+
+  public static final String ZIP_ENTRY_DATE_PATTERN = "yyyy-MM-dd_HHmm";
+
+  /** It's almost always a bad idea to have a large window size, say over 20. */
+  private static final int MAX_WINDOW_SIZE = 20;
+
+  public FixedWindowRollingPolicy() {
+    minIndex = 1;
+    maxIndex = 7;
+  }
+
+  @Override
+  public void start() {
+    util.setContext(this.context);
+
+    if (fileNamePatternStr != null) {
+      fileNamePattern = new FileNamePattern(fileNamePatternStr, this.context);
+      determineCompressionMode();
+    } else {
+      addError(FNP_NOT_SET);
+      addError(CoreConstants.SEE_FNP_NOT_SET);
+      throw new IllegalStateException(FNP_NOT_SET + CoreConstants.SEE_FNP_NOT_SET);
+    }
+
+    if (isParentPrudent()) {
+      addError("Prudent mode is not supported with FixedWindowRollingPolicy.");
+      addError(PRUDENT_MODE_UNSUPPORTED);
+      throw new IllegalStateException("Prudent mode is not supported.");
+    }
+
+    if (getParentsRawFileProperty() == null) {
+      addError("The File name property must be set before using this rolling policy.");
+      addError(SEE_PARENT_FN_NOT_SET);
+      throw new IllegalStateException("The \"File\" option must be set.");
+    }
+
+    if (maxIndex < minIndex) {
+      addWarn("MaxIndex (" + maxIndex + ") cannot be smaller than MinIndex (" + minIndex + ").");
+      addWarn("Setting maxIndex to equal minIndex.");
+      maxIndex = minIndex;
+    }
+
+    final int maxWindowSize = getMaxWindowSize();
+    if ((maxIndex - minIndex) > maxWindowSize) {
+      addWarn("Large window sizes are not allowed.");
+      maxIndex = minIndex + maxWindowSize;
+      addWarn("MaxIndex reduced to " + maxIndex);
+    }
+
+    IntegerTokenConverter itc = fileNamePattern.getIntegerTokenConverter();
+
+    if (itc == null) {
+      throw new IllegalStateException(
+          "FileNamePattern ["
+              + fileNamePattern.getPattern()
+              + "] does not contain a valid IntegerToken");
+    }
+
+    if (compressionMode == CompressionMode.ZIP) {
+      String zipEntryFileNamePatternStr = transformFileNamePatternFromInt2Date(fileNamePatternStr);
+      zipEntryFileNamePattern = new FileNamePattern(zipEntryFileNamePatternStr, context);
+    }
+    compressor = new Compressor(compressionMode);
+    compressor.setContext(this.context);
+    super.start();
+  }
+
+  /**
+   * Subclasses can override this method to increase the max window size, if required. This is to
+   * address LOGBACK-266.
+   *
+   * @return
+   */
+  protected int getMaxWindowSize() {
+    return MAX_WINDOW_SIZE;
+  }
+
+  private String transformFileNamePatternFromInt2Date(String fileNamePatternStr) {
+    String slashified = FileFilterUtil.slashify(fileNamePatternStr);
+    String stemOfFileNamePattern = FileFilterUtil.afterLastSlash(slashified);
+    return stemOfFileNamePattern.replace("%i", "%d{" + ZIP_ENTRY_DATE_PATTERN + "}");
+  }
+
+  @Override
+  public void rollover() throws RolloverFailure {
+
+    // Inside this method it is guaranteed that the hereto active log file is
+    // closed.
+    // If maxIndex <= 0, then there is no file renaming to be done.
+    if (maxIndex >= 0) {
+      // Delete the oldest file, to keep Windows happy.
+      File file = new File(fileNamePattern.convertInt(maxIndex));
+
+      if (file.exists()) {
+        file.delete();
+      }
+
+      // Map {(maxIndex - 1), ..., minIndex} to {maxIndex, ..., minIndex+1}
+      for (int i = maxIndex - 1; i >= minIndex; i--) {
+        String toRenameStr = fileNamePattern.convertInt(i);
+        File toRename = new File(toRenameStr);
+        // no point in trying to rename an inexistent file
+        if (toRename.exists()) {
+          util.rename(toRenameStr, fileNamePattern.convertInt(i + 1));
+        } else {
+          addInfo("Skipping roll-over for inexistent file " + toRenameStr);
+        }
+      }
+
+      // move active file name to min
+      switch (compressionMode) {
+        case NONE:
+          util.rename(getActiveFileName(), fileNamePattern.convertInt(minIndex));
+          break;
+        case GZ:
+          compressor.compress(getActiveFileName(), fileNamePattern.convertInt(minIndex), null);
+          break;
+        case ZIP:
+          compressor.compress(
+              getActiveFileName(),
+              fileNamePattern.convertInt(minIndex),
+              zipEntryFileNamePattern.convert(new Date()));
+          break;
+      }
+    }
+  }
+
+  /** Return the value of the parent's RawFile property. */
+  @Override
+  public String getActiveFileName() {
+    return getParentsRawFileProperty();
+  }
+
+  public int getMaxIndex() {
+    return maxIndex;
+  }
+
+  public int getMinIndex() {
+    return minIndex;
+  }
+
+  public void setMaxIndex(int maxIndex) {
+    this.maxIndex = maxIndex;
+  }
+
+  public void setMinIndex(int minIndex) {
+    this.minIndex = minIndex;
+  }
+}

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicy.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicy.java
@@ -31,6 +31,7 @@
  * <p>under the terms of the GNU Lesser General Public License version 2.1 as published by the Free
  * Software Foundation.
  */
+
 package com.microsoft.applicationinsights.agent.internal.logbackpatch;
 
 import static ch.qos.logback.core.CoreConstants.CODES_URL;
@@ -134,8 +135,6 @@ public class FixedWindowRollingPolicy extends RollingPolicyBase {
   /**
    * Subclasses can override this method to increase the max window size, if required. This is to
    * address LOGBACK-266.
-   *
-   * @return
    */
   protected int getMaxWindowSize() {
     return MAX_WINDOW_SIZE;

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FileNamePatternTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FileNamePatternTest.java
@@ -1,0 +1,35 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.agent.internal.logbackpatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class FileNamePatternTest {
+
+  @Test
+  public void test() {
+    assertThat(FileNamePattern.escapeDirectory("/test%20-test/filename%i.log"))
+        .isEqualTo("/test\\%20-test/filename%i.log");
+  }
+}

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicyTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/logbackpatch/FixedWindowRollingPolicyTest.java
@@ -1,0 +1,73 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.agent.internal.logbackpatch;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+public class FixedWindowRollingPolicyTest {
+
+  @Test
+  public void shouldFailWithOriginalFixedWindowRollingPolicy() {
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
+    appender.setContext(loggerContext);
+    appender.setName("FILE");
+    appender.setFile("test.log");
+
+    ch.qos.logback.core.rolling.FixedWindowRollingPolicy rollingPolicy =
+        new ch.qos.logback.core.rolling.FixedWindowRollingPolicy();
+    rollingPolicy.setContext(loggerContext);
+    rollingPolicy.setFileNamePattern(
+        "/test%20-test/applicationinsights-extension-%d{yyyy-MM-dd}.%i.log.old");
+    rollingPolicy.setMinIndex(1);
+    rollingPolicy.setMaxIndex(10);
+    rollingPolicy.setParent(appender);
+
+    Assertions.assertThrows(NumberFormatException.class, rollingPolicy::start);
+  }
+
+  @Test
+  public void shouldNotFailWithPatchedFixedWindowRollingPolicy() {
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
+    appender.setContext(loggerContext);
+    appender.setName("FILE");
+    appender.setFile("test.log");
+
+    FixedWindowRollingPolicy rollingPolicy = new FixedWindowRollingPolicy();
+    rollingPolicy.setContext(loggerContext);
+    rollingPolicy.setFileNamePattern(
+        "/test%20-test/applicationinsights-extension-%d{yyyy-MM-dd}.%i.log.old");
+    rollingPolicy.setMinIndex(1);
+    rollingPolicy.setMaxIndex(10);
+    rollingPolicy.setParent(appender);
+
+    rollingPolicy.start();
+  }
+}

--- a/agent/agent/gradle.lockfile
+++ b/agent/agent/gradle.lockfile
@@ -3,8 +3,8 @@
 # This file is expected to be part of source control.
 ch.qos.logback.contrib:logback-json-classic:0.1.5=runtimeClasspath
 ch.qos.logback.contrib:logback-json-core:0.1.5=runtimeClasspath
-ch.qos.logback:logback-classic:1.2.3=runtimeClasspath
-ch.qos.logback:logback-core:1.2.3=runtimeClasspath
+ch.qos.logback:logback-classic:1.2.6=runtimeClasspath
+ch.qos.logback:logback-core:1.2.6=runtimeClasspath
 com.google.code.findbugs:jsr305:3.0.2=runtimeClasspath
 com.google.guava:guava-bom:30.1.1-jre=runtimeClasspath
 com.squareup.moshi:moshi:1.11.0=runtimeClasspath
@@ -24,5 +24,5 @@ io.opentelemetry:opentelemetry-bom:1.7.0=runtimeClasspath
 io.opentelemetry:opentelemetry-context:1.7.0=runtimeClasspath
 io.opentelemetry:opentelemetry-semconv:1.7.0-alpha=runtimeClasspath
 org.junit:junit-bom:5.7.2=runtimeClasspath
-org.slf4j:slf4j-api:1.7.30=runtimeClasspath
+org.slf4j:slf4j-api:1.7.32=runtimeClasspath
 empty=

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -89,7 +89,7 @@ val DEPENDENCY_SETS = listOf(
 )
 
 val DEPENDENCIES = listOf(
-  "ch.qos.logback:logback-classic:1.2.3",
+  "ch.qos.logback:logback-classic:1.2.6",
   "ch.qos.logback.contrib:logback-json-classic:0.1.5",
   "com.google.auto.service:auto-service:1.0",
   "com.uber.nullaway:nullaway:0.9.1",


### PR DESCRIPTION
Currently the agent fails to start when it's located in a weird folder name like `test%20-test`.