### PR TITLE
Fix spring-rabbit instrumentation name

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiConfigPropertySource.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiConfigPropertySource.java
@@ -238,7 +238,7 @@ public class AiConfigPropertySource implements ConfigPropertySource {
     }
     if (config.instrumentation.rabbitmq.enabled) {
       properties.put("otel.instrumentation.rabbitmq.enabled", "true");
-      properties.put("otel.instrumentation.spring-rabbitmq.enabled", "true");
+      properties.put("otel.instrumentation.spring-rabbit.enabled", "true");
     }
     if (config.instrumentation.redis.enabled) {
       properties.put("otel.instrumentation.jedis.enabled", "true");


### PR DESCRIPTION
this was a regression in 3.3.0-BETA

correct name is here: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/4f29770f73c6225b6698be88bbcb9ad5c832fa01/instrumentation/spring/spring-rabbit-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spring/rabbit/SpringRabbitInstrumentationModule.java#L18