### PR TITLE
Remove gradle-build-action minor version pin

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 17
 
       - name: Spotless
-        uses: gradle/gradle-build-action@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: spotlessCheck ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
 
@@ -43,7 +43,7 @@ jobs:
           java-version: 17
 
       - name: Generate license report
-        uses: gradle/gradle-build-action@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
           # ignore inputs.no-build-cache and always run with --no-build-cache
           # see https://github.com/jk1/Gradle-License-Report/issues/231
@@ -82,7 +82,7 @@ jobs:
           java-version: 17
 
       - name: Assemble
-        uses: gradle/gradle-build-action@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
           # javadoc task fails sporadically fetching https://docs.oracle.com/javase/8/docs/api/
           arguments: assemble -Dai.etw.native.build=release -x javadoc ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
@@ -130,7 +130,7 @@ jobs:
           java-version: 17
 
       - name: Test
-        uses: gradle/gradle-build-action@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
           # spotless is checked separately since it's a common source of failure
           arguments: >
@@ -170,6 +170,6 @@ jobs:
           java-version: 17
 
       - name: Test
-        uses: gradle/gradle-build-action@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: ${{ matrix.module }}:smokeTest

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           languages: java
 
-      - uses: gradle/gradle-build-action@v2.6.0
+      - uses: gradle/gradle-build-action@v2
         with:
           # skipping build cache is needed so that all modules will be analyzed
           arguments: assemble --no-build-cache

--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v2.6.0
+      - uses: gradle/gradle-build-action@v2
         with:
           arguments: ":agent:agent:dependencyCheckAnalyze"
 

--- a/.github/workflows/pull-request-helper.yml
+++ b/.github/workflows/pull-request-helper.yml
@@ -21,7 +21,7 @@ jobs:
           gh pr checkout $NUMBER
 
       - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2.6.0
+        uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
 


### PR DESCRIPTION
The version pin was needed previously to remove a (false-positive) github security warning, but is no longer needed now that the warning has cleared