### PR TITLE
Improve the error message when the profiler can't be initialized

### DIFF
--- a/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
+++ b/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
@@ -133,8 +133,11 @@ public class JfrProfiler implements ProfilerConfigurationHandler, Profiler {
         flightRecorderConnection = FlightRecorderDiagnosticCommandConnection.connect(mbeanServer);
       }
     } catch (Exception e) {
-      String message = "Unable to initialize the profiler." + (isOpenJ9Jvm()
-          ? " OpenJ9 JVM is not supported. Instead, please use an OpenJDK JVM." : "");
+      String message =
+          "Unable to initialize the profiler."
+              + (isOpenJ9Jvm()
+                  ? " OpenJ9 JVM is not supported. Instead, please use an OpenJDK JVM."
+                  : "");
       LOGGER.error(message, e);
       return false;
     }

--- a/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
+++ b/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
@@ -133,11 +133,18 @@ public class JfrProfiler implements ProfilerConfigurationHandler, Profiler {
         flightRecorderConnection = FlightRecorderDiagnosticCommandConnection.connect(mbeanServer);
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to connect to mbean", e);
+      String message = "Unable to initialize the profiler." + (isOpenJ9Jvm()
+          ? " OpenJ9 JVM is not supported. Instead, please use an OpenJDK JVM." : "");
+      LOGGER.error(message, e);
       return false;
     }
 
     return true;
+  }
+
+  private static boolean isOpenJ9Jvm() {
+    String jvmName = System.getProperty("java.vm.name");
+    return jvmName.contains("OpenJ9");
   }
 
   /** Apply new configuration settings obtained from Service Profiler. */

--- a/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
+++ b/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
@@ -132,6 +132,7 @@ public class JfrProfiler implements ProfilerConfigurationHandler, Profiler {
     return true;
   }
 
+  @Nullable
   private static FlightRecorderConnection createFlightRecorderConnection() {
     if (isOpenJ9Jvm()) {
       LOGGER.error(

--- a/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
+++ b/agent/agent-profiler/agent-service-profiler/src/main/java/com/microsoft/applicationinsights/serviceprofilerapi/profiler/JfrProfiler.java
@@ -134,11 +134,6 @@ public class JfrProfiler implements ProfilerConfigurationHandler, Profiler {
 
   @Nullable
   private static FlightRecorderConnection createFlightRecorderConnection() {
-    if (isOpenJ9Jvm()) {
-      LOGGER.error(
-          "Unable to initialize the profiler. OpenJ9 JVM is not supported. Instead, please use an OpenJDK JVM");
-      return null;
-    }
     try {
       // connect to mbeans
       MBeanServerConnection mbeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -150,13 +145,8 @@ public class JfrProfiler implements ProfilerConfigurationHandler, Profiler {
       }
     } catch (Exception e) {
       LOGGER.error("Failed to connect to mbean", e);
+      return null;
     }
-    return null;
-  }
-
-  private static boolean isOpenJ9Jvm() {
-    String jvmName = System.getProperty("java.vm.name");
-    return jvmName != null && jvmName.contains("OpenJ9");
   }
 
   /** Apply new configuration settings obtained from Service Profiler. */

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -243,13 +243,16 @@ public class ConfigurationBuilder {
   }
 
   private static void overlayProfilerEnvVars(Configuration config) {
-    if (!isOpenJ9Jvm()) {
-      config.preview.profiler.enabled =
-          Boolean.parseBoolean(
-              overlayWithEnvVar(
-                  APPLICATIONINSIGHTS_PREVIEW_PROFILER_ENABLED,
-                  Boolean.toString(config.preview.profiler.enabled)));
+    if (isOpenJ9Jvm()) {
+      configurationLogger.warn(
+          "Unable to initialize the profiler. OpenJ9 JVM is not supported. Instead, please use an OpenJDK JVM");
+      return;
     }
+    config.preview.profiler.enabled =
+        Boolean.parseBoolean(
+            overlayWithEnvVar(
+                APPLICATIONINSIGHTS_PREVIEW_PROFILER_ENABLED,
+                Boolean.toString(config.preview.profiler.enabled)));
   }
 
   private static boolean isOpenJ9Jvm() {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -243,11 +243,18 @@ public class ConfigurationBuilder {
   }
 
   private static void overlayProfilerEnvVars(Configuration config) {
-    config.preview.profiler.enabled =
-        Boolean.parseBoolean(
-            overlayWithEnvVar(
-                APPLICATIONINSIGHTS_PREVIEW_PROFILER_ENABLED,
-                Boolean.toString(config.preview.profiler.enabled)));
+    if (!isOpenJ9Jvm()) {
+      config.preview.profiler.enabled =
+          Boolean.parseBoolean(
+              overlayWithEnvVar(
+                  APPLICATIONINSIGHTS_PREVIEW_PROFILER_ENABLED,
+                  Boolean.toString(config.preview.profiler.enabled)));
+    }
+  }
+
+  private static boolean isOpenJ9Jvm() {
+    String jvmName = System.getProperty("java.vm.name");
+    return jvmName != null && jvmName.contains("OpenJ9");
   }
 
   private static void overlayAadEnvVars(Configuration config) {


### PR DESCRIPTION
Improve the error message when the profiler can't be initialized

Fix #2379