### PR TITLE
Bump next version to 3.4.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 // Project properties
-version=3.4.0
+version=3.4.1
 
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
I think 3.4.1 is warranted for #2531, but will hold on the release for a bit to see if anything else arises.