### PR TITLE
Add start-up diagnostics

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.applicationinsights.agent.internal.init;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+class CommandExecutor {
+
+  private CommandExecutor() {}
+
+  static String execute(String[] command) {
+    IllegalStateException exitException = null;
+    String result = null;
+    try {
+      Process process = new ProcessBuilder(command).start();
+      int exitValue = process.waitFor();
+      exitException = buildExitValueExceptionIfNecessary(command, exitValue, process);
+      if (exitException == null) {
+        InputStream inputStream = process.getInputStream();
+        result = toString(inputStream);
+      }
+      process.destroy();
+    } catch (IllegalStateException | IOException | InterruptedException e) {
+      throw combineExceptionsIfNecessary(exitException, e, command);
+    }
+    if (exitException != null) {
+      throw exitException;
+    }
+    return result;
+  }
+
+  static String executeWithoutException(String[] command, Logger startupLogger) {
+    try {
+      return execute(command);
+    } catch (Exception e) {
+      startupLogger.error("Error when executing command " + Arrays.asList(command) + ".", e);
+      if (e.getSuppressed().length == 1) {
+        return e.getMessage() + " (Suppressed: " + e.getSuppressed()[0] + ")";
+      }
+      return e.getMessage();
+    }
+  }
+
+  private static IllegalStateException buildExitValueExceptionIfNecessary(
+      String[] command, int exitValue, Process directivesClearProcess) throws IOException {
+    if (exitValue != 0) {
+      InputStream errorStream = directivesClearProcess.getErrorStream();
+      String error = toString(errorStream);
+      return new IllegalStateException(
+          "Error executing command " + Arrays.asList(command) + ": " + error + ".");
+    }
+    return null;
+  }
+
+  private static String toString(InputStream inputStream) throws IOException {
+    try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
+      return bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
+    }
+  }
+
+  private static IllegalStateException combineExceptionsIfNecessary(
+      IllegalStateException exitValueException, Exception e, String[] command) {
+    IllegalStateException exceptionWithMessage =
+        new IllegalStateException("Error related to the execution of " + Arrays.asList(command) + ".", e);
+    if (exitValueException == null) {
+      return exceptionWithMessage;
+    }
+    exitValueException.addSuppressed(exceptionWithMessage);
+    return exitValueException;
+  }
+}

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
@@ -7,8 +7,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 
 class CommandExecutor {
@@ -39,7 +41,7 @@ class CommandExecutor {
   static String executeWithoutException(String[] command, Logger startupLogger) {
     try {
       return execute(command);
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       startupLogger.error("Error when executing command " + Arrays.asList(command) + ".", e);
       if (e.getSuppressed().length == 1) {
         return e.getMessage() + " (Suppressed: " + e.getSuppressed()[0] + ")";
@@ -48,6 +50,7 @@ class CommandExecutor {
     }
   }
 
+  @Nullable
   private static IllegalStateException buildExitValueExceptionIfNecessary(
       String[] command, int exitValue, Process directivesClearProcess) throws IOException {
     if (exitValue != 0) {
@@ -60,7 +63,8 @@ class CommandExecutor {
   }
 
   private static String toString(InputStream inputStream) throws IOException {
-    try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
+    try (BufferedReader bufferedReader =
+        new BufferedReader(new InputStreamReader(inputStream, Charset.defaultCharset()))) {
       return bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
     }
   }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
@@ -72,7 +72,7 @@ class CommandExecutor {
   }
 
   private static IllegalStateException combineExceptionsIfNecessary(
-      IllegalStateException exitValueException, Exception e, List<String> command) {
+      @Nullable IllegalStateException exitValueException, Exception e, List<String> command) {
     IllegalStateException exceptionWithMessage =
         new IllegalStateException(
             "Error related to the execution of " + Arrays.asList(command) + ".", e);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/CommandExecutor.java
@@ -68,7 +68,8 @@ class CommandExecutor {
   private static IllegalStateException combineExceptionsIfNecessary(
       IllegalStateException exitValueException, Exception e, String[] command) {
     IllegalStateException exceptionWithMessage =
-        new IllegalStateException("Error related to the execution of " + Arrays.asList(command) + ".", e);
+        new IllegalStateException(
+            "Error related to the execution of " + Arrays.asList(command) + ".", e);
     if (exitValueException == null) {
       return exceptionWithMessage;
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
@@ -91,8 +91,7 @@ public class FirstEntryPoint implements LoggingCustomizer {
 
       ClassicSdkInstrumentation.registerTransformers();
 
-      StartupDiagnostics startupDiagnostics = new StartupDiagnostics();
-      startupDiagnostics.execute();
+      StartupDiagnostics.execute();
 
       if (JvmCompiler.hasToDisableJvmCompilerDirectives()) {
         JvmCompiler.disableJvmCompilerDirectives();

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
@@ -93,6 +93,11 @@ public class FirstEntryPoint implements LoggingCustomizer {
 
       StartupDiagnostics startupDiagnostics = new StartupDiagnostics(startupLogger);
       startupDiagnostics.execute();
+
+      if (JvmCompiler.hasToDisableJvmCompilerDirectives()) {
+        JvmCompiler.disableJvmCompilerDirectives();
+      }
+
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
@@ -90,6 +90,9 @@ public class FirstEntryPoint implements LoggingCustomizer {
       ConfigurationBuilder.logConfigurationWarnMessages();
 
       ClassicSdkInstrumentation.registerTransformers();
+
+      StartupDiagnostics startupDiagnostics = new StartupDiagnostics(startupLogger);
+      startupDiagnostics.execute();
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
@@ -91,7 +91,7 @@ public class FirstEntryPoint implements LoggingCustomizer {
 
       ClassicSdkInstrumentation.registerTransformers();
 
-      StartupDiagnostics startupDiagnostics = new StartupDiagnostics(startupLogger);
+      StartupDiagnostics startupDiagnostics = new StartupDiagnostics();
       startupDiagnostics.execute();
 
       if (JvmCompiler.hasToDisableJvmCompilerDirectives()) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/JvmCompiler.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/JvmCompiler.java
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.applicationinsights.agent.internal.init;
+
+import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.PidFinder;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+class JvmCompiler {
+
+  // To disable C2 compiler during Application Insights set-up, for Java >= 9, do the following
+  // things.
+  // Execute with -XX:+UnlockDiagnosticVMOptions -XX:CompilerDirectivesFile=path/jvm-disable-c2.json
+  // Content of jvm-disable-c2.json file:
+  // [
+  //  {
+  //    match: [
+  //      "*::*"
+  //    ],
+  //    c2: {
+  //      Exclude: true
+  //    }
+  //  }
+  // ]
+  private static final String
+      APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION =
+          "applicationinsights.experiment.clear-compiler-directives-after-initialization";
+
+  private JvmCompiler() {}
+
+  static boolean hasToDisableJvmCompilerDirectives() {
+    return Boolean.getBoolean(
+        APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION);
+  }
+
+  @SuppressFBWarnings(
+      value = "SECCI", // Command Injection
+      justification = "No user data is used to construct the command below")
+  static void disableJvmCompilerDirectives() {
+    CommandExecutor.execute(new ProcessBuilder("jcmd", pid(), "Compiler.directives_clear"));
+  }
+
+  private static String pid() {
+    return new PidFinder().getValue();
+  }
+}

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -33,7 +33,7 @@ class StartupDiagnostics {
 
   static class DiagnosticsReport {
 
-    StringBuilder diagnosticBuilder = new StringBuilder();
+    final StringBuilder diagnosticBuilder = new StringBuilder();
 
     void addDiagnostic(String diagnostic) {
       diagnosticBuilder.append(diagnostic);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -83,8 +83,7 @@ class StartupDiagnostics {
 
   private String findResidentSetSize() {
     try (Stream<String> lines = Files.lines(Paths.get("/proc/self/status"))) {
-      Optional<String> optionalRss = lines.filter(line -> line.startsWith("VmRSS")).findAny();
-      return optionalRss.orElse("");
+      return lines.filter(line -> line.startsWith("VmRSS")).findAny().orElse("");
     } catch (IOException e) {
       startupLogger.error("Error when retrieving rss", e);
       return e.getMessage();

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -50,7 +50,9 @@ class StartupDiagnostics {
     }
   }
 
-  void execute() {
+  private StartupDiagnostics() {}
+
+  static void execute() {
 
     DiagnosticsReport diagnosticsReport = new DiagnosticsReport();
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -70,7 +70,7 @@ class StartupDiagnostics {
     generateReport(diagnosticsReport);
   }
 
-  private void generateReport(DiagnosticsReport diagnosticsReport) {
+  private static void generateReport(DiagnosticsReport diagnosticsReport) {
     if (!diagnosticsReport.isEmpty()) {
       startupLogger.info("Start-up diagnostics" + File.separator + diagnosticsReport);
       boolean exportToFile = Boolean.getBoolean(APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE);
@@ -89,7 +89,7 @@ class StartupDiagnostics {
     }
   }
 
-  private void saveIntoFile(DiagnosticsReport diagnosticsReport) {
+  private static void saveIntoFile(DiagnosticsReport diagnosticsReport) {
     Optional<File> optionalTempDir = createTempDirIfNotExists();
     if (optionalTempDir.isPresent()) {
       File tempDir = optionalTempDir.get();
@@ -98,7 +98,7 @@ class StartupDiagnostics {
     }
   }
 
-  private void write(DiagnosticsReport diagnosticsReport, File diagFile) {
+  private static void write(DiagnosticsReport diagnosticsReport, File diagFile) {
     byte[] diagReportAsBytes = diagnosticsReport.toString().getBytes(StandardCharsets.UTF_8);
     try {
       Files.write(diagFile.toPath(), diagReportAsBytes);
@@ -107,7 +107,7 @@ class StartupDiagnostics {
     }
   }
 
-  private Optional<File> createTempDirIfNotExists() {
+  private static Optional<File> createTempDirIfNotExists() {
     String tempDirectory = System.getProperty("java.io.tmpdir");
     File folder = new File(tempDirectory, "applicationinsights");
     if (!folder.exists() && !folder.mkdirs()) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.applicationinsights.agent.internal.init;
+
+import com.microsoft.applicationinsights.agent.bootstrap.diagnostics.PidFinder;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+
+class StartupDiagnostics {
+
+  // For Java >= 9
+  // Execute with -XX:+UnlockDiagnosticVMOptions -XX:CompilerDirectivesFile=path/jvm-disable-c2.json
+  // Content of jvm-disable-c2.json file:
+  // [
+  //  {
+  //    match: [
+  //      "*::*"
+  //    ],
+  //    c2: {
+  //      Exclude: true
+  //    }
+  //  }
+  // ]
+  private static final String APPPLICATIONINSIGHTS_DEBUG_JIT_C_2_DISABLING_ENABLED =
+      "appplicationinsights.debug.jit.c2-disabling.enabled";
+
+  private static final String APPPLICATIONINSIGHTS_DEBUG_JVM_FLAGS_ENABLED =
+      "appplicationinsights.debug.jvm-flags.enabled";
+
+  // Execute with -XX:NativeMemoryTracking=summary
+  private static final String APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
+      "appplicationinsights.debug.native-mem-tracking.enabled";
+
+  // "file" (default value) / "console" / "file-console"
+  public static final String APPPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT =
+      "appplicationinsights.debug.diag-export";
+  private final Logger startupLogger;
+
+  public StartupDiagnostics(Logger startupLogger) {
+    this.startupLogger = startupLogger;
+  }
+
+  static class DiagnosticsReport {
+
+    StringBuilder diagnosticBuilder = new StringBuilder();
+
+    void addDiagnostic(String diagnostic) {
+      diagnosticBuilder.append(diagnostic);
+      diagnosticBuilder.append(System.lineSeparator());
+      diagnosticBuilder.append(System.lineSeparator());
+    }
+
+    boolean isEmpty() {
+      return diagnosticBuilder.length() == 0;
+    }
+
+    @Override
+    public String toString() {
+      return diagnosticBuilder.toString();
+    }
+  }
+
+  void execute() {
+
+    String pid = new PidFinder().getValue();
+
+    executeDiagsAndGenerateReport(pid);
+
+    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_JIT_C_2_DISABLING_ENABLED)) {
+      disableC2CompilerDirectives(pid);
+    }
+  }
+
+  private void executeDiagsAndGenerateReport(String pid) {
+    DiagnosticsReport diagnosticsReport = new DiagnosticsReport();
+
+    if (Boolean.getBoolean("rss")) {
+      String os = System.getProperty("os.name");
+      if (os.equals("Linux")) {
+        String residentSetSize = findResidentSetSize();
+        diagnosticsReport.addDiagnostic(residentSetSize);
+      }
+    }
+
+    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_JVM_FLAGS_ENABLED)) {
+      String jvmFlags = executeJvmFlagsDiag(pid);
+      diagnosticsReport.addDiagnostic(jvmFlags);
+    }
+
+    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED)) {
+      String nativeSummary = executeNativeMemoryDiag(pid);
+      diagnosticsReport.addDiagnostic(nativeSummary);
+    }
+
+    generateReport(diagnosticsReport);
+  }
+
+  private void generateReport(DiagnosticsReport diagnosticsReport) {
+    if (!diagnosticsReport.isEmpty()) {
+      String diagExport = System.getProperty(APPPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT);
+      if ("console".equals(diagExport) || "file-console".equals(diagExport)) {
+        startupLogger.info("Start-up diagnostics" + File.separator + diagnosticsReport);
+      }
+      // "file" (default value) / "console" / "file-console"
+      if (diagExport == null || "file".equals(diagExport) || "file-console".equals(diagExport)) {
+        saveIntoFile(diagnosticsReport);
+      }
+    }
+  }
+
+  private String findResidentSetSize() {
+    try (Stream<String> lines = Files.lines(Paths.get("/proc/self/status"))) {
+      Optional<String> optionalRss = lines.filter(line -> line.startsWith("VmRSS")).findAny();
+      return optionalRss.orElse("");
+    } catch (IOException e) {
+      startupLogger.error("Error when retrieving rss", e);
+      return e.getMessage();
+    }
+  }
+
+  private String executeJvmFlagsDiag(String pid) {
+    String[] command = {"jcmd", pid, "VM.flags"};
+    return CommandExecutor.executeWithoutException(command, startupLogger);
+  }
+
+  private String executeNativeMemoryDiag(String pid) {
+    String[] command = {"jcmd", pid, "VM.native_memory", "summary"};
+    return CommandExecutor.executeWithoutException(command, startupLogger);
+  }
+
+  private void saveIntoFile(DiagnosticsReport diagnosticsReport) {
+    Optional<File> optionalTempDir = createTempDirIfNotExists();
+    if (optionalTempDir.isPresent()) {
+      File tempDir = optionalTempDir.get();
+      File diagFile = new File(tempDir, "diagnostics.txt");
+      write(diagnosticsReport, diagFile);
+    }
+  }
+
+  private void write(DiagnosticsReport diagnosticsReport, File diagFile) {
+    byte[] diagReportAsBytes = diagnosticsReport.toString().getBytes(StandardCharsets.UTF_8);
+    try {
+      Files.write(diagFile.toPath(), diagReportAsBytes);
+    } catch (IOException e) {
+      startupLogger.error("Error occurred when writing diag report.", e);
+    }
+  }
+
+  private static Optional<File> createTempDirIfNotExists() {
+    String tempDirectory = System.getProperty("java.io.tmpdir");
+    File folder = new File(tempDirectory, "applicationinsights");
+    if (!folder.exists() && !folder.mkdirs()) {
+      System.out.println("Failed to create directory: " + tempDirectory);
+      return Optional.empty();
+    }
+    return Optional.of(folder);
+  }
+
+  private static void disableC2CompilerDirectives(String pid) {
+    String[] command = {"jcmd", pid, "Compiler.directives_clear"};
+    CommandExecutor.execute(command);
+  }
+}

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -32,6 +32,8 @@ class StartupDiagnostics {
   private static final String APPPLICATIONINSIGHTS_DEBUG_JIT_C_2_DISABLING_ENABLED =
       "appplicationinsights.debug.jit.c2-disabling.enabled";
 
+  public static final String APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED = "appplicationinsights.debug.rss.enabled";
+
   // Execute with -XX:NativeMemoryTracking=summary
   private static final String APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
       "appplicationinsights.debug.native-mem-tracking.enabled";
@@ -77,7 +79,7 @@ class StartupDiagnostics {
   private void executeDiagsAndGenerateReport() {
     DiagnosticsReport diagnosticsReport = new DiagnosticsReport();
 
-    if (Boolean.getBoolean("rss")) {
+    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED)) {
       String os = System.getProperty("os.name");
       if (os.equals("Linux")) {
         String residentSetSize = findResidentSetSize();

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -153,11 +153,11 @@ class StartupDiagnostics {
     }
   }
 
-  private static Optional<File> createTempDirIfNotExists() {
+  private Optional<File> createTempDirIfNotExists() {
     String tempDirectory = System.getProperty("java.io.tmpdir");
     File folder = new File(tempDirectory, "applicationinsights");
     if (!folder.exists() && !folder.mkdirs()) {
-      System.out.println("Failed to create directory: " + tempDirectory);
+      startupLogger.error("Failed to create directory: " + tempDirectory);
       return Optional.empty();
     }
     return Optional.of(folder);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -23,9 +23,8 @@ class StartupDiagnostics {
   private static final String APPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
       "applicationinsights.debug.native-mem-tracking.enabled";
 
-  // "file"  / "console" (default value) / "file-console"
-  public static final String APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT =
-      "applicationinsights.debug.diag-export";
+  public static final String APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE =
+      "applicationinsights.debug.diag-export-to-file";
   private final Logger startupLogger;
 
   public StartupDiagnostics(Logger startupLogger) {
@@ -74,8 +73,8 @@ class StartupDiagnostics {
 
   private void generateReport(DiagnosticsReport diagnosticsReport) {
     if (!diagnosticsReport.isEmpty()) {
-      boolean exportToFile = Boolean.getBoolean(APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE);
       startupLogger.info("Start-up diagnostics" + File.separator + diagnosticsReport);
+      boolean exportToFile = Boolean.getBoolean(APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE);
       if (exportToFile) {
         saveIntoFile(diagnosticsReport);
       }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -74,11 +74,9 @@ class StartupDiagnostics {
 
   private void generateReport(DiagnosticsReport diagnosticsReport) {
     if (!diagnosticsReport.isEmpty()) {
-      String diagExport = System.getProperty(APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT);
-      if (diagExport == null || "console".equals(diagExport) || "file-console".equals(diagExport)) {
-        startupLogger.info("Start-up diagnostics" + File.separator + diagnosticsReport);
-      }
-      if ("file".equals(diagExport) || "file-console".equals(diagExport)) {
+      boolean exportToFile = Boolean.getBoolean(APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE);
+      startupLogger.info("Start-up diagnostics" + File.separator + diagnosticsReport);
+      if (exportToFile) {
         saveIntoFile(diagnosticsReport);
       }
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -16,16 +16,16 @@ import org.slf4j.Logger;
 
 class StartupDiagnostics {
 
-  public static final String APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED =
-      "appplicationinsights.debug.rss.enabled";
+  public static final String APPLICATIONINSIGHTS_DEBUG_RSS_ENABLED =
+      "applicationinsights.debug.rss.enabled";
 
   // Execute with -XX:NativeMemoryTracking=summary
-  private static final String APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
-      "appplicationinsights.debug.native-mem-tracking.enabled";
+  private static final String APPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
+      "applicationinsights.debug.native-mem-tracking.enabled";
 
   // "file" (default value) / "console" / "file-console"
-  public static final String APPPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT =
-      "appplicationinsights.debug.diag-export";
+  public static final String APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT =
+      "applicationinsights.debug.diag-export";
   private final Logger startupLogger;
 
   public StartupDiagnostics(Logger startupLogger) {
@@ -56,7 +56,7 @@ class StartupDiagnostics {
 
     DiagnosticsReport diagnosticsReport = new DiagnosticsReport();
 
-    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED)) {
+    if (Boolean.getBoolean(APPLICATIONINSIGHTS_DEBUG_RSS_ENABLED)) {
       String os = System.getProperty("os.name");
       if (os.equals("Linux")) {
         String residentSetSize = findResidentSetSize();
@@ -64,7 +64,7 @@ class StartupDiagnostics {
       }
     }
 
-    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED)) {
+    if (Boolean.getBoolean(APPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED)) {
       String nativeSummary = executeNativeMemoryDiag();
       diagnosticsReport.addDiagnostic(nativeSummary);
     }
@@ -74,7 +74,7 @@ class StartupDiagnostics {
 
   private void generateReport(DiagnosticsReport diagnosticsReport) {
     if (!diagnosticsReport.isEmpty()) {
-      String diagExport = System.getProperty(APPPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT);
+      String diagExport = System.getProperty(APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT);
       if ("console".equals(diagExport) || "file-console".equals(diagExport)) {
         startupLogger.info("Start-up diagnostics" + File.separator + diagnosticsReport);
       }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 
 class StartupDiagnostics {
 
-  // For Java >= 9
+  // To disable C2 compiler during Application Insights set-up, for Java >= 9, do the following things.
   // Execute with -XX:+UnlockDiagnosticVMOptions -XX:CompilerDirectivesFile=path/jvm-disable-c2.json
   // Content of jvm-disable-c2.json file:
   // [
@@ -29,8 +29,8 @@ class StartupDiagnostics {
   //    }
   //  }
   // ]
-  private static final String APPPLICATIONINSIGHTS_DEBUG_JIT_C_2_DISABLING_ENABLED =
-      "appplicationinsights.debug.jit.c2-disabling.enabled";
+  private static final String APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION =
+      "applicationinsights.experiment.clear-compiler-directives-after-initialization";
 
   public static final String APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED = "appplicationinsights.debug.rss.enabled";
 
@@ -71,8 +71,9 @@ class StartupDiagnostics {
 
     executeDiagsAndGenerateReport();
 
-    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_JIT_C_2_DISABLING_ENABLED)) {
-      disableC2CompilerDirectives();
+    if (Boolean.getBoolean(
+        APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION)) {
+      disableJvmCompilerDirectives();
     }
   }
 
@@ -158,7 +159,7 @@ class StartupDiagnostics {
   @SuppressFBWarnings(
       value = "SECCI", // Command Injection
       justification = "No user data is used to construct the command below")
-  private static void disableC2CompilerDirectives() {
+  private static void disableJvmCompilerDirectives() {
     CommandExecutor.execute(new ProcessBuilder("jcmd", pid(), "Compiler.directives_clear"));
   }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -120,7 +120,7 @@ class StartupDiagnostics {
   @SuppressFBWarnings(
       value = "SECCI", // Command Injection
       justification = "No user data is used to construct the command below")
-  private String executeNativeMemoryDiag() {
+  private static String executeNativeMemoryDiag() {
     ProcessBuilder processBuilder =
         new ProcessBuilder("jcmd", pid(), "VM.native_memory", "summary");
     return CommandExecutor.executeWithoutException(processBuilder, startupLogger);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -32,9 +32,6 @@ class StartupDiagnostics {
   private static final String APPPLICATIONINSIGHTS_DEBUG_JIT_C_2_DISABLING_ENABLED =
       "appplicationinsights.debug.jit.c2-disabling.enabled";
 
-  private static final String APPPLICATIONINSIGHTS_DEBUG_JVM_FLAGS_ENABLED =
-      "appplicationinsights.debug.jvm-flags.enabled";
-
   // Execute with -XX:NativeMemoryTracking=summary
   private static final String APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
       "appplicationinsights.debug.native-mem-tracking.enabled";
@@ -86,11 +83,6 @@ class StartupDiagnostics {
         String residentSetSize = findResidentSetSize();
         diagnosticsReport.addDiagnostic(residentSetSize);
       }
-    }
-
-    if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_JVM_FLAGS_ENABLED)) {
-      String jvmFlags = executeJvmFlagsDiag();
-      diagnosticsReport.addDiagnostic(jvmFlags);
     }
 
     if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED)) {
@@ -150,14 +142,6 @@ class StartupDiagnostics {
       return Optional.empty();
     }
     return Optional.of(folder);
-  }
-
-  @SuppressFBWarnings(
-      value = "SECCI", // Command Injection
-      justification = "No user data is used to construct the command below")
-  private String executeJvmFlagsDiag() {
-    ProcessBuilder processBuilder = new ProcessBuilder("jcmd", pid(), "VM.flags");
-    return CommandExecutor.executeWithoutException(processBuilder, startupLogger);
   }
 
   @SuppressFBWarnings(

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -16,24 +16,6 @@ import org.slf4j.Logger;
 
 class StartupDiagnostics {
 
-  // To disable C2 compiler during Application Insights set-up, for Java >= 9, do the following
-  // things.
-  // Execute with -XX:+UnlockDiagnosticVMOptions -XX:CompilerDirectivesFile=path/jvm-disable-c2.json
-  // Content of jvm-disable-c2.json file:
-  // [
-  //  {
-  //    match: [
-  //      "*::*"
-  //    ],
-  //    c2: {
-  //      Exclude: true
-  //    }
-  //  }
-  // ]
-  private static final String
-      APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION =
-          "applicationinsights.experiment.clear-compiler-directives-after-initialization";
-
   public static final String APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED =
       "appplicationinsights.debug.rss.enabled";
 
@@ -72,15 +54,6 @@ class StartupDiagnostics {
 
   void execute() {
 
-    executeDiagsAndGenerateReport();
-
-    if (Boolean.getBoolean(
-        APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION)) {
-      disableJvmCompilerDirectives();
-    }
-  }
-
-  private void executeDiagsAndGenerateReport() {
     DiagnosticsReport diagnosticsReport = new DiagnosticsReport();
 
     if (Boolean.getBoolean(APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED)) {
@@ -157,13 +130,6 @@ class StartupDiagnostics {
     ProcessBuilder processBuilder =
         new ProcessBuilder("jcmd", pid(), "VM.native_memory", "summary");
     return CommandExecutor.executeWithoutException(processBuilder, startupLogger);
-  }
-
-  @SuppressFBWarnings(
-      value = "SECCI", // Command Injection
-      justification = "No user data is used to construct the command below")
-  private static void disableJvmCompilerDirectives() {
-    CommandExecutor.execute(new ProcessBuilder("jcmd", pid(), "Compiler.directives_clear"));
   }
 
   private static String pid() {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -23,7 +23,7 @@ class StartupDiagnostics {
   private static final String APPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
       "applicationinsights.debug.native-mem-tracking.enabled";
 
-  // "file" (default value) / "console" / "file-console"
+  // "file"  / "console" (default value) / "file-console"
   public static final String APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT =
       "applicationinsights.debug.diag-export";
   private final Logger startupLogger;
@@ -75,11 +75,10 @@ class StartupDiagnostics {
   private void generateReport(DiagnosticsReport diagnosticsReport) {
     if (!diagnosticsReport.isEmpty()) {
       String diagExport = System.getProperty(APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT);
-      if ("console".equals(diagExport) || "file-console".equals(diagExport)) {
+      if (diagExport == null || "console".equals(diagExport) || "file-console".equals(diagExport)) {
         startupLogger.info("Start-up diagnostics" + File.separator + diagnosticsReport);
       }
-      // "file" (default value) / "console" / "file-console"
-      if (diagExport == null || "file".equals(diagExport) || "file-console".equals(diagExport)) {
+      if ("file".equals(diagExport) || "file-console".equals(diagExport)) {
         saveIntoFile(diagnosticsReport);
       }
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -80,7 +80,7 @@ class StartupDiagnostics {
     }
   }
 
-  private String findResidentSetSize() {
+  private static String findResidentSetSize() {
     try (Stream<String> lines = Files.lines(Paths.get("/proc/self/status"))) {
       return lines.filter(line -> line.startsWith("VmRSS")).findAny().orElse("");
     } catch (IOException e) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -25,7 +25,7 @@ class StartupDiagnostics {
 
   public static final String APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE =
       "applicationinsights.debug.startup.diag-export-to-file";
-  private final Logger startupLogger;
+  private static final Logger startupLogger = LoggerFactory.getLogger("com.microsoft.applicationinsights.agent");
 
   public StartupDiagnostics(Logger startupLogger) {
     this.startupLogger = startupLogger;

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -17,14 +17,14 @@ import org.slf4j.Logger;
 class StartupDiagnostics {
 
   public static final String APPLICATIONINSIGHTS_DEBUG_RSS_ENABLED =
-      "applicationinsights.debug.rss.enabled";
+      "applicationinsights.debug.startup.rss.enabled";
 
   // Execute with -XX:NativeMemoryTracking=summary
   private static final String APPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =
-      "applicationinsights.debug.native-mem-tracking.enabled";
+      "applicationinsights.debug.startup.native-mem-tracking.enabled";
 
   public static final String APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE =
-      "applicationinsights.debug.diag-export-to-file";
+      "applicationinsights.debug.startup.diag-export-to-file";
   private final Logger startupLogger;
 
   public StartupDiagnostics(Logger startupLogger) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -16,7 +16,8 @@ import org.slf4j.Logger;
 
 class StartupDiagnostics {
 
-  // To disable C2 compiler during Application Insights set-up, for Java >= 9, do the following things.
+  // To disable C2 compiler during Application Insights set-up, for Java >= 9, do the following
+  // things.
   // Execute with -XX:+UnlockDiagnosticVMOptions -XX:CompilerDirectivesFile=path/jvm-disable-c2.json
   // Content of jvm-disable-c2.json file:
   // [
@@ -29,10 +30,12 @@ class StartupDiagnostics {
   //    }
   //  }
   // ]
-  private static final String APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION =
-      "applicationinsights.experiment.clear-compiler-directives-after-initialization";
+  private static final String
+      APPLICATIONINSIGHTS_EXPERIMENT_CLEAR_COMPILER_DIRECTIVES_AFTER_INITIALIZATION =
+          "applicationinsights.experiment.clear-compiler-directives-after-initialization";
 
-  public static final String APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED = "appplicationinsights.debug.rss.enabled";
+  public static final String APPPLICATIONINSIGHTS_DEBUG_RSS_ENABLED =
+      "appplicationinsights.debug.rss.enabled";
 
   // Execute with -XX:NativeMemoryTracking=summary
   private static final String APPPLICATIONINSIGHTS_DEBUG_NATIVE_MEM_TRACKING_ENABLED =

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StartupDiagnostics.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class StartupDiagnostics {
 
@@ -25,11 +26,9 @@ class StartupDiagnostics {
 
   public static final String APPLICATIONINSIGHTS_DEBUG_DIAG_EXPORT_TO_FILE =
       "applicationinsights.debug.startup.diag-export-to-file";
-  private static final Logger startupLogger = LoggerFactory.getLogger("com.microsoft.applicationinsights.agent");
 
-  public StartupDiagnostics(Logger startupLogger) {
-    this.startupLogger = startupLogger;
-  }
+  private static final Logger startupLogger =
+      LoggerFactory.getLogger("com.microsoft.applicationinsights.agent");
 
   static class DiagnosticsReport {
 


### PR DESCRIPTION
Add start-up diagnostics:
* Disable C2 compiler during start-up
* _JVM flags (removed from this PR)_
* Resident-set size
* Native memory tracking
