### PR TITLE
Update debug logging

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/FirstEntryPoint.java
@@ -114,13 +114,7 @@ public class FirstEntryPoint implements LoggingCustomizer {
     startupLogger.debug("Classpath: " + System.getProperty("java.class.path"));
     startupLogger.debug(
         "Input arguments: " + ManagementFactory.getRuntimeMXBean().getInputArguments());
-    startupLogger.debug(
-        "JAVA_OPTS: "
-            + System.getenv("JAVA_OPTS")
-            + ", _JAVA_OPTIONS: "
-            + System.getenv("_JAVA_OPTIONS")
-            + ", JAVA_OPTIONS: "
-            + System.getenv("JAVA_OPTIONS"));
+    startupLogger.debug("_JAVA_OPTIONS: " + System.getenv("_JAVA_OPTIONS"));
     startupLogger.debug("JAVA_TOOL_OPTIONS: " + System.getenv("JAVA_TOOL_OPTIONS"));
   }
 


### PR DESCRIPTION
my thought here is that JAVA_OPT and JAVA_OPTIONS are just conventions that some app servers use to populate the command line args, so those should show up in "Input arguments", while JAVA_TOOL_OPTIONS and _JAVA_OPTIONS are read directly by the JVM, so don't show up in the command line args