### PR TITLE
Make vertx opt-in preview instrumentation for now

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
@@ -337,6 +337,8 @@ public class Configuration {
 
     public DisabledByDefaultInstrumentation springIntegration =
         new DisabledByDefaultInstrumentation();
+
+    public DisabledByDefaultInstrumentation vertx = new DisabledByDefaultInstrumentation();
   }
 
   public static class PreviewStatsbeat {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/ConfigOverride.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/ConfigOverride.java
@@ -100,6 +100,10 @@ class ConfigOverride {
       // springIntegration instrumentation is ON by default in OTEL
       properties.put("otel.instrumentation.spring-integration.enabled", "false");
     }
+    if (!config.preview.instrumentation.vertx.enabled) {
+      // vertx instrumentation is ON by default in OTEL
+      properties.put("otel.instrumentation.vertx.enabled", "false");
+    }
     if (!config.preview.captureControllerSpans) {
       properties.put("otel.instrumentation.common.experimental.suppress-controller-spans", "true");
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/Feature.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/Feature.java
@@ -56,7 +56,8 @@ enum Feature {
   PLAY_DISABLED(25), // preview instrumentation, play is ON by default in OTEL
   CAPTURE_HTTP_SERVER_4XX_AS_SUCCESS(26),
   CAPTURE_HTTP_SERVER_HEADERS(27),
-  CAPTURE_HTTP_CLIENT_HEADERS(28);
+  CAPTURE_HTTP_CLIENT_HEADERS(28),
+  VERTX_DISABLED(29); // preview instrumentation, vertx is ON by default in OTEL
 
   private static final Map<String, Feature> javaVendorFeatureMap;
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/FeatureStatsbeat.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/statsbeat/FeatureStatsbeat.java
@@ -147,6 +147,9 @@ public class FeatureStatsbeat extends BaseStatsbeat {
     if (!config.preview.instrumentation.springIntegration.enabled) {
       featureList.add(Feature.SPRING_INTEGRATION_DISABLED);
     }
+    if (!config.preview.instrumentation.vertx.enabled) {
+      featureList.add(Feature.VERTX_DISABLED);
+    }
 
     // Statsbeat
     if (config.preview.statsbeat.disabled) {


### PR DESCRIPTION
initially added in 3.2.5-BETA, ok to switch it to preview prior to 3.2.5 GA. will make it on-by-default in the future after getting positive feedback for the preview instrumentation

linking to original request: #1651