### PR TITLE
Fix log sampling

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/AgentLogExporter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/AgentLogExporter.java
@@ -29,6 +29,7 @@ import com.azure.monitor.opentelemetry.exporter.implementation.quickpulse.QuickP
 import com.microsoft.applicationinsights.agent.internal.telemetry.BatchItemProcessor;
 import com.microsoft.applicationinsights.agent.internal.telemetry.TelemetryClient;
 import com.microsoft.applicationinsights.agent.internal.telemetry.TelemetryObservers;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.data.LogData;
 import io.opentelemetry.sdk.logs.data.Severity;
@@ -83,7 +84,8 @@ public class AgentLogExporter implements LogExporter {
       return CompletableResultCode.ofFailure();
     }
     for (LogData log : logs) {
-      if (!log.getSpanContext().getTraceFlags().isSampled()) {
+      SpanContext spanContext = log.getSpanContext();
+      if (spanContext.isValid() && !spanContext.getTraceFlags().isSampled()) {
         continue;
       }
       logger.debug("exporting log: {}", log);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/AgentLogExporter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/AgentLogExporter.java
@@ -83,6 +83,9 @@ public class AgentLogExporter implements LogExporter {
       return CompletableResultCode.ofFailure();
     }
     for (LogData log : logs) {
+      if (!log.getSpanContext().getTraceFlags().isSampled()) {
+        continue;
+      }
       logger.debug("exporting log: {}", log);
       try {
         int severity = log.getSeverity().getSeverityNumber();

--- a/smoke-tests/apps/Sampling/src/main/java/com/microsoft/applicationinsights/smoketestapp/SimpleSamplingServlet.java
+++ b/smoke-tests/apps/Sampling/src/main/java/com/microsoft/applicationinsights/smoketestapp/SimpleSamplingServlet.java
@@ -25,6 +25,8 @@ import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.telemetry.EventTelemetry;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -35,6 +37,8 @@ import javax.servlet.http.HttpServletResponse;
     urlPatterns = {"/sampling"})
 public class SimpleSamplingServlet extends HttpServlet {
 
+  private static final Logger logger = Logger.getLogger(SimpleSamplingServlet.class.getName());
+
   private final TelemetryClient client = new TelemetryClient();
 
   private final AtomicInteger count = new AtomicInteger();
@@ -44,5 +48,7 @@ public class SimpleSamplingServlet extends HttpServlet {
     ServletFuncs.getRenderedHtml(request, response);
 
     client.trackEvent(new EventTelemetry("Event Test " + count.getAndIncrement()));
+
+    logger.log(Level.WARNING, "test");
   }
 }

--- a/smoke-tests/apps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
+++ b/smoke-tests/apps/Sampling/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/SamplingTest.java
@@ -49,19 +49,24 @@ abstract class SamplingTest {
     // super super low chance that number of sampled requests is less than 25
     long start = System.nanoTime();
     while (testing.mockedIngestion.getCountForType("RequestData") < 25
-        && NANOSECONDS.toSeconds(System.nanoTime() - start) < 10) {}
+        && NANOSECONDS.toSeconds(System.nanoTime() - start) < 10) {
+    }
     // wait ten more seconds before checking that we didn't receive too many
     Thread.sleep(SECONDS.toMillis(10));
 
     List<Envelope> requestEnvelopes =
         testing.mockedIngestion.getItemsEnvelopeDataType("RequestData");
     List<Envelope> eventEnvelopes = testing.mockedIngestion.getItemsEnvelopeDataType("EventData");
+    List<Envelope> messageEnvelopes = testing.mockedIngestion.getItemsEnvelopeDataType(
+        "MessageData");
     // super super low chance that number of sampled requests/dependencies/events
     // is less than 25 or greater than 75
     assertThat(requestEnvelopes.size()).isGreaterThanOrEqualTo(25);
     assertThat(requestEnvelopes.size()).isLessThanOrEqualTo(75);
     assertThat(eventEnvelopes.size()).isGreaterThanOrEqualTo(25);
     assertThat(eventEnvelopes.size()).isLessThanOrEqualTo(75);
+    assertThat(messageEnvelopes.size()).isGreaterThanOrEqualTo(25);
+    assertThat(messageEnvelopes.size()).isLessThanOrEqualTo(75);
 
     for (Envelope requestEnvelope : requestEnvelopes) {
       assertThat(requestEnvelope.getSampleRate()).isEqualTo(50);
@@ -69,10 +74,14 @@ abstract class SamplingTest {
     for (Envelope eventEnvelope : eventEnvelopes) {
       assertThat(eventEnvelope.getSampleRate()).isEqualTo(50);
     }
+    for (Envelope messageEnvelope : messageEnvelopes) {
+      assertThat(messageEnvelope.getSampleRate()).isEqualTo(50);
+    }
 
     for (Envelope requestEnvelope : requestEnvelopes) {
       String operationId = requestEnvelope.getTags().get("ai.operation.id");
       testing.mockedIngestion.waitForItemsInOperation("EventData", 1, operationId);
+      testing.mockedIngestion.waitForItemsInOperation("MessageData", 1, operationId);
     }
   }
 


### PR DESCRIPTION
Logs stopped getting sampled in 3.3.0, this restores previous (3.0-3.2.x) behavior.