### PR TITLE
Send operation name for function

### DIFF
--- a/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/AzureFunctionsCustomDimensions.java
+++ b/agent/agent-bootstrap/src/main/java/com/microsoft/applicationinsights/agent/bootstrap/AzureFunctionsCustomDimensions.java
@@ -18,6 +18,7 @@ public final class AzureFunctionsCustomDimensions implements ImplicitContextKeye
   public final String category;
   public final String hostInstanceId;
   public final String azFunctionLiveLogsSessionId;
+  public final String operationName;
 
   public AzureFunctionsCustomDimensions(
       String invocationId,
@@ -25,13 +26,15 @@ public final class AzureFunctionsCustomDimensions implements ImplicitContextKeye
       String logLevel,
       String category,
       String hostInstanceId,
-      String azFunctionLiveLogsSessionId) {
+      String azFunctionLiveLogsSessionId,
+      String operationName) {
     this.invocationId = invocationId;
     this.processId = processId;
     this.logLevel = logLevel;
     this.category = category;
     this.hostInstanceId = hostInstanceId;
     this.azFunctionLiveLogsSessionId = azFunctionLiveLogsSessionId;
+    this.operationName = operationName;
   }
 
   public static AzureFunctionsCustomDimensions fromContext(Context context) {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureFunctionsLogProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureFunctionsLogProcessor.java
@@ -44,5 +44,8 @@ public final class AzureFunctionsLogProcessor implements LogRecordProcessor {
           AiSemanticAttributes.AZ_FN_LIVE_LOGS_SESSION_ID,
           customDimensions.azFunctionLiveLogsSessionId);
     }
+    if (customDimensions.operationName != null) {
+      logRecord.setAttribute(AiSemanticAttributes.OPERATION_NAME, customDimensions.operationName);
+    }
   }
 }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureMonitorLogProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureMonitorLogProcessor.java
@@ -5,8 +5,6 @@ package com.microsoft.applicationinsights.agent.internal.init;
 
 import com.azure.monitor.opentelemetry.exporter.implementation.AiSemanticAttributes;
 import com.azure.monitor.opentelemetry.exporter.implementation.OperationNames;
-import com.microsoft.applicationinsights.agent.bootstrap.AzureFunctionsCustomDimensions;
-import com.microsoft.applicationinsights.agent.internal.configuration.ConfigurationBuilder;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
@@ -21,18 +19,9 @@ public class AzureMonitorLogProcessor implements LogRecordProcessor {
     if (!(currentSpan instanceof ReadableSpan)) {
       return;
     }
-
     ReadableSpan readableSpan = (ReadableSpan) currentSpan;
-    if (ConfigurationBuilder.inAzureFunctionsWorker()) {
-      AzureFunctionsCustomDimensions customDimensions =
-          AzureFunctionsCustomDimensions.fromContext(context);
-      if (customDimensions != null && customDimensions.operationName != null) {
-        logRecord.setAttribute(AiSemanticAttributes.OPERATION_NAME, customDimensions.operationName);
-      }
-    } else {
-      logRecord.setAttribute(
-          AiSemanticAttributes.OPERATION_NAME, OperationNames.getOperationName(readableSpan));
-    }
+    logRecord.setAttribute(
+        AiSemanticAttributes.OPERATION_NAME, OperationNames.getOperationName(readableSpan));
     Long itemCount = readableSpan.getAttribute(AiSemanticAttributes.ITEM_COUNT);
     if (itemCount != null) {
       logRecord.setAttribute(AiSemanticAttributes.ITEM_COUNT, itemCount);

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureMonitorSpanProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureMonitorSpanProcessor.java
@@ -21,11 +21,9 @@ public class AzureMonitorSpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(Context parentContext, ReadWriteSpan span) {
-
     // if user wants to change operation name, they should change operation name on the parent span
     // first before creating child span
 
-    Span parentSpan = Span.fromContextOrNull(parentContext);
     // Azure function host is emitting request, java agent doesn't.
     // parentSpan is not an instanceof ReadableSpan here, thus need to update operationName before
     // checking for ReadableSpan
@@ -36,6 +34,7 @@ public class AzureMonitorSpanProcessor implements SpanProcessor {
         span.setAttribute(AiSemanticAttributes.OPERATION_NAME, customDimensions.operationName);
       }
     }
+    Span parentSpan = Span.fromContextOrNull(parentContext);
     if (!(parentSpan instanceof ReadableSpan)) {
       return;
     }

--- a/agent/instrumentation/azure-functions/src/main/java/io/opentelemetry/javaagent/instrumentation/azurefunctions/InvocationInstrumentation.java
+++ b/agent/instrumentation/azure-functions/src/main/java/io/opentelemetry/javaagent/instrumentation/azurefunctions/InvocationInstrumentation.java
@@ -82,7 +82,8 @@ class InvocationInstrumentation implements TypeInstrumentation {
               attributesMap.get("LogLevel"),
               attributesMap.get("Category"),
               attributesMap.get("HostInstanceId"),
-              attributesMap.get("#AzFuncLiveLogsSessionId"));
+              attributesMap.get("#AzFuncLiveLogsSessionId"),
+              attributesMap.get("OperationName"));
 
       return Context.current().with(Span.wrap(spanContext)).with(customDimensions).makeCurrent();
     }


### PR DESCRIPTION
Fix #3066

OperationName will set it directly to _**operation_name**_ column.
no need to update it in LogDataMapper::setFunctionExtraTraceAttributes, i.e. it's not available in _**customDimensions**_ column.