### PR TITLE
Update gradle toolchain to Java 17

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Generate license report
         uses: gradle/gradle-build-action@v2.4.2
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Assemble
         uses: gradle/gradle-build-action@v2.4.2
@@ -127,7 +127,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Test
         uses: gradle/gradle-build-action@v2.4.2
@@ -163,11 +163,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Test
         uses: gradle/gradle-build-action@v2.4.2

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - uses: gradle/gradle-build-action@v2.4.2
         with:

--- a/buildSrc/src/main/kotlin/ai.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ai.java-conventions.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
+    languageVersion.set(JavaLanguageVersion.of(17))
   }
 
   // See https://docs.gradle.org/current/userguide/upgrading_version_5.html, Automatic target JVM version

--- a/buildSrc/src/main/kotlin/ai.smoke-test.gradle.kts
+++ b/buildSrc/src/main/kotlin/ai.smoke-test.gradle.kts
@@ -24,7 +24,7 @@ configurations["smokeTestRuntimeOnly"].extendsFrom(configurations.runtimeOnly.ge
 // FIXME (trask) copy-pasted from ai.java-conventions.gradle
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
+    languageVersion.set(JavaLanguageVersion.of(17))
   }
 
   // See https://docs.gradle.org/current/userguide/upgrading_version_5.html, Automatic target JVM version


### PR DESCRIPTION
Doesn't seem to help with #3020, but worth doing anyways. Note: this doesn't affect end-user Java compatibility as the target Java version is still Java 8, it only affects the Java version that is used to run the builds themselves.