### PR TITLE
Fix URI parse error

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/UrlParser.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/UrlParser.java
@@ -26,6 +26,43 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 class UrlParser {
 
   /**
+   * Returns the "target" (host:port) portion of the url.
+   *
+   * <p>Returns {@code null} if the target cannot be extracted from url for any reason.
+   */
+  @Nullable
+  static String getTargetFromUrl(String url) {
+
+    int schemeEndIndex = url.indexOf(':');
+    if (schemeEndIndex == -1) {
+      // not a valid url
+      return null;
+    }
+
+    int len = url.length();
+    if (schemeEndIndex + 2 < len
+        && url.charAt(schemeEndIndex + 1) == '/'
+        && url.charAt(schemeEndIndex + 2) == '/') {
+      // has authority component
+      // look for
+      //   '/' - start of path
+      //   '?' or end of string - empty path
+      int index;
+      for (index = schemeEndIndex + 3; index < len; index++) {
+        char c = url.charAt(index);
+        if (c == '/' || c == '?' || c == '#') {
+          break;
+        }
+      }
+      String target = url.substring(schemeEndIndex + 3, index);
+      return target.isEmpty() ? null : target;
+    } else {
+      // has no authority
+      return null;
+    }
+  }
+
+  /**
    * Returns the path portion of the url.
    *
    * <p>Returns {@code null} if the path cannot be extracted from url for any reason.

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/exporter/UrlParserPathTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/exporter/UrlParserPathTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class UrlParserTest {
+public class UrlParserPathTest {
 
   @Test
   public void testGetPathFromUrl() {

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/exporter/UrlParserTargetTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/exporter/UrlParserTargetTest.java
@@ -1,0 +1,175 @@
+/*
+ * ApplicationInsights-Java
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the ""Software""), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.microsoft.applicationinsights.agent.internal.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class UrlParserTargetTest {
+
+  // there are more test cases here than needed, but they are just copied from UrlParserPathTest
+
+  @Test
+  public void testGetTargetFromUrl() {
+    assertThat(UrlParser.getTargetFromUrl("https://localhost")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path/")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path/")).isEqualTo("localhost");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost?")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/?")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path?")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path/?")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path?")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path/?")).isEqualTo("localhost");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost?query")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/?query")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path?query")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path/?query")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path?query"))
+        .isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path/?query"))
+        .isEqualTo("localhost");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost#")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/#")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path#")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path/#")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path#")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path/#")).isEqualTo("localhost");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost#fragment")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/#fragment")).isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path#fragment"))
+        .isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/path/#fragment"))
+        .isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path#fragment"))
+        .isEqualTo("localhost");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost/more/path/#fragment"))
+        .isEqualTo("localhost");
+  }
+
+  @Test
+  public void testGetTargetFromUrlWithPort() {
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080")).isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/")).isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path/"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path/"))
+        .isEqualTo("localhost:8080");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080?")).isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/?")).isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path?"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path/?"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path?"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path/?"))
+        .isEqualTo("localhost:8080");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080?query"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/?query"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path?query"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path/?query"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path?query"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path/?query"))
+        .isEqualTo("localhost:8080");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080#")).isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/#")).isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path#"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path/#"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path#"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path/#"))
+        .isEqualTo("localhost:8080");
+
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080#fragment"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/#fragment"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path#fragment"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/path/#fragment"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path#fragment"))
+        .isEqualTo("localhost:8080");
+    assertThat(UrlParser.getTargetFromUrl("https://localhost:8080/more/path/#fragment"))
+        .isEqualTo("localhost:8080");
+  }
+
+  @Test
+  public void testGetTargetFromUrlWithNoAuthority() {
+    assertThat(UrlParser.getTargetFromUrl("https:")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path/")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path/")).isNull();
+
+    assertThat(UrlParser.getTargetFromUrl("https:?")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/?")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path?")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path/?")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path?")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path/?")).isNull();
+
+    assertThat(UrlParser.getTargetFromUrl("https:?query")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/?query")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path?query")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path/?query")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path?query")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path/?query")).isNull();
+
+    assertThat(UrlParser.getTargetFromUrl("https:#")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/#")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path#")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path/#")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path#")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path/#")).isNull();
+
+    assertThat(UrlParser.getTargetFromUrl("https:#fragment")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/#fragment")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path#fragment")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/path/#fragment")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path#fragment")).isNull();
+    assertThat(UrlParser.getTargetFromUrl("https:/more/path/#fragment")).isNull();
+  }
+}


### PR DESCRIPTION
Fixes this error

```
WARN c.m.a.a.internal.exporter.Exporter - Parsing http.url: Illegal character in query at index 167: REDACTED
at java.net.URI$Parser.fail(URI.java:2845)
at java.net.URI$Parser.checkChars(URI.java:3018)
at java.net.URI$Parser.parseHierarchical(URI.java:3108)
at java.net.URI$Parser.parse(URI.java:3050)
at java.net.URI.<init>(URI.java:588)
at com.microsoft.applicationinsights.agent.internal.exporter.Exporter.getTargetForHttpClientSpan(Exporter.java:546)
at com.microsoft.applicationinsights.agent.internal.exporter.Exporter.applyHttpClientSpan(Exporter.java:479)
at com.microsoft.applicationinsights.agent.internal.exporter.Exporter.applySemanticConventions(Exporter.java:324)
at com.microsoft.applicationinsights.agent.internal.exporter.Exporter.exportRemoteDependency(Exporter.java:272)
at com.microsoft.applicationinsights.agent.internal.exporter.Exporter.internalExport(Exporter.java:221)
at com.microsoft.applicationinsights.agent.internal.exporter.Exporter.export(Exporter.java:177)
at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.exportCurrentBatch(BatchSpanProcessor.java:305)
at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.run(BatchSpanProcessor.java:222)
at java.lang.Thread.run(Thread.java:748)
```