### PR TITLE
Fix startup profiling

### DIFF
--- a/agent/agent/src/main/java/com/microsoft/applicationinsights/agent/StartupProfiler.java
+++ b/agent/agent/src/main/java/com/microsoft/applicationinsights/agent/StartupProfiler.java
@@ -77,6 +77,7 @@ final class StartupProfiler {
     }
 
     @Override
+    @SuppressWarnings("SystemOut")
     public void run() {
       long start = System.currentTimeMillis();
       while (System.currentTimeMillis() - start < MINUTES.toMillis(10)) {

--- a/agent/agent/src/main/java/com/microsoft/applicationinsights/agent/StartupProfiler.java
+++ b/agent/agent/src/main/java/com/microsoft/applicationinsights/agent/StartupProfiler.java
@@ -21,6 +21,8 @@
 
 package com.microsoft.applicationinsights.agent;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -30,8 +32,6 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 final class StartupProfiler {
 
@@ -41,21 +41,19 @@ final class StartupProfiler {
   public static void start() {
     String tempDirectory = System.getProperty("java.io.tmpdir");
     File folder = new File(tempDirectory, "applicationinsights");
-    if (!folder.exists()) {
-      folder.mkdirs();
+    if (!folder.exists() && !folder.mkdirs()) {
+      System.out.println("Failed to create directory: " + tempDirectory);
+      return;
     }
 
     File dumpFile = new File(folder, STACKTRACES);
     System.out.println("Writing startup profiler to '" + dumpFile.getPath() + "'");
 
-    PrintWriter printWriter = null;
-    try (PrintWriter out =
-        new PrintWriter(Files.newBufferedWriter(dumpFile.toPath(), Charset.defaultCharset()))) {
-      printWriter = new PrintWriter(out);
+    PrintWriter printWriter;
+    try {
+      printWriter =
+          new PrintWriter(Files.newBufferedWriter(dumpFile.toPath(), Charset.defaultCharset()));
     } catch (IOException e) {
-      if (printWriter != null) {
-        printWriter.close();
-      }
       System.out.println("Error occurred when writing dump to " + dumpFile.getPath());
       e.printStackTrace();
       return;
@@ -65,11 +63,10 @@ final class StartupProfiler {
   }
 
   private static void start(PrintWriter out) {
-    Executors.newSingleThreadScheduledExecutor()
-        .scheduleAtFixedRate(new ThreadDump(out), 50, 50, TimeUnit.MILLISECONDS);
+    Thread thread = new Thread(new ThreadDump(out), "StartupProfiler");
+    thread.setDaemon(true);
+    thread.start();
   }
-
-  private StartupProfiler() {}
 
   private static class ThreadDump implements Runnable {
 
@@ -81,8 +78,22 @@ final class StartupProfiler {
 
     @Override
     public void run() {
+      long start = System.currentTimeMillis();
+      while (System.currentTimeMillis() - start < MINUTES.toMillis(10)) {
+        try {
+          Thread.sleep(50);
+        } catch (InterruptedException e) {
+          System.out.println("Startup profiler interrupted");
+          return;
+        }
+        captureThreadDump();
+      }
+    }
+
+    private void captureThreadDump() {
       out.println("========================================");
       RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
+      out.print("uptime: ");
       out.println(runtimeBean.getUptime());
       out.println();
       ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
@@ -107,4 +118,6 @@ final class StartupProfiler {
       out.println();
     }
   }
+
+  private StartupProfiler() {}
 }


### PR DESCRIPTION
Startup profiling isn't writing out anything to the file because the PrintWriter is constructed in a try-with-resources block and so getting closed before it can be written to.

Also added a max 10 minute limit for startup profiling, so the file doesn't get enormous if someone forgets about it.