### PR TITLE
Add classpath and input arguments to the self-diagnostics

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
@@ -97,6 +97,12 @@ public class FirstEntryPoint implements LoggingCustomizer {
         JvmCompiler.disableJvmCompilerDirectives();
       }
 
+      if (startupLogger.isDebugEnabled()) {
+        startupLogger.debug("Classpath: " + System.getProperty("java.class.path"));
+        startupLogger.debug(
+            "Input arguments: " + ManagementFactory.getRuntimeMXBean().getInputArguments());
+      }
+
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
Add the following info to the self-diagnostics:
* Class path
* Input arguments (what is added by the users: JVM options, properties, ...)