### PR TITLE
Log ingestion error on 206 response

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
@@ -163,13 +163,13 @@ public class LocalFileLoader {
 
   // either delete it permanently on success or add it back to cache to be processed again later on
   // failure
-  public void updateProcessedFileStatus(boolean success, File file) {
+  public void updateProcessedFileStatus(boolean successOrNonRetryableError, File file) {
     if (!file.exists()) {
       // not sure why this would happen
       updateOperationLogger.recordFailure("File no longer exists: " + file.getName());
       return;
     }
-    if (success) {
+    if (successOrNonRetryableError) {
       // delete a file on the queue permanently when http response returns success.
       if (!LocalStorageUtils.deleteFileWithRetries(file)) {
         // TODO (heya) track file deletion failure via Statsbeat

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoader.java
@@ -114,7 +114,7 @@ public class LocalFileLoader {
     byte[] ikeyBytes = new byte[36];
     int rawByteLength = (int) tempFile.length() - 36;
     byte[] telemetryBytes = new byte[rawByteLength];
-    String instrumentationKey = null;
+    String instrumentationKey;
     try (FileInputStream fileInputStream = new FileInputStream(tempFile)) {
       readFully(fileInputStream, ikeyBytes, 36);
       instrumentationKey = new String(ikeyBytes, UTF_8);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileSender.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileSender.java
@@ -64,17 +64,9 @@ public class LocalFileSender implements Runnable {
             telemetryChannel.sendRawBytes(
                 persistedFile.rawBytes,
                 persistedFile.instrumentationKey,
-                new TelemetryChannel.CompletionListener() {
-                  @Override
-                  public void onSuccess() {
-                    localFileLoader.updateProcessedFileStatus(true, persistedFile.file);
-                  }
-
-                  @Override
-                  public void onError(boolean retryable) {
-                    localFileLoader.updateProcessedFileStatus(!retryable, persistedFile.file);
-                  }
-                });
+                () -> localFileLoader.updateProcessedFileStatus(true, persistedFile.file),
+                retryable ->
+                    localFileLoader.updateProcessedFileStatus(!retryable, persistedFile.file));
         resultCode.join(30, TimeUnit.SECONDS); // wait max 30 seconds for request to be completed.
       }
     } catch (RuntimeException ex) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileSender.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileSender.java
@@ -61,9 +61,21 @@ public class LocalFileSender implements Runnable {
       LocalFileLoader.PersistedFile persistedFile = localFileLoader.loadTelemetriesFromDisk();
       if (persistedFile != null) {
         CompletableResultCode resultCode =
-            telemetryChannel.sendRawBytes(persistedFile.rawBytes, persistedFile.instrumentationKey);
+            telemetryChannel.sendRawBytes(
+                persistedFile.rawBytes,
+                persistedFile.instrumentationKey,
+                new TelemetryChannel.CompletionListener() {
+                  @Override
+                  public void onSuccess() {
+                    localFileLoader.updateProcessedFileStatus(true, persistedFile.file);
+                  }
+
+                  @Override
+                  public void onError(boolean retryable) {
+                    localFileLoader.updateProcessedFileStatus(!retryable, persistedFile.file);
+                  }
+                });
         resultCode.join(30, TimeUnit.SECONDS); // wait max 30 seconds for request to be completed.
-        localFileLoader.updateProcessedFileStatus(resultCode.isSuccess(), persistedFile.file);
       }
     } catch (RuntimeException ex) {
       logger.error(

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
@@ -307,7 +307,7 @@ public class TelemetryChannel {
                       break;
                     case 401: // breeze returns if aad enabled and no authentication token provided
                     case 403: // breeze returns if aad enabled or disabled (both cases) and
-                              // wrong/expired credentials provided
+                      // wrong/expired credentials provided
                     case 408: // REQUEST TIMEOUT
                     case 429: // TOO MANY REQUESTS
                     case 500: // INTERNAL SERVER ERROR

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
@@ -305,6 +305,7 @@ public class TelemetryChannel {
                           getErrorMessageFromPartialSuccessResponse(body));
                       onFailure.accept(false);
                       break;
+                    case 403: // AUTHORIZATION (AAD)
                     case 408: // REQUEST TIMEOUT
                     case 429: // TOO MANY REQUESTS
                     case 500: // INTERNAL SERVER ERROR

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryChannel.java
@@ -305,7 +305,9 @@ public class TelemetryChannel {
                           getErrorMessageFromPartialSuccessResponse(body));
                       onFailure.accept(false);
                       break;
-                    case 403: // AUTHORIZATION (AAD)
+                    case 401: // breeze returns if aad enabled and no authentication token provided
+                    case 403: // breeze returns if aad enabled or disabled (both cases) and
+                              // wrong/expired credentials provided
                     case 408: // REQUEST TIMEOUT
                     case 429: // TOO MANY REQUESTS
                     case 500: // INTERNAL SERVER ERROR

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/IntegrationTests.java
@@ -87,12 +87,12 @@ public class IntegrationTests {
                       () ->
                           new Exception("this is expected to be logged by the operation logger")));
     } else {
-      // 408, 429, 500, and 503 response codes are the only ones the result in storing to disk
+      // 401, 403, 408, 429, 500, and 503 response codes result in storing to disk
       when(mockedClient.send(any(HttpRequest.class), any(Context.class)))
           .then(
               invocation ->
                   Mono.just(
-                      new MockHttpResponse(invocation.getArgument(0, HttpRequest.class), 500)));
+                      new MockHttpResponse(invocation.getArgument(0, HttpRequest.class), 401)));
     }
     HttpPipelineBuilder pipelineBuilder = new HttpPipelineBuilder().httpClient(mockedClient);
     localFileCache = new LocalFileCache(tempFolder);

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/localstorage/LocalFileLoaderTests.java
@@ -277,7 +277,8 @@ public class LocalFileLoaderTests {
     for (int i = 0; i < 10; i++) {
       LocalFileLoader.PersistedFile persistedFile = localFileLoader.loadTelemetriesFromDisk();
       CompletableResultCode completableResultCode =
-          telemetryChannel.sendRawBytes(persistedFile.rawBytes, persistedFile.instrumentationKey);
+          telemetryChannel.sendRawBytes(
+              persistedFile.rawBytes, persistedFile.instrumentationKey, () -> {}, retryable -> {});
       completableResultCode.join(10, SECONDS);
       assertThat(completableResultCode.isSuccess()).isEqualTo(true);
       localFileLoader.updateProcessedFileStatus(true, persistedFile.file);
@@ -331,7 +332,8 @@ public class LocalFileLoaderTests {
       assertThat(persistedFile.instrumentationKey).isEqualTo(INSTRUMENTATION_KEY);
 
       CompletableResultCode completableResultCode =
-          telemetryChannel.sendRawBytes(persistedFile.rawBytes, persistedFile.instrumentationKey);
+          telemetryChannel.sendRawBytes(
+              persistedFile.rawBytes, persistedFile.instrumentationKey, () -> {}, retryable -> {});
       completableResultCode.join(10, SECONDS);
       assertThat(completableResultCode.isSuccess()).isEqualTo(false);
       localFileLoader.updateProcessedFileStatus(false, persistedFile.file);


### PR DESCRIPTION
Related to #2064, which we never noticed since we didn't log it.

Now the error in #2064 would be logged as:

```
2022-01-21 15:30:10.108-08:00 WARN  c.m.a.a.i.telemetry.TelemetryChannel - Sending telemetry to the ingestion service (telemetry will be stored to disk on failure and retried later): 109: Field 'message' on type 'ExceptionDetails' is required but missing or empty. Expected: string, Actual: undefined (future warnings will be aggregated and logged once every 5 minutes)
```