### PR TITLE
Fix ingestion error on missing exception message

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exceptions.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exceptions.java
@@ -23,7 +23,6 @@ package com.microsoft.applicationinsights.agent.internal.exporter;
 
 import static java.util.Collections.singletonList;
 
-import com.microsoft.applicationinsights.agent.internal.common.Strings;
 import com.microsoft.applicationinsights.agent.internal.exporter.models.TelemetryExceptionDetails;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,10 +44,17 @@ public class Exceptions {
     }
     // at the end of the loop, current will be end of the first line
     if (separator != -1) {
-      details.setTypeName(str.substring(0, separator));
-      details.setMessage(Strings.trimAndEmptyToNull(str.substring(separator + 1, current)));
+      String typeName = str.substring(0, separator);
+      String message = str.substring(separator + 1, current).trim();
+      if (message.isEmpty()) {
+        message = typeName;
+      }
+      details.setTypeName(typeName);
+      details.setMessage(message);
     } else {
-      details.setTypeName(str.substring(0, current));
+      String typeName = str.substring(0, current);
+      details.setTypeName(typeName);
+      details.setMessage(typeName);
     }
     details.setStack(str);
     return singletonList(details);
@@ -83,10 +89,16 @@ public class Exceptions {
         current = new TelemetryExceptionDetails();
         int index = line.indexOf(':');
         if (index != -1) {
-          current.setTypeName(line.substring(0, index));
-          current.setMessage(Strings.trimAndEmptyToNull(line.substring(index + 1)));
+          String typeName = line.substring(0, index);
+          String message = line.substring(index + 1).trim();
+          if (message.isEmpty()) {
+            message = typeName;
+          }
+          current.setTypeName(typeName);
+          current.setMessage(message);
         } else {
           current.setTypeName(line);
+          current.setMessage(line);
         }
       }
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exporter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exporter.java
@@ -236,18 +236,33 @@ public class Exporter implements SpanExporter {
 
   private static List<TelemetryExceptionDetails> minimalParse(String errorStack) {
     TelemetryExceptionDetails details = new TelemetryExceptionDetails();
-    String line = errorStack.split(System.lineSeparator())[0];
+    String line = getFirstLine(errorStack);
     int index = line.indexOf(": ");
-
     if (index != -1) {
-      details.setTypeName(line.substring(0, index));
-      details.setMessage(line.substring(index + 2));
+      String typeName = line.substring(0, index);
+      details.setTypeName(typeName);
+      String message = line.substring(index + 2).trim();
+      if (message.isEmpty()) {
+        details.setMessage(typeName);
+      } else {
+        details.setMessage(message);
+      }
     } else {
       details.setTypeName(line);
+      details.setMessage(line);
     }
     // TODO (trask): map OpenTelemetry exception to Application Insights exception better
     details.setStack(errorStack);
     return Collections.singletonList(details);
+  }
+
+  private static String getFirstLine(String errorStack) {
+    int index = errorStack.indexOf(System.lineSeparator());
+    if (index != -1) {
+      return errorStack.substring(0, index);
+    } else {
+      return errorStack;
+    }
   }
 
   private void exportRemoteDependency(SpanData span, boolean inProc) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exporter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/Exporter.java
@@ -34,7 +34,6 @@ import com.microsoft.applicationinsights.agent.internal.exporter.models.RemoteDe
 import com.microsoft.applicationinsights.agent.internal.exporter.models.RequestData;
 import com.microsoft.applicationinsights.agent.internal.exporter.models.SeverityLevel;
 import com.microsoft.applicationinsights.agent.internal.exporter.models.TelemetryExceptionData;
-import com.microsoft.applicationinsights.agent.internal.exporter.models.TelemetryExceptionDetails;
 import com.microsoft.applicationinsights.agent.internal.exporter.models.TelemetryItem;
 import com.microsoft.applicationinsights.agent.internal.telemetry.FormattedDuration;
 import com.microsoft.applicationinsights.agent.internal.telemetry.FormattedTime;
@@ -231,37 +230,6 @@ public class Exporter implements SpanExporter {
       exportRequest(span);
     } else {
       throw new UnsupportedOperationException(kind.name());
-    }
-  }
-
-  private static List<TelemetryExceptionDetails> minimalParse(String errorStack) {
-    TelemetryExceptionDetails details = new TelemetryExceptionDetails();
-    String line = getFirstLine(errorStack);
-    int index = line.indexOf(": ");
-    if (index != -1) {
-      String typeName = line.substring(0, index);
-      details.setTypeName(typeName);
-      String message = line.substring(index + 2).trim();
-      if (message.isEmpty()) {
-        details.setMessage(typeName);
-      } else {
-        details.setMessage(message);
-      }
-    } else {
-      details.setTypeName(line);
-      details.setMessage(line);
-    }
-    // TODO (trask): map OpenTelemetry exception to Application Insights exception better
-    details.setStack(errorStack);
-    return Collections.singletonList(details);
-  }
-
-  private static String getFirstLine(String errorStack) {
-    int index = errorStack.indexOf(System.lineSeparator());
-    if (index != -1) {
-      return errorStack.substring(0, index);
-    } else {
-      return errorStack;
     }
   }
 
@@ -1024,7 +992,7 @@ public class Exporter implements SpanExporter {
     setSampleRate(telemetry, samplingPercentage);
 
     // set exception-specific properties
-    data.setExceptions(minimalParse(errorStack));
+    data.setExceptions(Exceptions.minimalParse(errorStack));
 
     telemetryClient.trackAsync(telemetry);
   }

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/exporter/ExceptionsTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/exporter/ExceptionsTest.java
@@ -60,7 +60,7 @@ class ExceptionsTest {
 
     TelemetryExceptionDetails details = list.get(0);
     assertThat(details.getTypeName()).isEqualTo(IllegalStateException.class.getName());
-    assertThat(details.getMessage()).isNull();
+    assertThat(details.getMessage()).isEqualTo(IllegalStateException.class.getName());
   }
 
   @Test
@@ -76,7 +76,7 @@ class ExceptionsTest {
 
     TelemetryExceptionDetails details = list.get(0);
     assertThat(details.getTypeName()).isEqualTo(ProblematicException.class.getName());
-    assertThat(details.getMessage()).isNull();
+    assertThat(details.getMessage()).isEqualTo(ProblematicException.class.getName());
   }
 
   @Test
@@ -108,7 +108,7 @@ class ExceptionsTest {
 
     TelemetryExceptionDetails details = list.get(0);
     assertThat(details.getTypeName()).isEqualTo(IllegalStateException.class.getName());
-    assertThat(details.getMessage()).isNull();
+    assertThat(details.getMessage()).isEqualTo(IllegalStateException.class.getName());
   }
 
   @Test
@@ -124,7 +124,7 @@ class ExceptionsTest {
 
     TelemetryExceptionDetails details = list.get(0);
     assertThat(details.getTypeName()).isEqualTo(ProblematicException.class.getName());
-    assertThat(details.getMessage()).isNull();
+    assertThat(details.getMessage()).isEqualTo(ProblematicException.class.getName());
   }
 
   @Test


### PR DESCRIPTION
Fixes issue where breeze rejects exception telemetry due to empty message:

```
{"itemsReceived":2,"itemsAccepted":1,"errors":[{"index":1,"statusCode":400,"message":"109: Field 'message' on type 'ExceptionDetails' is required but missing or empty. Expected: string, Actual:  "}]}
```