### PR TITLE
Extract RequestChecker class

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/triggers/AlertTriggerSpanProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/triggers/AlertTriggerSpanProcessor.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.applicationinsights.agent.internal.profiler.triggers;
 
-import com.azure.monitor.opentelemetry.exporter.implementation.SpanDataMapper;
+import com.azure.monitor.opentelemetry.exporter.implementation.RequestChecker;
 import com.microsoft.applicationinsights.agent.internal.profiler.AlertingServiceFactory;
 import com.microsoft.applicationinsights.alerting.AlertingSubsystem;
 import com.microsoft.applicationinsights.alerting.analysis.TimeSource;
@@ -50,7 +50,7 @@ public class AlertTriggerSpanProcessor implements SpanProcessor {
   }
 
   public void processSpan(ReadableSpan span) {
-    if (SpanDataMapper.isRequest(span)) {
+    if (RequestChecker.isRequest(span)) {
       double durationInMillis = span.getLatencyNanos() / 1_000_000.0d;
       AlertingSubsystem alertingSubsystem = alertingSubsystemSupplier.get();
 

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiOverrideSampler.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiOverrideSampler.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.applicationinsights.agent.internal.sampling;
 
-import com.azure.monitor.opentelemetry.exporter.implementation.SpanDataMapper;
+import com.azure.monitor.opentelemetry.exporter.implementation.RequestChecker;
 import com.microsoft.applicationinsights.agent.internal.configuration.Configuration.SamplingOverride;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -40,7 +40,7 @@ class AiOverrideSampler implements Sampler {
       List<LinkData> parentLinks) {
 
     SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
-    boolean isRequest = SpanDataMapper.isRequest(spanKind, parentSpanContext, attributes::get);
+    boolean isRequest = RequestChecker.isRequest(spanKind, parentSpanContext, attributes::get);
 
     SamplingOverrides samplingOverrides =
         isRequest ? requestSamplingOverrides : dependencySamplingOverrides;

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiSampler.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/sampling/AiSampler.java
@@ -4,8 +4,8 @@
 package com.microsoft.applicationinsights.agent.internal.sampling;
 
 import com.azure.monitor.opentelemetry.exporter.implementation.AiSemanticAttributes;
+import com.azure.monitor.opentelemetry.exporter.implementation.RequestChecker;
 import com.azure.monitor.opentelemetry.exporter.implementation.SamplingScoreGeneratorV2;
-import com.azure.monitor.opentelemetry.exporter.implementation.SpanDataMapper;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
@@ -70,7 +70,7 @@ public class AiSampler implements Sampler {
       sp = requestSamplingPercentage.get();
     } else {
       SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
-      boolean isRequest = SpanDataMapper.isRequest(spanKind, parentSpanContext, attributes::get);
+      boolean isRequest = RequestChecker.isRequest(spanKind, parentSpanContext, attributes::get);
 
       sp =
           isRequest

--- a/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/RequestChecker.java
+++ b/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/RequestChecker.java
@@ -9,14 +9,14 @@
 
 package com.azure.monitor.opentelemetry.exporter.implementation;
 
+import static com.azure.monitor.opentelemetry.exporter.implementation.AiSemanticAttributes.JOB_SYSTEM;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.function.Function;
-
-import static com.azure.monitor.opentelemetry.exporter.implementation.AiSemanticAttributes.JOB_SYSTEM;
 
 public final class RequestChecker {
 

--- a/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/RequestChecker.java
+++ b/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/RequestChecker.java
@@ -20,8 +20,7 @@ import java.util.function.Function;
 
 public final class RequestChecker {
 
-  private RequestChecker() {
-  }
+  private RequestChecker() {}
 
   public static boolean isRequest(SpanData span) {
     return isRequest(span.getKind(), span.getParentSpanContext(), span.getAttributes()::get);
@@ -47,5 +46,4 @@ public final class RequestChecker {
       throw new UnsupportedOperationException(kind.name());
     }
   }
-
 }

--- a/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/RequestChecker.java
+++ b/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/RequestChecker.java
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Includes work from:
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.azure.monitor.opentelemetry.exporter.implementation;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.function.Function;
+
+import static com.azure.monitor.opentelemetry.exporter.implementation.AiSemanticAttributes.JOB_SYSTEM;
+
+public final class RequestChecker {
+
+  private RequestChecker() {
+  }
+
+  public static boolean isRequest(SpanData span) {
+    return isRequest(span.getKind(), span.getParentSpanContext(), span.getAttributes()::get);
+  }
+
+  public static boolean isRequest(ReadableSpan span) {
+    return isRequest(span.getKind(), span.getParentSpanContext(), span::getAttribute);
+  }
+
+  public static boolean isRequest(
+      SpanKind kind, SpanContext parentSpanContext, Function<AttributeKey<String>, String> attrFn) {
+    if (kind == SpanKind.INTERNAL) {
+      // INTERNAL scheduled job spans with no parent are mapped to requests
+      return attrFn.apply(JOB_SYSTEM) != null && !parentSpanContext.isValid();
+    } else if (kind == SpanKind.CLIENT || kind == SpanKind.PRODUCER) {
+      return false;
+    } else if (kind == SpanKind.CONSUMER
+        && "receive".equals(attrFn.apply(SemanticAttributes.MESSAGING_OPERATION))) {
+      return false;
+    } else if (kind == SpanKind.SERVER || kind == SpanKind.CONSUMER) {
+      return true;
+    } else {
+      throw new UnsupportedOperationException(kind.name());
+    }
+  }
+
+}


### PR DESCRIPTION
[`SpanDataMapper` class](https://github.com/microsoft/ApplicationInsights-Java/blob/main/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/SpanDataMapper.java) contains almost 1000 lines.

This class may have too many responsibilities.

 The check of the request case does not seem to be the responsibility of the `SpanDataMapper` class. So, this PR has extracted several public methods of SpandDataMapper to a `RequestChecker` class.