### PR TITLE
Separate queue for metrics to avoid dropping telemetry

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
@@ -244,7 +244,10 @@ public class Configuration {
 
     public List<InstrumentationKeyOverride> instrumentationKeyOverrides = new ArrayList<>();
 
-    public int exportQueueCapacity = 2048;
+    public int generalExportQueueCapacity = 2048;
+    // metrics get flooded every 60 seconds by default, so need larger queue size to avoid dropping
+    // telemetry (they are much smaller so a larger queue size is ok)
+    public int metricsExportQueueCapacity = 65536;
   }
 
   public static class InheritedAttribute {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiComponentInstaller.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiComponentInstaller.java
@@ -173,7 +173,8 @@ class AiComponentInstaller {
             .setIkeyEndpointMap(ikeyEndpointMap)
             .setStatsbeatModule(statsbeatModule)
             .setReadOnlyFileSystem(readOnlyFileSystem)
-            .setMaxExportQueueSize(config.preview.exportQueueCapacity)
+            .setGeneralExportQueueSize(config.preview.generalExportQueueCapacity)
+            .setMetricsExportQueueSize(config.preview.metricsExportQueueCapacity)
             .setAadAuthentication(config.preview.authentication)
             .build();
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/BatchSpanProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/BatchSpanProcessor.java
@@ -61,7 +61,8 @@ public final class BatchSpanProcessor {
       long scheduleDelayNanos,
       int maxQueueSize,
       int maxExportBatchSize,
-      long exporterTimeoutNanos) {
+      long exporterTimeoutNanos,
+      String queueName) {
     MpscArrayQueue<TelemetryItem> queue = new MpscArrayQueue<>(maxQueueSize);
     this.worker =
         new Worker(
@@ -70,7 +71,8 @@ public final class BatchSpanProcessor {
             maxExportBatchSize,
             exporterTimeoutNanos,
             queue,
-            queue.capacity());
+            queue.capacity(),
+            queueName);
     Thread workerThread = new DaemonThreadFactory(WORKER_THREAD_NAME).newThread(worker);
     workerThread.start();
   }
@@ -103,6 +105,7 @@ public final class BatchSpanProcessor {
 
     private final Queue<TelemetryItem> queue;
     private final int queueCapacity;
+    private final String queueName;
     // When waiting on the spans queue, exporter thread sets this atomic to the number of more
     // spans it needs before doing an export. Writer threads would then wait for the queue to reach
     // spansNeeded size before notifying the exporter thread about new entries.
@@ -124,13 +127,15 @@ public final class BatchSpanProcessor {
         int maxExportBatchSize,
         long exporterTimeoutNanos,
         Queue<TelemetryItem> queue,
-        int queueCapacity) {
+        int queueCapacity,
+        String queueName) {
       this.spanExporter = spanExporter;
       this.scheduleDelayNanos = scheduleDelayNanos;
       this.maxExportBatchSize = maxExportBatchSize;
       this.exporterTimeoutNanos = exporterTimeoutNanos;
       this.queue = queue;
       this.queueCapacity = queueCapacity;
+      this.queueName = queueName;
       this.signal = new ArrayBlockingQueue<>(1);
       this.batch = new ArrayList<>(this.maxExportBatchSize);
     }
@@ -138,11 +143,16 @@ public final class BatchSpanProcessor {
     private void addSpan(TelemetryItem span) {
       if (!queue.offer(span)) {
         queuingSpanLogger.recordFailure(
-            "Max export queue size of "
+            "Max "
+                + queueName
+                + " export queue capacity of "
                 + queueCapacity
-                + " has been hit, dropping a span (max export queue size can be increased"
-                + " in the applicationinsights.json configuration file, e.g."
-                + " { \"preview\": { \"exportQueueCapacity\": "
+                + " has been hit, dropping a telemetry record (max "
+                + queueName
+                + " export queue capacity can be increased in the applicationinsights.json"
+                + " configuration file, e.g. { \"preview\": { \""
+                + queueName
+                + "ExportQueueCapacity\": "
                 + (queueCapacity * 2)
                 + " } }");
       } else {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/BatchSpanProcessorBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/BatchSpanProcessorBuilder.java
@@ -129,8 +129,13 @@ final class BatchSpanProcessorBuilder {
    * @return a new {@link io.opentelemetry.sdk.trace.export.BatchSpanProcessor}.
    * @throws NullPointerException if the {@code spanExporter} is {@code null}.
    */
-  public BatchSpanProcessor build() {
+  public BatchSpanProcessor build(String queueName) {
     return new BatchSpanProcessor(
-        spanExporter, scheduleDelayNanos, maxQueueSize, maxExportBatchSize, exporterTimeoutNanos);
+        spanExporter,
+        scheduleDelayNanos,
+        maxQueueSize,
+        maxExportBatchSize,
+        exporterTimeoutNanos,
+        queueName);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 // Project properties
-version=3.2.5-BETA
+version=3.2.5-BETA.2
 group=com.microsoft.azure
 # gradle default is 256m which causes sporadic failures - https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Creates a separate metrics channel batcher, since metrics are bursty (e.g. reported once a minute) and small so good to have a larger queue size for them.