### PR TITLE
Update standalone sampling behavior

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
@@ -151,6 +151,9 @@ public class Configuration {
     // default is 5 requests per second (set in ConfigurationBuilder if neither percentage nor
     // requestsPerSecond was configured)
     @Nullable public Double requestsPerSecond;
+
+    // this config option only existed in one BETA release (3.4.0-BETA)
+    @Deprecated @Nullable public Double limitPerSecond;
   }
 
   public static class SamplingPreview {
@@ -614,6 +617,9 @@ public class Configuration {
     // TODO (trask) make this required when moving out of preview
     //   for now the default is both "request" and "dependency" for backwards compatibility
     @Nullable public SamplingTelemetryKind telemetryKind;
+
+    // this config option only existed in one BETA release (3.4.0-BETA)
+    @Deprecated @Nullable public Boolean includingStandaloneTelemetry;
 
     // not using include/exclude, because you can still get exclude with this by adding a second
     // (exclude) override above it

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
@@ -150,7 +150,7 @@ public class Configuration {
 
     // default is 5 requests per second (set in ConfigurationBuilder if neither percentage nor
     // limitPerSecond was configured)
-    @Nullable public Double limitPerSecond;
+    @Nullable public Double requestsPerSecond;
   }
 
   public static class SamplingPreview {
@@ -614,10 +614,6 @@ public class Configuration {
     // TODO (trask) make this required when moving out of preview
     //   for now the default is both "request" and "dependency" for backwards compatibility
     @Nullable public SamplingTelemetryKind telemetryKind;
-
-    // TODO (trask) add test for this
-    // this is primarily useful for batch jobs
-    public boolean includingStandaloneTelemetry;
 
     // not using include/exclude, because you can still get exclude with this by adding a second
     // (exclude) override above it

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
@@ -149,7 +149,7 @@ public class Configuration {
     @Nullable public Double percentage;
 
     // default is 5 requests per second (set in ConfigurationBuilder if neither percentage nor
-    // limitPerSecond was configured)
+    // requestsPerSecond was configured)
     @Nullable public Double requestsPerSecond;
   }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -68,7 +68,7 @@ public class ConfigurationBuilder {
   private static final String APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE =
       "APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE";
 
-  private static final String APPLICATIONINSIGHTS_SAMPLING_LIMIT_PER_SECOND =
+  private static final String APPLICATIONINSIGHTS_SAMPLING_REQUESTS_PER_SECOND =
       "APPLICATIONINSIGHTS_SAMPLING_LIMIT_PER_SECOND";
 
   private static final String APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL =
@@ -220,8 +220,8 @@ public class ConfigurationBuilder {
       overlayRpConfiguration(config, rpConfiguration);
     }
     // only fall back to default sampling configuration after all overlays have been performed
-    if (config.sampling.limitPerSecond == null && config.sampling.percentage == null) {
-      config.sampling.limitPerSecond = 5.0;
+    if (config.sampling.requestsPerSecond == null && config.sampling.percentage == null) {
+      config.sampling.requestsPerSecond = 5.0;
     }
     // only set role instance to host name as a last resort
     if (config.role.instance == null) {
@@ -494,9 +494,9 @@ public class ConfigurationBuilder {
     config.sampling.percentage =
         overlayWithEnvVar(APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE, config.sampling.percentage);
 
-    config.sampling.limitPerSecond =
+    config.sampling.requestsPerSecond =
         overlayWithEnvVar(
-            APPLICATIONINSIGHTS_SAMPLING_LIMIT_PER_SECOND, config.sampling.limitPerSecond);
+            APPLICATIONINSIGHTS_SAMPLING_REQUESTS_PER_SECOND, config.sampling.requestsPerSecond);
 
     config.proxy = overlayProxyFromEnv(config.proxy);
 
@@ -616,7 +616,7 @@ public class ConfigurationBuilder {
     }
     if (rpConfiguration.sampling != null) {
       config.sampling.percentage = rpConfiguration.sampling.percentage;
-      config.sampling.limitPerSecond = rpConfiguration.sampling.limitPerSecond;
+      config.sampling.requestsPerSecond = rpConfiguration.sampling.requestsPerSecond;
     }
     if (isTrimEmpty(config.role.name)) {
       // only use rp configuration role name as a fallback, similar to WEBSITE_SITE_NAME

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -189,6 +189,11 @@ public class ConfigurationBuilder {
                 + " and will be required in a future release, please transition to add"
                 + " \"telemetryKind\" for sampling overrides.");
       }
+      if (override.includingStandaloneTelemetry != null) {
+        configurationLogger.warn(
+            "Sampling overrides \"includingStandaloneTelemetry\" (from 3.4.0-BETA) has been"
+                + " removed in 3.4.0 (GA)");
+      }
     }
     if (!config.preview.instrumentationKeyOverrides.isEmpty()) {
       configurationLogger.warn(
@@ -200,6 +205,14 @@ public class ConfigurationBuilder {
         newOverride.httpPathPrefix = override.httpPathPrefix;
         newOverride.connectionString = "InstrumentationKey=" + override.instrumentationKey;
         config.preview.connectionStringOverrides.add(newOverride);
+      }
+    }
+    if (config.sampling.limitPerSecond != null) {
+      configurationLogger.warn(
+          "\"limitPerSecond\" (from 3.4.0-BETA) has been renamed to \"requestsPerSecond\""
+              + " in 3.4.0 (GA)");
+      if (config.sampling.requestsPerSecond == null && config.sampling.percentage == null) {
+        config.sampling.requestsPerSecond = config.sampling.limitPerSecond;
       }
     }
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/AgentLogExporter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/exporter/AgentLogExporter.java
@@ -95,16 +95,14 @@ public class AgentLogExporter implements LogExporter {
 
         SpanContext spanContext = log.getSpanContext();
 
-        boolean isStandaloneLog = !spanContext.isValid();
-        Double samplingPercentage =
-            samplingOverrides.getOverridePercentage(isStandaloneLog, log.getAttributes());
+        Double samplingPercentage = samplingOverrides.getOverridePercentage(log.getAttributes());
 
         if (samplingPercentage != null && !shouldSample(spanContext, samplingPercentage)) {
           continue;
         }
 
         if (samplingPercentage == null
-            && !isStandaloneLog
+            && spanContext.isValid()
             && !spanContext.getTraceFlags().isSampled()) {
           // if there is no sampling override, and the log is part of an unsampled trace, then don't
           // capture it

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/RpConfigurationPolling.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/RpConfigurationPolling.java
@@ -101,16 +101,17 @@ public class RpConfigurationPolling implements Runnable {
           changed = true;
         }
         if (!Objects.equals(
-            rpConfiguration.sampling.limitPerSecond, newRpConfiguration.sampling.limitPerSecond)) {
+            rpConfiguration.sampling.requestsPerSecond,
+            newRpConfiguration.sampling.requestsPerSecond)) {
           logger.debug(
               "Updating limit per second from {} to {}",
-              rpConfiguration.sampling.limitPerSecond,
-              newRpConfiguration.sampling.limitPerSecond);
+              rpConfiguration.sampling.requestsPerSecond,
+              newRpConfiguration.sampling.requestsPerSecond);
           changed = true;
         }
         if (changed) {
           configuration.sampling.percentage = newRpConfiguration.sampling.percentage;
-          configuration.sampling.limitPerSecond = newRpConfiguration.sampling.limitPerSecond;
+          configuration.sampling.requestsPerSecond = newRpConfiguration.sampling.requestsPerSecond;
           DelegatingSampler.getInstance().setDelegate(Samplers.getSampler(configuration));
           if (configuration.sampling.percentage != null) {
             BytecodeUtilImpl.samplingPercentage = configuration.sampling.percentage.floatValue();

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiOverrideSampler.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiOverrideSampler.java
@@ -40,14 +40,12 @@ class AiOverrideSampler implements Sampler {
       List<LinkData> parentLinks) {
 
     SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
-
     boolean isRequest = SpanDataMapper.isRequest(spanKind, parentSpanContext, attributes::get);
 
     SamplingOverrides samplingOverrides =
         isRequest ? requestSamplingOverrides : dependencySamplingOverrides;
 
-    boolean isStandaloneTelemetry = !isRequest && !parentSpanContext.isValid();
-    Sampler override = samplingOverrides.getOverride(isStandaloneTelemetry, attributes);
+    Sampler override = samplingOverrides.getOverride(attributes);
     if (override != null) {
       return override.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
@@ -12,16 +12,18 @@ import java.util.stream.Collectors;
 public class Samplers {
 
   public static Sampler getSampler(Configuration config) {
-    SamplingPercentage samplingPercentage;
-    if (config.sampling.limitPerSecond != null) {
-      samplingPercentage = SamplingPercentage.rateLimited(config.sampling.limitPerSecond);
+    Sampler sampler;
+    if (config.sampling.requestsPerSecond != null) {
+      SamplingPercentage requestSamplingPercentage =
+          SamplingPercentage.rateLimited(config.sampling.requestsPerSecond);
+      SamplingPercentage dependencySamplingPercentage = SamplingPercentage.fixed(100);
+      sampler = new AiSampler(requestSamplingPercentage, dependencySamplingPercentage);
     } else if (config.sampling.percentage != null) {
-      samplingPercentage = SamplingPercentage.fixed(config.sampling.percentage);
+      SamplingPercentage samplingPercentage = SamplingPercentage.fixed(config.sampling.percentage);
+      sampler = new AiSampler(samplingPercentage, samplingPercentage);
     } else {
       throw new AssertionError("ConfigurationBuilder should have set the default sampling");
     }
-
-    Sampler sampler = new AiSampler(samplingPercentage);
 
     Configuration.SamplingPreview sampling = config.preview.sampling;
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/Samplers.java
@@ -16,8 +16,8 @@ public class Samplers {
     if (config.sampling.requestsPerSecond != null) {
       SamplingPercentage requestSamplingPercentage =
           SamplingPercentage.rateLimited(config.sampling.requestsPerSecond);
-      SamplingPercentage dependencySamplingPercentage = SamplingPercentage.fixed(100);
-      sampler = new AiSampler(requestSamplingPercentage, dependencySamplingPercentage);
+      SamplingPercentage parentlessDependencySamplingPercentage = SamplingPercentage.fixed(100);
+      sampler = new AiSampler(requestSamplingPercentage, parentlessDependencySamplingPercentage);
     } else if (config.sampling.percentage != null) {
       SamplingPercentage samplingPercentage = SamplingPercentage.fixed(config.sampling.percentage);
       sampler = new AiSampler(samplingPercentage, samplingPercentage);

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/sampling/SamplingOverridesTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/sampling/SamplingOverridesTest.java
@@ -28,7 +28,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.empty();
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();
@@ -42,25 +42,11 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.empty();
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNotNull();
     assertThat(SamplingTestUtil.getCurrentSamplingPercentage(sampler)).isEqualTo(25);
-  }
-
-  @Test
-  void shouldNotFilterStandaloneTelemetry() {
-    // given
-    List<SamplingOverride> overrides = singletonList(newOverride(25));
-    SamplingOverrides samplingOverrides = new SamplingOverrides(overrides);
-    Attributes attributes = Attributes.empty();
-
-    // when
-    Sampler sampler = samplingOverrides.getOverride(true, attributes);
-
-    // expect
-    assertThat(sampler).isNull();
   }
 
   @Test
@@ -72,7 +58,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("one"), "1");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNotNull();
@@ -88,7 +74,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("one"), "2");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();
@@ -103,7 +89,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("two"), "1");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();
@@ -118,7 +104,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("one"), "11");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNotNull();
@@ -134,7 +120,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("one"), "22");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();
@@ -149,7 +135,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("two"), "11");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();
@@ -163,7 +149,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("one"), "11");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNotNull();
@@ -178,7 +164,7 @@ class SamplingOverridesTest {
     Attributes attributes = Attributes.of(AttributeKey.stringKey("two"), "22");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();
@@ -195,7 +181,7 @@ class SamplingOverridesTest {
         Attributes.of(AttributeKey.stringKey("one"), "1", AttributeKey.stringKey("two"), "22");
 
     // when
-    Sampler sampler = samplerOverride.getOverride(false, attributes);
+    Sampler sampler = samplerOverride.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNotNull();
@@ -213,7 +199,7 @@ class SamplingOverridesTest {
         Attributes.of(AttributeKey.stringKey("one"), "2", AttributeKey.stringKey("two"), "22");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();
@@ -231,7 +217,7 @@ class SamplingOverridesTest {
         Attributes.of(AttributeKey.stringKey("one"), "1", AttributeKey.stringKey("two"), "22");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNotNull();
@@ -250,7 +236,7 @@ class SamplingOverridesTest {
         Attributes.of(AttributeKey.stringKey("one"), "2", AttributeKey.stringKey("two"), "22");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNotNull();
@@ -269,7 +255,7 @@ class SamplingOverridesTest {
         Attributes.of(AttributeKey.stringKey("one"), "2", AttributeKey.stringKey("two"), "33");
 
     // when
-    Sampler sampler = samplingOverrides.getOverride(false, attributes);
+    Sampler sampler = samplingOverrides.getOverride(attributes);
 
     // expect
     assertThat(sampler).isNull();

--- a/smoke-tests/apps/RateLimitedSampling/src/smokeTest/resources/applicationinsights.json
+++ b/smoke-tests/apps/RateLimitedSampling/src/smokeTest/resources/applicationinsights.json
@@ -4,6 +4,6 @@
     "instance": "testroleinstance"
   },
   "sampling" : {
-    "limitPerSecond": 0.5
+    "requestsPerSecond": 0.5
   }
 }


### PR DESCRIPTION
TODO add ConfigurationBuilder log warning if still using `limitPerSecond` or `includingStandaloneTelemetry`