### PR TITLE
Merge main into vnext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+# Version 3.2.10 GA
+* Fix Statsbeat warning [#2208](https://github.com/microsoft/ApplicationInsights-Java/pull/2208).
+
+# Version 3.2.9 GA
+* Increase export throughput [#2204](https://github.com/microsoft/ApplicationInsights-Java/pull/2204).
+* Fix parsing exception with colons [#2196](https://github.com/microsoft/ApplicationInsights-Java/issues/2196).
+* Remove reverse name lookup everywhere [#2205](https://github.com/microsoft/ApplicationInsights-Java/pull/2205).
+
 # Version 3.2.8 GA
 * Fix spring actuator endpoint behavior [#2146](https://github.com/microsoft/ApplicationInsights-Java/pull/2146).
 * Better JMX debug logging [#2157](https://github.com/microsoft/ApplicationInsights-Java/pull/2157).

--- a/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/builders/Exceptions.java
+++ b/agent/agent-tooling/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/builders/Exceptions.java
@@ -34,7 +34,7 @@ public final class Exceptions {
     int current;
     for (current = 0; current < length; current++) {
       char c = str.charAt(current);
-      if (c == ':') {
+      if (c == ':' && separator == -1) {
         separator = current;
       } else if (c == '\r' || c == '\n') {
         break;

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/OpenTelemetryConfigurer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/OpenTelemetryConfigurer.java
@@ -186,7 +186,7 @@ public class OpenTelemetryConfigurer implements AutoConfigurationCustomizerProvi
       builder.setMaxExportBatchSize(1);
     }
 
-    return builder.setScheduleDelay(Duration.ofMillis(100)).build();
+    return builder.build();
   }
 
   private static List<ProcessorConfig> getSpanProcessorConfigs(Configuration configuration) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/BatchItemProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/BatchItemProcessor.java
@@ -29,8 +29,10 @@ import io.opentelemetry.sdk.internal.DaemonThreadFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -63,6 +65,7 @@ public final class BatchItemProcessor {
       int maxQueueSize,
       int maxExportBatchSize,
       long exporterTimeoutNanos,
+      int maxPendingExports,
       String queueName) {
     MpscArrayQueue<TelemetryItem> queue = new MpscArrayQueue<>(maxQueueSize);
     this.worker =
@@ -71,6 +74,7 @@ public final class BatchItemProcessor {
             scheduleDelayNanos,
             maxExportBatchSize,
             exporterTimeoutNanos,
+            maxPendingExports,
             queue,
             queue.capacity(),
             queueName);
@@ -101,6 +105,7 @@ public final class BatchItemProcessor {
     private final long scheduleDelayNanos;
     private final int maxExportBatchSize;
     private final long exporterTimeoutNanos;
+    private final int maxPendingExports;
 
     private long nextExportTime;
 
@@ -119,14 +124,21 @@ public final class BatchItemProcessor {
     private volatile boolean continueWork = true;
     private final ArrayList<TelemetryItem> batch;
 
+    private final Set<CompletableResultCode> pendingExports =
+        Collections.newSetFromMap(new ConcurrentHashMap<>());
+
     private static final OperationLogger queuingItemLogger =
         new OperationLogger(BatchItemProcessor.class, "Queuing telemetry item");
+
+    private static final OperationLogger addAsyncExport =
+        new OperationLogger(BatchItemProcessor.class, "Add async export");
 
     private Worker(
         TelemetryItemExporter exporter,
         long scheduleDelayNanos,
         int maxExportBatchSize,
         long exporterTimeoutNanos,
+        int maxPendingExports,
         Queue<TelemetryItem> queue,
         int queueCapacity,
         String queueName) {
@@ -134,6 +146,7 @@ public final class BatchItemProcessor {
       this.scheduleDelayNanos = scheduleDelayNanos;
       this.maxExportBatchSize = maxExportBatchSize;
       this.exporterTimeoutNanos = exporterTimeoutNanos;
+      this.maxPendingExports = maxPendingExports;
       this.queue = queue;
       this.queueCapacity = queueCapacity;
       this.queueName = queueName;
@@ -207,8 +220,12 @@ public final class BatchItemProcessor {
         }
       }
       exportCurrentBatch();
-      flushRequested.get().succeed();
-      flushRequested.set(null);
+      CompletableResultCode.ofAll(pendingExports).join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+      CompletableResultCode flushResult = flushRequested.get();
+      if (flushResult != null) {
+        flushResult.succeed();
+        flushRequested.set(null);
+      }
     }
 
     private void updateNextExportTime() {
@@ -275,7 +292,24 @@ public final class BatchItemProcessor {
       try {
         // batching, retry, logging, and writing to disk on failure occur downstream
         CompletableResultCode result = exporter.send(Collections.unmodifiableList(batch));
-        result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        if (pendingExports.size() < maxPendingExports - 1) {
+          addAsyncExport.recordSuccess();
+          pendingExports.add(result);
+          result.whenComplete(
+              () -> {
+                pendingExports.remove(result);
+              });
+        } else {
+          // need conditional, otherwise this will always get logged when maxPendingExports is 1
+          // (e.g. statsbeat)
+          if (maxPendingExports > 1) {
+            addAsyncExport.recordFailure(
+                "Max number of concurrent exports "
+                    + maxPendingExports
+                    + " has been hit, may see some export throttling due to this");
+          }
+          result.join(exporterTimeoutNanos, TimeUnit.NANOSECONDS);
+        }
       } finally {
         batch.clear();
       }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryClient.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/telemetry/TelemetryClient.java
@@ -282,6 +282,9 @@ public class TelemetryClient {
             new TelemetryItemExporter(telemetryPipeline, telemetryPipelineListener))
         .setMaxQueueSize(exportQueueCapacity)
         .setMaxExportBatchSize(maxExportBatchSize)
+        // the number 100 was calculated as the max number of concurrent exports that the single
+        // worker thread can drive, so anything higher than this should not increase throughput
+        .setMaxPendingExports(100)
         .build(queueName);
   }
 

--- a/agent/agent-tooling/src/test/java/com/azure/monitor/opentelemetry/exporter/implementation/utils/ExceptionsTest.java
+++ b/agent/agent-tooling/src/test/java/com/azure/monitor/opentelemetry/exporter/implementation/utils/ExceptionsTest.java
@@ -50,6 +50,22 @@ public class ExceptionsTest {
   }
 
   @Test
+  public void testMinimalParseWithColonInMessage() {
+    // given
+    String str = toString(new IllegalStateException("hello: world"));
+
+    // when
+    List<ExceptionDetailBuilder> list = Exceptions.minimalParse(str);
+
+    // then
+    assertThat(list.size()).isEqualTo(1);
+
+    TelemetryExceptionDetails details = list.get(0).build();
+    assertThat(details.getTypeName()).isEqualTo(IllegalStateException.class.getName());
+    assertThat(details.getMessage()).isEqualTo("hello: world");
+  }
+
+  @Test
   public void testMinimalParseWithNoMessage() {
     // given
     String str = toString(new IllegalStateException());


### PR DESCRIPTION
Did not merge #2210, as that is handled differently now in `vnext` by not registering a `DiagnosticTelemetryPipelineListener` at all for the statsbeat channel.

Note: merge don't squash this PR