### PR TITLE
Add back compat for http.host attribute

### DIFF
--- a/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/SpanDataMapper.java
+++ b/agent/azure-monitor-exporter/src/main/java/com/azure/monitor/opentelemetry/exporter/implementation/SpanDataMapper.java
@@ -602,15 +602,20 @@ public final class SpanDataMapper {
     if (scheme == null) {
       return null;
     }
-    String host = attributes.get(SemanticAttributes.NET_HOST_NAME);
-    if (host == null) {
-      return null;
-    }
-    Long port = attributes.get(SemanticAttributes.NET_HOST_PORT);
     String target = attributes.get(SemanticAttributes.HTTP_TARGET);
     if (target == null) {
       return null;
     }
+    String host = attributes.get(SemanticAttributes.NET_HOST_NAME);
+    if (host == null) {
+      // fall back to deprecated http.host if available
+      host = attributes.get(SemanticAttributes.HTTP_HOST);
+      if (host == null) {
+        return null;
+      }
+      return scheme + "://" + host + target;
+    }
+    Long port = attributes.get(SemanticAttributes.NET_HOST_PORT);
     if (port != null && port > 0) {
       return scheme + "://" + host + ":" + port + target;
     }


### PR DESCRIPTION
I realized I should have kept backwards compatibility in mind when upgrading to otel 1.19, for (manual) instrumentation that may still be using older semantic convention.