### PR TITLE
Suppress invalid CVE

### DIFF
--- a/buildscripts/dependency-check-suppressions.xml
+++ b/buildscripts/dependency-check-suppressions.xml
@@ -15,4 +15,11 @@
     <packageUrl regex="true">^pkg:maven/org.slf4j/jcl-over-slf4j@.*$</packageUrl>
     <cpe>cpe:/a:apache:commons_net</cpe>
   </suppress>
+  <suppress>
+    <notes>
+      CVE-2023-35116 is not a valid CVE, see comment from library maintainer
+      https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596308216
+    </notes>
+    <cve>CVE-2023-35116</cve>
+  </suppress>
 </suppressions>

--- a/buildscripts/dependency-check-suppressions.xml
+++ b/buildscripts/dependency-check-suppressions.xml
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
-    <notes>commons-codec should not be matched to commons_net</notes>
-    <packageUrl regex="true">^pkg:maven/commons-codec/commons-codec@.*$</packageUrl>
-    <cpe>cpe:/a:apache:commons_net</cpe>
-  </suppress>
-  <suppress>
-    <notes>commons-text should not be matched to commons_net</notes>
-    <packageUrl regex="true">^pkg:maven/org.apache.commons/commons-text@.*$</packageUrl>
-    <cpe>cpe:/a:apache:commons_net</cpe>
-  </suppress>
-  <suppress>
-    <notes>jcl-over-slf4j should not be matched to commons_net</notes>
-    <packageUrl regex="true">^pkg:maven/org.slf4j/jcl-over-slf4j@.*$</packageUrl>
-    <cpe>cpe:/a:apache:commons_net</cpe>
-  </suppress>
-  <suppress>
     <notes>
       CVE-2023-35116 is not a valid CVE, see comment from library maintainer
       https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596308216


### PR DESCRIPTION
Closes #3133

CVE-2023-35116 is not a valid CVE, see comment from library maintainer https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596308216

Also removed some suppressions which are no longer needed.

Tested against my fork: https://github.com/trask/ApplicationInsights-Java/actions/runs/5317965027/jobs/9629003133