### PR TITLE
Fix build attachment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check
+          arguments: check assemble
       - name: Upload snapshot
         # only upload from windows since only that build includes etw
         if: matrix.os == 'windows-2019'


### PR DESCRIPTION
Agent jar is not currently getting attached to CI builds. It looks like I fixed this for PR builds already.