### PR TITLE
Enable etw dll control flow guard for component govenance

### DIFF
--- a/etw/native/build.gradle
+++ b/etw/native/build.gradle
@@ -50,6 +50,7 @@ tasks.withType(CppCompile).configureEach {
   compilerArgs.add "/EHsc"
   compilerArgs.add "/sdl"
   compilerArgs.add "/std:c++14"
+  compilerArgs.add "/guard:cf"
 
   String buildNative = System.properties[NATIVE_BUILD_VARIANT_PROPERTY]
   String outputNative = project.hasProperty(NATIVE_VERBOSE_OUTPUT_PROPERTY)
@@ -70,7 +71,9 @@ tasks.withType(CppCompile).configureEach {
 
 // NOTE: these options apply to Visual Studio Build Tools (link.exe)
 tasks.withType(LinkSharedLibrary).configureEach {
-
+  // BinSkim: Rule: BA2008 (EnableControlFlowGuard)
+  linkerArgs.add '/guard:cf'
+  linkerArgs.add '/DYNAMICBASE'
 }
 
 import org.apache.tools.ant.taskdefs.condition.Os


### PR DESCRIPTION
Tool: BinSkim: Rule: BA2008 (EnableControlFlowGuard). https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard