### PR TITLE
Reduce issue noise

### DIFF
--- a/.github/workflows/build-daily-no-build-cache.yml
+++ b/.github/workflows/build-daily-no-build-cache.yml
@@ -21,11 +21,3 @@ jobs:
     uses: ./.github/workflows/reusable-smoke-test.yml
     with:
       no-build-cache: true
-
-  open-issue-on-failure:
-    needs:
-      - assemble
-      - test
-      - smoke-test
-    if: failure()
-    uses: ./.github/workflows/reusable-open-issue-on-failure.yml

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -15,11 +15,3 @@ jobs:
 
   smoke-test:
     uses: ./.github/workflows/reusable-smoke-test.yml
-
-  open-issue-on-failure:
-    needs:
-      - assemble
-      - test
-      - smoke-test
-    if: failure()
-    uses: ./.github/workflows/reusable-open-issue-on-failure.yml

--- a/.github/workflows/reusable-open-issue-on-failure.yml
+++ b/.github/workflows/reusable-open-issue-on-failure.yml
@@ -14,5 +14,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue create --title "$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER failed" \
-                          --label bug \
                           --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."


### PR DESCRIPTION
build cached failed while restoring the gradle cache, which is something we see upstream a lot too, and would open issue each time, which I don't think is necessary in this repo