### PR TITLE
Bump sql server docker image

### DIFF
--- a/test/smoke/testApps/Jdbc/build.gradle.kts
+++ b/test/smoke/testApps/Jdbc/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("ai.smoke-test-war")
 }
 
-aiSmokeTest.dependencyContainers.addAll("mysql:5", "postgres:11", "mcr.microsoft.com/mssql/server:2017-latest")
+aiSmokeTest.dependencyContainers.addAll("mysql:5", "postgres:11", "mcr.microsoft.com/mssql/server:2019-latest")
 
 dependencies {
   implementation("org.hsqldb:hsqldb:2.3.6") // 2.4.0+ requires Java 8+

--- a/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
+++ b/test/smoke/testApps/Jdbc/src/smokeTest/java/com/microsoft/applicationinsights/smoketestapp/JdbcTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
       environmentVariables = {"POSTGRES_PASSWORD=passw0rd2"},
       hostnameEnvironmentVariable = "POSTGRES"),
   @DependencyContainer(
-      value = "mcr.microsoft.com/mssql/server:2017-latest",
+      value = "mcr.microsoft.com/mssql/server:2019-latest",
       environmentVariables = {"ACCEPT_EULA=Y", "SA_PASSWORD=Password1"},
       portMapping = "1433",
       hostnameEnvironmentVariable = "SQLSERVER")


### PR DESCRIPTION
I added more diagnostics recently to debug sporadic jdbc smoke test failures, and found that the sql server container is failing to start sometimes:

```
    2022-01-25 21:56:52.81 spid29s     The activated proc '[dbo].[sp_syspolicy_events_reader]' running on queue 'msdb.dbo.syspolicy_event_queue' output the following:  'Transaction (Process ID 29) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.'
    2022-01-25 21:56:57.81 spid31s     Error: 1205, Severity: 13, State: 55.
    2022-01-25 21:56:57.81 spid31s     Transaction (Process ID 31) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.
    2022-01-25 21:56:57.83 spid31s     The default language (LCID 0) failed to be set for engine and full-text services.
    2022-01-25 21:56:57.83 spid31s     An error occurred during server setup. See previous errors for more information.
    2022-01-25 21:56:57.84 spid31s     SQL Trace was stopped due to server shutdown. Trace ID = '1'. This is an informational message only; no user action is required.
```

Not sure why, but worth bumping the version to see if we get lucky and it gets resolved.