### PR TITLE
Add Netty versions to the self-diagnostics

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
@@ -103,6 +103,7 @@ public class FirstEntryPoint implements LoggingCustomizer {
       if (startupLogger.isDebugEnabled()) {
         startupLogger.debug("OS: " + System.getProperty("os.name"));
         logJavaInfo();
+        startupLogger.debug("Netty versions: " + NettyVersions.extract());
       }
 
     } catch (Exception e) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/NettyVersions.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/NettyVersions.java
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.applicationinsights.agent.internal.init;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+class NettyVersions {
+
+  // Example: **19** **Group:** `io.netty` **Name:** `netty-codec-dns` **Version:** `4.1.79.Final`
+  private static final Pattern DEPENDENCY_COORDINATE_PATTERN =
+      Pattern.compile(".*`(.*)`.*`(.*)`.*`(.*)`");
+
+  private NettyVersions() {}
+
+  static String extract() {
+    String moreLicenseResource = "/META-INF/licenses/more-licenses.md";
+    InputStream moreLicenseAsStream = NettyVersions.class.getResourceAsStream(moreLicenseResource);
+    if (moreLicenseAsStream == null) {
+      return moreLicenseResource + " notFound";
+    }
+    return extractNettyVersions(moreLicenseAsStream);
+  }
+
+  private static String extractNettyVersions(InputStream moreLicenseAsStream) {
+    try (InputStreamReader inputStreamReader =
+            new InputStreamReader(moreLicenseAsStream, StandardCharsets.UTF_8);
+        BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+      return bufferedReader
+          .lines()
+          .filter(line -> line.contains("netty") && line.contains("Group"))
+          .map(line -> extractDependency(line.trim()))
+          .collect(Collectors.joining(", "));
+    } catch (IOException e) {
+      return e.getMessage();
+    }
+  }
+
+  private static String extractDependency(String line) {
+    Matcher matcher = DEPENDENCY_COORDINATE_PATTERN.matcher(line);
+    boolean matched = matcher.find();
+    if (!matched) {
+      return "(" + line + ")";
+    }
+    try {
+      return "(" + matcher.group(1) + ", " + matcher.group(2) + ", " + matcher.group(3) + ")";
+    } catch (IllegalStateException | IndexOutOfBoundsException e) {
+      return "(" + e.getMessage() + " for " + line + ")";
+    }
+  }
+}


### PR DESCRIPTION
For this code branch:
`DEBUG c.m.applicationinsights.agent - Netty versions: (io.netty, netty-buffer, 4.1.84.Final), (io.netty, netty-codec, 4.1.84.Final), (io.netty, netty-codec-dns, 4.1.84.Final), (io.netty, netty-codec-http, 4.1.84.Final), (io.netty, netty-codec-http2, 4.1.84.Final), (io.netty, netty-codec-socks, 4.1.84.Final), (io.netty, netty-common, 4.1.84.Final), (io.netty, netty-handler, 4.1.84.Final), (io.netty, netty-handler-proxy, 4.1.84.Final), (io.netty, netty-resolver, 4.1.84.Final), (io.netty, netty-resolver-dns, 4.1.84.Final), (io.netty, netty-resolver-dns-classes-macos, 4.1.84.Final), (io.netty, netty-resolver-dns-native-macos, 4.1.84.Final), (io.netty, netty-tcnative-boringssl-static, 2.0.54.Final), (io.netty, netty-tcnative-classes, 2.0.54.Final), (io.netty, netty-transport, 4.1.84.Final), (io.netty, netty-transport-classes-epoll, 4.1.84.Final), (io.netty, netty-transport-classes-kqueue, 4.1.82.Final), (io.netty, netty-transport-native-epoll, 4.1.84.Final), (io.netty, netty-transport-native-kqueue, 4.1.82.Final), (io.netty, netty-transport-native-unix-common, 4.1.84.Final), (io.projectreactor.netty, reactor-netty-core, 1.1.0), (io.projectreactor.netty, reactor-netty-http, 1.1.0), (com.azure, azure-core-http-netty, 1.12.6)`