### PR TITLE
Update Jetty artifact

### DIFF
--- a/smoke-tests/framework/build.gradle.kts
+++ b/smoke-tests/framework/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation("com.google.code.gson:gson")
   implementation("org.apache.httpcomponents:httpclient:4.5.13")
 
-  implementation("org.eclipse.jetty.aggregate:jetty-all:9.4.39.v20210325")
+  implementation("org.eclipse.jetty:jetty-servlet:9.4.39.v20210325")
 
   // this is exposed in SmokeTestExtension API
   api("org.testcontainers:testcontainers:1.17.6")


### PR DESCRIPTION
`org.eclipse.jetty.aggregate:jetty-all` appears to be discontinued after version 9

will let dependabot take care of trying to update us to the latest