### PR TITLE
DRAFT: Fix log sampling behavior

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exporter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exporter.java
@@ -84,7 +84,7 @@ public class Exporter implements SpanExporter {
   public static final AttributeKey<String> AI_OPERATION_NAME_KEY =
       AttributeKey.stringKey("applicationinsights.internal.operation_name");
 
-  private static final AttributeKey<Boolean> AI_LOG_KEY =
+  public static final AttributeKey<Boolean> AI_LOG_KEY =
       AttributeKey.booleanKey("applicationinsights.internal.log");
 
   public static final AttributeKey<String> AI_LEGACY_PARENT_ID_KEY =

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiSampler.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiSampler.java
@@ -21,6 +21,7 @@
 
 package com.microsoft.applicationinsights.agent.internal.sampling;
 
+import com.microsoft.applicationinsights.agent.internal.exporter.Exporter;
 import com.microsoft.applicationinsights.agent.internal.sampling.SamplingOverrides.MatcherGroup;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
@@ -86,6 +87,13 @@ class AiSampler implements Sampler {
       SpanKind spanKind,
       Attributes attributes,
       List<LinkData> parentLinks) {
+
+    if (attributes.get(Exporter.AI_LOG_KEY) != null) {
+      // for root - want to capture all logs that are not part of trace
+      // for remoteParentSampled and localParentSampled - want to capture all logs that are part of
+      // sampled trace
+      return SamplingResult.recordAndSample();
+    }
 
     MatcherGroup override = samplingOverrides.getOverride(spanKind, attributes);
 


### PR DESCRIPTION
DRAFT b/c even though it's changing undocumented behavior, we should consider waiting to merge until ready for version bump to 3.3.0.

Logs being captured as spans is a temporary implementation detail that we need to hide, since it will be changing once OpenTelemetry logs are stable and can be used instead.

Currently we only support single default behavior when it comes to log sampling:
* If a log is not part of a trace, capture it.
* If a log is part of a trace, sample it if the trace is being sampled.