### PR TITLE
Add ramthi to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @heyams @jeanbisutti @trask
-/agent/agent-profiler @heyams @jeanbisutti @trask @johnoliver 
-/agent/agent-gc-monitor @heyams @jeanbisutti @trask @johnoliver 
+* @heyams @jeanbisutti @ramthi @trask
+/agent/agent-profiler @heyams @jeanbisutti @ramthi @trask @johnoliver
+/agent/agent-gc-monitor @heyams @jeanbisutti @ramthi @trask @johnoliver


### PR DESCRIPTION
So that his approval can be used to merge without resorting to admin override.