### PR TITLE
Respect traceflags sampling decision by default

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
@@ -217,9 +217,10 @@ public class Configuration {
     // world,
     // so safer to only allow single interval for now
     public int metricIntervalSeconds = 60;
-    // ignoreRemoteParentNotSampled is currently needed
-    // because .NET SDK always propagates trace flags "00" (not sampled)
-    public boolean ignoreRemoteParentNotSampled = true;
+    // ignoreRemoteParentNotSampled is sometimes needed because .NET SDK always propagates trace
+    // flags "00" (not sampled)
+    // in particular, it is always needed in Azure Functions worker
+    public boolean ignoreRemoteParentNotSampled = DiagnosticsHelper.rpIntegrationChar() == 'f';
     public boolean captureControllerSpans;
     // this is just here to detect if using this old setting in order to give a helpful message
     @Deprecated public boolean httpMethodInOperationName;

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -459,9 +459,6 @@ public class ConfigurationBuilder {
     if (rpConfiguration.sampling != null) {
       config.sampling.percentage = rpConfiguration.sampling.percentage;
     }
-    if (rpConfiguration.ignoreRemoteParentNotSampled != null) {
-      config.preview.ignoreRemoteParentNotSampled = rpConfiguration.ignoreRemoteParentNotSampled;
-    }
     if (isTrimEmpty(config.role.name)) {
       // only use rp configuration role name as a fallback, similar to WEBSITE_SITE_NAME
       config.role.name = rpConfiguration.role.name;

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/RpConfiguration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/RpConfiguration.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.microsoft.applicationinsights.agent.internal.configuration.Configuration.Role;
 import com.microsoft.applicationinsights.agent.internal.configuration.Configuration.Sampling;
 import java.nio.file.Path;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class RpConfiguration {
 
@@ -42,9 +41,4 @@ public class RpConfiguration {
   // on behalf of customers by default.
   // Note the role doesn't support hot load due to unnecessary currently.
   public Role role = new Role();
-
-  // this is needed in Azure Functions because .NET SDK always propagates trace flags "00" (not
-  // sampled)
-  // null means do not override the users selection
-  public @Nullable Boolean ignoreRemoteParentNotSampled;
 }


### PR DESCRIPTION
Important: this is a potentially breaking change and needs to be highlighted at https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent#download-the-jar-file

Related to [#1883](https://github.com/microsoft/ApplicationInsights-Java/issues/1883#issuecomment-1054106724)