### PR TITLE
Don't load expired telemetry

### DIFF
--- a/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/localstorage/LocalFileCache.java
+++ b/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/localstorage/LocalFileCache.java
@@ -79,14 +79,14 @@ class LocalFileCache {
     int index = name.indexOf('-');
     if (index == -1) {
       logger.debug("unexpected .trn file name: {}", name);
-      return false;
+      return true;
     }
     long timestamp;
     try {
       timestamp = Long.parseLong(name.substring(0, index));
     } catch (NumberFormatException e) {
       logger.debug("unexpected .trn file name: {}", name);
-      return false;
+      return true;
     }
     Date expirationDate = new Date(System.currentTimeMillis() - 1000 * expiredIntervalSeconds);
     Date fileDate = new Date(timestamp);

--- a/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/localstorage/LocalFileCache.java
+++ b/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/localstorage/LocalFileCache.java
@@ -23,30 +23,31 @@ package com.azure.monitor.opentelemetry.exporter.implementation.localstorage;
 
 import java.io.File;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class LocalFileCache {
 
+  private static final Logger logger = LoggerFactory.getLogger(LocalFileCache.class);
+
   /**
    * Track a list of active filenames persisted on disk. FIFO (First-In-First-Out) read will avoid
-   * an additional sorting at every read. Caveat: data loss happens when the app crashes. filenames
-   * stored in this queue will be lost forever. There isn't an unique way to identify each java app.
-   * C# uses "User@processName" to identify each app, but Java can't rely on process name since it's
-   * a system property that can be customized via the command line.
+   * an additional sorting at every read.
+   *
+   * <p>There isn't a unique way to identify each java app. C# uses "User@processName" to identify
+   * each app, but Java can't rely on process name since it's a system property that can be
+   * customized via the command line.
    */
   private final Queue<File> persistedFilesCache = new ConcurrentLinkedDeque<>();
 
   LocalFileCache(File folder) {
-    List<File> files = sortPersistedFiles(folder);
-    // existing files are not older than 48 hours and need to get added to the queue to be
-    // re-processed.
-    // this will avoid data loss in the case of app crashes and restarts.
-    for (File file : files) {
-      persistedFilesCache.add(file);
-    }
+    persistedFilesCache.addAll(loadPersistedFiles(folder));
   }
 
   // Track the newly persisted filename to the concurrent hashmap.
@@ -63,9 +64,32 @@ class LocalFileCache {
     return persistedFilesCache;
   }
 
-  private static List<File> sortPersistedFiles(File folder) {
+  // load existing files that are not older than 48 hours
+  // this will avoid data loss in the case of app crashes and restarts.
+  private static List<File> loadPersistedFiles(File folder) {
     return FileUtil.listTrnFiles(folder).stream()
         .sorted(Comparator.comparing(File::lastModified))
+        .filter(file -> !isExpired(file, TimeUnit.DAYS.toSeconds(2)))
         .collect(Collectors.toList());
+  }
+
+  // files that are older than expiredIntervalSeconds (default 48 hours) are expired
+  static boolean isExpired(File file, long expiredIntervalSeconds) {
+    String name = file.getName();
+    int index = name.indexOf('-');
+    if (index == -1) {
+      logger.debug("unexpected .trn file name: {}", name);
+      return false;
+    }
+    long timestamp;
+    try {
+      timestamp = Long.parseLong(name.substring(0, index));
+    } catch (NumberFormatException e) {
+      logger.debug("unexpected .trn file name: {}", name);
+      return false;
+    }
+    Date expirationDate = new Date(System.currentTimeMillis() - 1000 * expiredIntervalSeconds);
+    Date fileDate = new Date(timestamp);
+    return fileDate.before(expirationDate);
   }
 }

--- a/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/localstorage/LocalFilePurger.java
+++ b/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/localstorage/LocalFilePurger.java
@@ -26,7 +26,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import com.azure.monitor.opentelemetry.exporter.implementation.utils.ThreadPoolUtils;
 import java.io.File;
 import java.util.Collection;
-import java.util.Date;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -74,7 +73,7 @@ class LocalFilePurger implements Runnable {
     Collection<File> files = FileUtil.listTrnFiles(folder);
     int numDeleted = 0;
     for (File file : files) {
-      if (expired(file.getName())) {
+      if (LocalFileCache.isExpired(file, expiredIntervalSeconds)) {
         if (!FileUtil.deleteFileWithRetries(file)) {
           logger.warn(
               "Fail to delete the expired {} from folder '{}'.", file.getName(), folder.getName());
@@ -89,15 +88,5 @@ class LocalFilePurger implements Runnable {
           numDeleted,
           folder.getName());
     }
-  }
-
-  // files that are older than expiredIntervalSeconds (default 48 hours) are expired and need to
-  // be deleted permanently.
-  private boolean expired(String fileName) {
-    String time = fileName.substring(0, fileName.lastIndexOf('-'));
-    long milliseconds = Long.parseLong(time);
-    Date expirationDate = new Date(System.currentTimeMillis() - 1000 * expiredIntervalSeconds);
-    Date fileDate = new Date(milliseconds);
-    return fileDate.before(expirationDate);
   }
 }


### PR DESCRIPTION
I've noticed a couple of times getting breeze errors that telemetry has expired, because files are loaded from disk at startup before purge happens