### PR TITLE
Prefer forwarded url scheme

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiConfigCustomizer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AiConfigCustomizer.java
@@ -122,6 +122,8 @@ public class AiConfigCustomizer implements Function<ConfigProperties, Map<String
 
     properties.put("otel.instrumentation.experimental.span-suppression-strategy", "client");
 
+    properties.put("otel.instrumentation.http.prefer-forwarded-url-scheme", "true");
+
     // instrumentation that cannot be disabled (currently at least)
 
     properties.put("otel.instrumentation.ai-azure-functions.enabled", "true");


### PR DESCRIPTION
In current OTel Java Instrumentation release, url scheme will reflect scheme provided in `Forwarded` or `X-Forwarded-Proto`. This is preferred for us, because otherwise when SSL is terminated at the web server (e.g. in App Services) users would see url like `http://...` and think the request was unencrypted.

In the next OTel Java Instrumentation release, this behavior will change, and adding this setting is needed in order to preserve the existing behavior.

TODO add a smoke test for this, will need to add an option to send `X-Forwarded-Proto` header from SmokeTestExtension.