### PR TITLE
When diagnostics are enabled, automatically use DIAGNOSTIC_PROFILE

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurations.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurations.java
@@ -52,35 +52,68 @@ class AlternativeJfrConfigurations {
       justification =
           "The constructed file path cannot be controlled by an end user of the instrumented application")
   private static RecordingConfiguration getRecordingConfiguration(
-      @Nullable String triggeredSettings, AlertMetricType type) {
-    if (triggeredSettings != null) {
-      try {
-        // Look for file on the local file system
-        FileInputStream fis = new FileInputStream(triggeredSettings);
-        return new RecordingConfiguration.JfcFileConfiguration(fis);
-      } catch (FileNotFoundException e) {
-        // NOP, to be expected if a configuration and not a file is provided
-      }
-
-      // Look for file in the class path
-      InputStream fis = AlternativeJfrConfigurations.class.getResourceAsStream(triggeredSettings);
-      if (fis != null) {
-        return new RecordingConfiguration.JfcFileConfiguration(fis);
-      }
-
-      try {
-        // Try parsing the triggeredSettings as a pre-configured type
-        // Convert from kebab case to enum type
-        String enumType = triggeredSettings.toUpperCase(Locale.ROOT).replaceAll("-", "_");
-        ProfileTypes profile = ProfileTypes.valueOf(enumType);
-
-        return AlternativeJfrConfigurations.get(profile, type);
-      } catch (IllegalArgumentException e) {
-        logger.error("Failed to find JFC configuration " + triggeredSettings);
-      }
+      Configuration.ProfilerConfiguration configuration,
+      @Nullable String triggeredSettings,
+      AlertMetricType type) {
+    if (triggeredSettings == null) {
+      // Default to PROFILE_WITHOUT_ENV_DATA
+      triggeredSettings = ProfileTypes.PROFILE_WITHOUT_ENV_DATA.toString();
     }
 
-    return RecordingConfiguration.PROFILE_CONFIGURATION;
+    InputStream fis = null;
+
+    try {
+      // Look for file on the local file system
+      fis = new FileInputStream(triggeredSettings);
+    } catch (FileNotFoundException e) {
+      // NOP, to be expected if a configuration and not a file is provided
+    }
+
+    if (fis == null) {
+      // Look for file in the class path
+      fis = AlternativeJfrConfigurations.class.getResourceAsStream(triggeredSettings);
+    }
+
+    if (fis != null) {
+      if (configuration.enableDiagnostics) {
+        logger.warn(
+            "Diagnostics have been enabled, however a custom JFR config was provided. This is likely to prevent diagnostics from functioning");
+      }
+      return new RecordingConfiguration.JfcFileConfiguration(fis);
+    }
+
+    try {
+      // Try parsing the triggeredSettings as a pre-configured type
+      // Convert from kebab case to enum type
+      String enumType = triggeredSettings.toUpperCase(Locale.ROOT).replaceAll("-", "_");
+      ProfileTypes profile = ProfileTypes.valueOf(enumType);
+
+      profile = overlayDiagnosticSetting(configuration, profile);
+
+      return AlternativeJfrConfigurations.get(profile, type);
+    } catch (IllegalArgumentException e) {
+      logger.error("Failed to find JFC configuration " + triggeredSettings);
+    }
+
+    return AlternativeJfrConfigurations.get(ProfileTypes.PROFILE_WITHOUT_ENV_DATA, type);
+  }
+
+  private static ProfileTypes overlayDiagnosticSetting(
+      Configuration.ProfilerConfiguration configuration,
+      ProfileTypes profile) {
+
+    if (configuration.enableDiagnostics && profile != ProfileTypes.DIAGNOSTIC_PROFILE) {
+      // If diagnostics are enabled then use the DIAGNOSTIC_PROFILE configuration
+      if (profile != ProfileTypes.PROFILE_WITHOUT_ENV_DATA) {
+        // Since DIAGNOSTIC_PROFILE and PROFILE_WITHOUT_ENV_DATA are similar, no need to warn in that scenario
+        logger.warn(
+            "Diagnostics is enabled, this requires the use of the DIAGNOSTIC_PROFILE jfc configuration. The DIAGNOSTIC_PROFILE settings have been applied, overriding the current setting of "
+                + profile.name());
+      }
+      return ProfileTypes.DIAGNOSTIC_PROFILE;
+    }
+
+    return profile;
   }
 
   static RecordingConfiguration getCpu(ProfileTypes profile) {
@@ -108,18 +141,20 @@ class AlternativeJfrConfigurations {
   }
 
   static RecordingConfiguration getMemoryProfileConfig(Configuration.ProfilerConfiguration config) {
-    return getRecordingConfiguration(config.memoryTriggeredSettings, AlertMetricType.MEMORY);
+    return getRecordingConfiguration(config, config.memoryTriggeredSettings,
+        AlertMetricType.MEMORY);
   }
 
   static RecordingConfiguration getCpuProfileConfig(Configuration.ProfilerConfiguration config) {
-    return getRecordingConfiguration(config.cpuTriggeredSettings, AlertMetricType.CPU);
+    return getRecordingConfiguration(config, config.cpuTriggeredSettings, AlertMetricType.CPU);
   }
 
   static RecordingConfiguration getSpanProfileConfig(Configuration.ProfilerConfiguration config) {
-    return getRecordingConfiguration(config.cpuTriggeredSettings, AlertMetricType.REQUEST);
+    return getRecordingConfiguration(config, config.cpuTriggeredSettings, AlertMetricType.REQUEST);
   }
 
   static RecordingConfiguration getManualProfileConfig(Configuration.ProfilerConfiguration config) {
-    return getRecordingConfiguration(config.manualTriggeredSettings, AlertMetricType.MANUAL);
+    return getRecordingConfiguration(config, config.manualTriggeredSettings,
+        AlertMetricType.MANUAL);
   }
 }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurations.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurations.java
@@ -99,13 +99,13 @@ class AlternativeJfrConfigurations {
   }
 
   private static ProfileTypes overlayDiagnosticSetting(
-      Configuration.ProfilerConfiguration configuration,
-      ProfileTypes profile) {
+      Configuration.ProfilerConfiguration configuration, ProfileTypes profile) {
 
     if (configuration.enableDiagnostics && profile != ProfileTypes.DIAGNOSTIC_PROFILE) {
       // If diagnostics are enabled then use the DIAGNOSTIC_PROFILE configuration
       if (profile != ProfileTypes.PROFILE_WITHOUT_ENV_DATA) {
-        // Since DIAGNOSTIC_PROFILE and PROFILE_WITHOUT_ENV_DATA are similar, no need to warn in that scenario
+        // Since DIAGNOSTIC_PROFILE and PROFILE_WITHOUT_ENV_DATA are similar, no need to warn in
+        // that scenario
         logger.warn(
             "Diagnostics is enabled, this requires the use of the DIAGNOSTIC_PROFILE jfc configuration. The DIAGNOSTIC_PROFILE settings have been applied, overriding the current setting of "
                 + profile.name());
@@ -141,8 +141,8 @@ class AlternativeJfrConfigurations {
   }
 
   static RecordingConfiguration getMemoryProfileConfig(Configuration.ProfilerConfiguration config) {
-    return getRecordingConfiguration(config, config.memoryTriggeredSettings,
-        AlertMetricType.MEMORY);
+    return getRecordingConfiguration(
+        config, config.memoryTriggeredSettings, AlertMetricType.MEMORY);
   }
 
   static RecordingConfiguration getCpuProfileConfig(Configuration.ProfilerConfiguration config) {
@@ -154,7 +154,7 @@ class AlternativeJfrConfigurations {
   }
 
   static RecordingConfiguration getManualProfileConfig(Configuration.ProfilerConfiguration config) {
-    return getRecordingConfiguration(config, config.manualTriggeredSettings,
-        AlertMetricType.MANUAL);
+    return getRecordingConfiguration(
+        config, config.manualTriggeredSettings, AlertMetricType.MANUAL);
   }
 }

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurationsTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurationsTest.java
@@ -1,0 +1,82 @@
+package com.microsoft.applicationinsights.agent.internal.profiler;
+
+import com.microsoft.applicationinsights.agent.internal.configuration.Configuration;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AlternativeJfrConfigurationsTest {
+
+  private static void assertForAllConfigs(Configuration.ProfilerConfiguration config,
+      Consumer<String> assertion) {
+
+    assertion.accept(
+        AlternativeJfrConfigurations
+            .getCpuProfileConfig(config)
+            .getConfiguration());
+
+    assertion.accept(
+        AlternativeJfrConfigurations
+            .getMemoryProfileConfig(config)
+            .getConfiguration());
+
+    assertion.accept(
+        AlternativeJfrConfigurations
+            .getManualProfileConfig(config)
+            .getConfiguration());
+
+    assertion.accept(
+        AlternativeJfrConfigurations
+            .getSpanProfileConfig(config)
+            .getConfiguration());
+  }
+
+  @Test
+  public void ifDiagnosticsAreEnabled_A_CustomJfcFileIsNotOverridden() throws IOException {
+    File tmpfile = File.createTempFile("config", "jfc");
+    try {
+      try (BufferedWriter fw = Files.newBufferedWriter(tmpfile.toPath(), StandardCharsets.UTF_8)) {
+        fw.write("a-jfc-file");
+      }
+
+      Configuration.ProfilerConfiguration config = new Configuration.ProfilerConfiguration();
+
+      config.cpuTriggeredSettings = tmpfile.getAbsolutePath();
+      config.manualTriggeredSettings = tmpfile.getAbsolutePath();
+      config.memoryTriggeredSettings = tmpfile.getAbsolutePath();
+
+      config.enableDiagnostics = true;
+      assertForAllConfigs(config, (fileContent) -> {
+        Assertions.assertEquals("a-jfc-file", fileContent);
+      });
+
+    } finally {
+      tmpfile.delete();
+    }
+  }
+
+  @Test
+  public void ifDiagnosticsAreEnabledDefaultToDiagnosticProfile() {
+    Configuration.ProfilerConfiguration config = new Configuration.ProfilerConfiguration();
+    config.enableDiagnostics = true;
+    assertForAllConfigs(config, fileContent -> {
+      Assertions.assertTrue(
+          fileContent.contains("com.microsoft.jeg.illuminate.events.jfr.DiagnosticEvent"));
+    });
+  }
+
+  @Test
+  public void ifDiagnosticsAreDisabledDoesNotUseDiagnosticProfile() {
+    Configuration.ProfilerConfiguration config = new Configuration.ProfilerConfiguration();
+    config.enableDiagnostics = false;
+    assertForAllConfigs(config, fileContent -> {
+      Assertions.assertFalse(
+          fileContent.contains("com.microsoft.jeg.illuminate.events.jfr.DiagnosticEvent"));
+    });
+  }
+}

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurationsTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/AlternativeJfrConfigurationsTest.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.microsoft.applicationinsights.agent.internal.profiler;
 
 import com.microsoft.applicationinsights.agent.internal.configuration.Configuration;
@@ -12,28 +15,18 @@ import org.junit.jupiter.api.Test;
 
 public class AlternativeJfrConfigurationsTest {
 
-  private static void assertForAllConfigs(Configuration.ProfilerConfiguration config,
-      Consumer<String> assertion) {
+  private static void assertForAllConfigs(
+      Configuration.ProfilerConfiguration config, Consumer<String> assertion) {
+
+    assertion.accept(AlternativeJfrConfigurations.getCpuProfileConfig(config).getConfiguration());
 
     assertion.accept(
-        AlternativeJfrConfigurations
-            .getCpuProfileConfig(config)
-            .getConfiguration());
+        AlternativeJfrConfigurations.getMemoryProfileConfig(config).getConfiguration());
 
     assertion.accept(
-        AlternativeJfrConfigurations
-            .getMemoryProfileConfig(config)
-            .getConfiguration());
+        AlternativeJfrConfigurations.getManualProfileConfig(config).getConfiguration());
 
-    assertion.accept(
-        AlternativeJfrConfigurations
-            .getManualProfileConfig(config)
-            .getConfiguration());
-
-    assertion.accept(
-        AlternativeJfrConfigurations
-            .getSpanProfileConfig(config)
-            .getConfiguration());
+    assertion.accept(AlternativeJfrConfigurations.getSpanProfileConfig(config).getConfiguration());
   }
 
   @Test
@@ -51,9 +44,11 @@ public class AlternativeJfrConfigurationsTest {
       config.memoryTriggeredSettings = tmpfile.getAbsolutePath();
 
       config.enableDiagnostics = true;
-      assertForAllConfigs(config, (fileContent) -> {
-        Assertions.assertEquals("a-jfc-file", fileContent);
-      });
+      assertForAllConfigs(
+          config,
+          (fileContent) -> {
+            Assertions.assertEquals("a-jfc-file", fileContent);
+          });
 
     } finally {
       tmpfile.delete();
@@ -64,19 +59,23 @@ public class AlternativeJfrConfigurationsTest {
   public void ifDiagnosticsAreEnabledDefaultToDiagnosticProfile() {
     Configuration.ProfilerConfiguration config = new Configuration.ProfilerConfiguration();
     config.enableDiagnostics = true;
-    assertForAllConfigs(config, fileContent -> {
-      Assertions.assertTrue(
-          fileContent.contains("com.microsoft.jeg.illuminate.events.jfr.DiagnosticEvent"));
-    });
+    assertForAllConfigs(
+        config,
+        fileContent -> {
+          Assertions.assertTrue(
+              fileContent.contains("com.microsoft.jeg.illuminate.events.jfr.DiagnosticEvent"));
+        });
   }
 
   @Test
   public void ifDiagnosticsAreDisabledDoesNotUseDiagnosticProfile() {
     Configuration.ProfilerConfiguration config = new Configuration.ProfilerConfiguration();
     config.enableDiagnostics = false;
-    assertForAllConfigs(config, fileContent -> {
-      Assertions.assertFalse(
-          fileContent.contains("com.microsoft.jeg.illuminate.events.jfr.DiagnosticEvent"));
-    });
+    assertForAllConfigs(
+        config,
+        fileContent -> {
+          Assertions.assertFalse(
+              fileContent.contains("com.microsoft.jeg.illuminate.events.jfr.DiagnosticEvent"));
+        });
   }
 }


### PR DESCRIPTION
Currently if enableDiagnostics is set to true, the user must also use the DIAGNOSTIC_PROFILE ProfileType. At the moment enabling diagnostics with a different profile is _probably_ an incorrect configuration as it is unlikely to work. 

This PR:

1. If enableDiagnostics == true && a custom JFR config is provided by the user:
    - A warning is logged that this is unlikely to work, however continues to use the custom profile
2. If enableDiagnostics == true && an alternative inbuilt config was selected by the user:
    - The configuration is overridden to the DIAGNOSTIC_PROFILE  and a warning is logged that this has happened.
3. If enableDiagnostics == true && the user has not configured any profile setting:
    - The configuration is overridden to the DIAGNOSTIC_PROFILE.
