### PR TITLE
Update span suppression strategy

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiConfigPropertySource.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiConfigPropertySource.java
@@ -139,6 +139,8 @@ public class AiConfigPropertySource implements ConfigPropertySource {
   private static void enableInstrumentations(Configuration config, Map<String, String> properties) {
     properties.put("otel.instrumentation.common.default-enabled", "false");
 
+    properties.put("otel.instrumentation.experimental.span-suppression-strategy", "client");
+
     // TODO (trask) remove these two after
     // https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5989
     properties.put("otel.instrumentation.oshi-metrics.enabled", "false");


### PR DESCRIPTION
I realized the default upstream span suppression strategy changed recently and I think we want to preserve the old behavior. Also see https://github.com/open-telemetry/opentelemetry.io/pull/1486