### PR TITLE
Update Log4j to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/test/smoke/testApps/TraceLog4j2/build.gradle.kts
+++ b/test/smoke/testApps/TraceLog4j2/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-  implementation("org.apache.logging.log4j:log4j-api:2.17.0")
-  implementation("org.apache.logging.log4j:log4j-core:2.17.0")
+  implementation("org.apache.logging.log4j:log4j-api:2.17.1")
+  implementation("org.apache.logging.log4j:log4j-core:2.17.1")
   implementation("com.microsoft.azure:applicationinsights-web") {
     // applicationinsights-core is embedded in applicationinsights-web
     // and duplicate class files produces lots of warning messages on jetty

--- a/test/smoke/testApps/TraceLog4j2UsingAgent/build.gradle.kts
+++ b/test/smoke/testApps/TraceLog4j2UsingAgent/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation("org.apache.logging.log4j:log4j-api:2.17.0")
-  implementation("org.apache.logging.log4j:log4j-core:2.17.0")
+  implementation("org.apache.logging.log4j:log4j-api:2.17.1")
+  implementation("org.apache.logging.log4j:log4j-core:2.17.1")
   implementation("com.microsoft.azure:applicationinsights-web-auto")
 }


### PR DESCRIPTION
Updating Log4j version to 2.17.1 because of CVE-2021-44832 vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
