### PR TITLE
Improve the error message when the runtime attachment fails with a JRE or a read-only file system

### DIFF
--- a/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/AppInsightAgentFileProvider.java
+++ b/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/AppInsightAgentFileProvider.java
@@ -51,7 +51,9 @@ final class AppInsightAgentFileProvider {
     try {
       tempDir = Files.createTempDirectory("otel-agent");
     } catch (IOException e) {
-      throw new IllegalStateException("Runtime attachment can't create temp directory", e);
+      throw new IllegalStateException(
+          "Runtime attachment can't create a temp directory. You may use a read-only file system.",
+          e);
     }
     return tempDir;
   }

--- a/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/AppInsightAgentFileProvider.java
+++ b/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/AppInsightAgentFileProvider.java
@@ -67,7 +67,7 @@ final class AppInsightAgentFileProvider {
       Files.copy(jarAsInputStream, agentJarPath);
     } catch (IOException e) {
       throw new IllegalStateException(
-          "Runtime attachment can't create agent jar file in temp directory", e);
+          "Runtime attachment has failed. Are you using a JRE (not a JDK)?", e);
     }
     return agentJarPath;
   }

--- a/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
+++ b/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
@@ -66,7 +66,7 @@ public final class ApplicationInsights {
 
     try {
       RuntimeAttach.attachJavaagentToCurrentJvm(agentFile);
-    } catch (Exception e) {
+    } catch (IllegalStateException e) {
       if (e.getMessage()
           .contains("No compatible attachment provider is available")) { // Byte Buddy exception
         throw new RuntimeException("Runtime attachment was not done. You may use a JRE.", e);

--- a/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
+++ b/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
@@ -67,8 +67,9 @@ public final class ApplicationInsights {
     try {
       RuntimeAttach.attachJavaagentToCurrentJvm(agentFile);
     } catch (IllegalStateException e) {
-      if (e.getMessage()
-          .contains("No compatible attachment provider is available")) { // Byte Buddy exception
+      if (e.getMessage() != null
+          && e.getMessage()
+              .contains("No compatible attachment provider is available")) { // Byte Buddy exception
         throw new IllegalStateException("Runtime attachment was not done. You may use a JRE.", e);
       }
       throw e;

--- a/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
+++ b/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
@@ -69,7 +69,7 @@ public final class ApplicationInsights {
     } catch (IllegalStateException e) {
       if (e.getMessage()
           .contains("No compatible attachment provider is available")) { // Byte Buddy exception
-        throw new RuntimeException("Runtime attachment was not done. You may use a JRE.", e);
+        throw new IllegalStateException("Runtime attachment was not done. You may use a JRE.", e);
       }
       throw e;
     }

--- a/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
+++ b/agent/runtime-attach/src/main/java/com/microsoft/applicationinsights/attach/ApplicationInsights.java
@@ -64,7 +64,15 @@ public final class ApplicationInsights {
 
     File agentFile = AppInsightAgentFileProvider.getAgentFile();
 
-    RuntimeAttach.attachJavaagentToCurrentJvm(agentFile);
+    try {
+      RuntimeAttach.attachJavaagentToCurrentJvm(agentFile);
+    } catch (Exception e) {
+      if (e.getMessage()
+          .contains("No compatible attachment provider is available")) { // Byte Buddy exception
+        throw new RuntimeException("Runtime attachment was not done. You may use a JRE.", e);
+      }
+      throw e;
+    }
   }
 
   private static Optional<String> findJsonConfig() {


### PR DESCRIPTION
Improve the error message when the runtime attachment fails with a JRE