### PR TITLE
Fix sporadic failure

### DIFF
--- a/smoke-tests/apps/CoreAndFilter2x/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilter2xTest.java
+++ b/smoke-tests/apps/CoreAndFilter2x/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilter2xTest.java
@@ -254,7 +254,7 @@ abstract class CoreAndFilter2xTest {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> messages = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> messages = testing.mockedIngestion.getMessageDataInRequest(3);
 
     assertThat(messages)
         .anySatisfy(m -> assertThat(m.getMessage()).isEqualTo("This is first trace message."));

--- a/smoke-tests/apps/CoreAndFilter3x/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilter3xTest.java
+++ b/smoke-tests/apps/CoreAndFilter3x/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilter3xTest.java
@@ -256,7 +256,7 @@ abstract class CoreAndFilter3xTest {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> messages = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> messages = testing.mockedIngestion.getMessageDataInRequest(3);
 
     assertThat(messages)
         .anySatisfy(m -> assertThat(m.getMessage()).isEqualTo("This is first trace message."));

--- a/smoke-tests/apps/CoreAndFilter3xUsingOld3xAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilter3xUsingOld3xAgentTest.java
+++ b/smoke-tests/apps/CoreAndFilter3xUsingOld3xAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/CoreAndFilter3xUsingOld3xAgentTest.java
@@ -256,7 +256,7 @@ abstract class CoreAndFilter3xUsingOld3xAgentTest {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> messages = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> messages = testing.mockedIngestion.getMessageDataInRequest(3);
 
     assertThat(messages)
         .anySatisfy(m -> assertThat(m.getMessage()).isEqualTo("This is first trace message."));

--- a/smoke-tests/apps/TelemetryProcessors/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TelemetryProcessorsTest.java
+++ b/smoke-tests/apps/TelemetryProcessors/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TelemetryProcessorsTest.java
@@ -39,7 +39,7 @@ abstract class TelemetryProcessorsTest {
         .containsEntry("_MS.ProcessedByMetricExtractors", "True");
     assertThat(telemetry.rd.getSuccess()).isTrue();
     // Log processor test
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(1);
     MessageData md1 = logs.get(0);
     assertThat(md1.getMessage()).isEqualTo("testValue1::testValue2");
   }

--- a/smoke-tests/apps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
+++ b/smoke-tests/apps/TraceJavaUtilLoggingUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceJavaUtilLoggingTest.java
@@ -48,7 +48,7 @@ abstract class TraceJavaUtilLoggingTest {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(2);
     logs.sort(Comparator.comparing(MessageData::getSeverityLevel));
 
     MessageData md1 = logs.get(0);

--- a/smoke-tests/apps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j12Test.java
+++ b/smoke-tests/apps/TraceLog4j1_2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j12Test.java
@@ -55,7 +55,7 @@ abstract class TraceLog4j12Test {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(3);
     logs.sort(Comparator.comparing(MessageData::getSeverityLevel));
 
     MessageData md1 = logs.get(0);

--- a/smoke-tests/apps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j12Test.java
+++ b/smoke-tests/apps/TraceLog4j1_2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j12Test.java
@@ -55,7 +55,7 @@ abstract class TraceLog4j12Test {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(3);
     logs.sort(Comparator.comparing(MessageData::getSeverityLevel));
 
     MessageData md1 = logs.get(0);

--- a/smoke-tests/apps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/smoke-tests/apps/TraceLog4j2/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -51,7 +51,7 @@ abstract class TraceLog4j2Test {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(3);
     logs.sort(Comparator.comparing(MessageData::getSeverityLevel));
 
     MessageData md1 = logs.get(0);

--- a/smoke-tests/apps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
+++ b/smoke-tests/apps/TraceLog4j2UsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLog4j2Test.java
@@ -54,7 +54,7 @@ abstract class TraceLog4j2Test {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(4);
     logs.sort(Comparator.comparing(MessageData::getSeverityLevel));
 
     MessageData md1 = logs.get(0);

--- a/smoke-tests/apps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/smoke-tests/apps/TraceLogBack/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -48,7 +48,7 @@ abstract class TraceLogBackTest {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(2);
     logs.sort(Comparator.comparing(MessageData::getSeverityLevel));
 
     MessageData md1 = logs.get(0);

--- a/smoke-tests/apps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
+++ b/smoke-tests/apps/TraceLogBackUsingAgent/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TraceLogBackTest.java
@@ -55,7 +55,7 @@ abstract class TraceLogBackTest {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
 
-    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest();
+    List<MessageData> logs = testing.mockedIngestion.getMessageDataInRequest(3);
     logs.sort(Comparator.comparing(MessageData::getSeverityLevel));
 
     MessageData md1 = logs.get(0);

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/fakeingestion/MockedAppInsightsIngestionServer.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/fakeingestion/MockedAppInsightsIngestionServer.java
@@ -98,8 +98,9 @@ public class MockedAppInsightsIngestionServer {
     return getTelemetryDataByType(type, true);
   }
 
-  public <T extends Domain> List<T> getMessageDataInRequest() {
-    List<Envelope> items = getItemsEnvelopeDataType("MessageData");
+  public <T extends Domain> List<T> getMessageDataInRequest(int numItems)
+      throws ExecutionException, InterruptedException, TimeoutException {
+    List<Envelope> items = waitForItems("MessageData", numItems);
     List<T> dataItems = new ArrayList<>();
     for (Envelope e : items) {
       if (e.getTags().containsKey("ai.operation.id")) {


### PR DESCRIPTION
I noticed TelemetryProcessors smoke test has been sporadically failing lately, I suspect because otel log pipeline is different from span pipeline, so it's not guaranteed that request logs will show up before the request itself.