### PR TITLE
Update 2.x SDK log4j2 appender to not pull in log4j2 on its own

### DIFF
--- a/logging/log4j2/build.gradle
+++ b/logging/log4j2/build.gradle
@@ -33,6 +33,6 @@ projectPomDescription = "This module provides a $project.msftAppInsights appende
 // endregion Publishing properties
 
 dependencies {
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
+    compileOnly group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
 }

--- a/logging/log4j2/build.gradle
+++ b/logging/log4j2/build.gradle
@@ -33,6 +33,6 @@ projectPomDescription = "This module provides a $project.msftAppInsights appende
 // endregion Publishing properties
 
 dependencies {
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
 }

--- a/logging/log4j2/build.gradle
+++ b/logging/log4j2/build.gradle
@@ -35,4 +35,6 @@ projectPomDescription = "This module provides a $project.msftAppInsights appende
 dependencies {
     compileOnly group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
+
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
 }

--- a/logging/log4j2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/logging/log4j2/gradle/dependency-locks/compileClasspath.lockfile
@@ -16,8 +16,8 @@ eu.infomas:annotation-detector:3.0.5
 org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.3
 org.apache.httpcomponents:httpcore:4.4.6
-org.apache.logging.log4j:log4j-api:2.11.0
-org.apache.logging.log4j:log4j-core:2.11.0
+org.apache.logging.log4j:log4j-api:2.15.0
+org.apache.logging.log4j:log4j-core:2.15.0
 org.checkerframework:checker-compat-qual:2.5.2
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 xmlpull:xmlpull:1.1.3.1

--- a/logging/log4j2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/logging/log4j2/gradle/dependency-locks/compileClasspath.lockfile
@@ -16,8 +16,8 @@ eu.infomas:annotation-detector:3.0.5
 org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.3
 org.apache.httpcomponents:httpcore:4.4.6
-org.apache.logging.log4j:log4j-api:2.15.0
-org.apache.logging.log4j:log4j-core:2.15.0
+org.apache.logging.log4j:log4j-api:2.11.0
+org.apache.logging.log4j:log4j-core:2.11.0
 org.checkerframework:checker-compat-qual:2.5.2
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 xmlpull:xmlpull:1.1.3.1

--- a/logging/log4j2/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/logging/log4j2/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -16,8 +16,8 @@ eu.infomas:annotation-detector:3.0.5
 org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.3
 org.apache.httpcomponents:httpcore:4.4.6
-org.apache.logging.log4j:log4j-api:2.11.0
-org.apache.logging.log4j:log4j-core:2.11.0
+org.apache.logging.log4j:log4j-api:2.15.0
+org.apache.logging.log4j:log4j-core:2.15.0
 org.checkerframework:checker-compat-qual:2.5.2
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 xmlpull:xmlpull:1.1.3.1

--- a/logging/log4j2/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/logging/log4j2/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -16,8 +16,6 @@ eu.infomas:annotation-detector:3.0.5
 org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.3
 org.apache.httpcomponents:httpcore:4.4.6
-org.apache.logging.log4j:log4j-api:2.15.0
-org.apache.logging.log4j:log4j-core:2.15.0
 org.checkerframework:checker-compat-qual:2.5.2
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 xmlpull:xmlpull:1.1.3.1

--- a/test/smoke/testApps/Jdbc/build.gradle
+++ b/test/smoke/testApps/Jdbc/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile aiWebJar
 
     compile group: 'org.hsqldb', name: 'hsqldb', version: '2.3.6' // 2.4.0+ requires Java 8+
-    compile group: 'mysql', name: 'mysql-connector-java', version: '5.1.43' // the old agent did not support 8.x
+    compile group: 'mysql', name: 'mysql-connector-java', version: '5.1.49' // the old agent did not support 8.x
     compile group: 'org.postgresql', name: 'postgresql', version: '42.2.5.jre7'
     compile group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '6.4.0.jre7' // 6.5.0+ requires Java 8+
 

--- a/test/smoke/testApps/Jdbc/src/main/java/com/microsoft/applicationinsights/smoketestapp/JdbcTestServlet.java
+++ b/test/smoke/testApps/Jdbc/src/main/java/com/microsoft/applicationinsights/smoketestapp/JdbcTestServlet.java
@@ -263,7 +263,12 @@ public class JdbcTestServlet extends HttpServlet {
 
     private static Connection getMysqlConnection() throws Exception {
         String hostname = System.getenv("MYSQL");
-        return DriverManager.getConnection("jdbc:mysql://" + hostname + "/mysql?autoReconnect=true&useSSL=true&verifyServerCertificate=false", "root", "password");
+        return DriverManager.getConnection(
+                "jdbc:mysql://"
+                        + hostname
+                        + "/mysql?autoReconnect=true&useSSL=true&enabledTLSProtocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3&verifyServerCertificate=false",
+                "root",
+                "password");
     }
 
     private static Connection getPostgresConnection() throws Exception {


### PR DESCRIPTION
The 2.x SDK log4j2 appender is designed for users who are already using log4j2. It should not pull in log4j2 on its own. Users should already be bringing their own version of log4j2 (and should be upgrading that version or applying the mitigation steps from [CVE-2021-44228](https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/)). The PR ensures that users *have* to bring their own version of log4j2.