### PR TITLE
Change azure instrumentation scope name prefix for statsbeats

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StatsbeatSpanExporter.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/StatsbeatSpanExporter.java
@@ -25,7 +25,7 @@ public class StatsbeatSpanExporter implements SpanExporter {
   public CompletableResultCode export(Collection<SpanData> spans) {
     for (SpanData span : spans) {
       String instrumentationScopeName = span.getInstrumentationScopeInfo().getName();
-      if (instrumentationScopeName.startsWith("com.azure:")) {
+      if (instrumentationScopeName.startsWith("azure-")) {
         instrumentationScopeName = AZURE_OPENTELEMETRY;
       }
       statsbeatModule.getInstrumentationStatsbeat().addInstrumentation(instrumentationScopeName);


### PR DESCRIPTION
@heyams @trask 

I'm sorry I gave you the wrong prefix for Azure SDK instrumentation scope name. We don't include group id and use artifact id as is. So, it should be not "com.azure:", but "azure-".

This should fix it.

