### PR TITLE
Trim the connecting string and add new tests

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/FileStringLookup.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/FileStringLookup.java
@@ -21,7 +21,8 @@ final class FileStringLookup implements StringLookup {
   @Override
   public String lookup(String key) {
     try {
-      return new String(Files.readAllBytes(baseDir.resolve(key)), StandardCharsets.UTF_8);
+      String connectionString = new String(Files.readAllBytes(baseDir.resolve(key)), StandardCharsets.UTF_8);
+      return connectionString.trim();
     } catch (IOException | InvalidPathException e) {
       throw new IllegalArgumentException(
           "Error occurs when reading connection string from the file '"

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/configuration/FileStringLookupTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/configuration/FileStringLookupTest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.text.StringSubstitutor;
@@ -112,6 +113,39 @@ public class FileStringLookupTest {
   @Test
   public void testRelativePath() {
     String connectionString = "${file:./" + file.getName() + "}";
+    String value = stringSubstitutor.replace(connectionString);
+    assertThat(value).isEqualTo(CONNECTION_STRING);
+  }
+
+  @Test
+  public void testFileWithCRLFLineTerminators() throws IOException {
+    Writer writer = Files.newBufferedWriter(file.toPath(), UTF_8, StandardOpenOption.APPEND);
+    writer.write("\r\n");
+    writer.close();
+
+    String connectionString = "${file:" + file.getAbsolutePath() + "}";
+    String value = stringSubstitutor.replace(connectionString);
+    assertThat(value).isEqualTo(CONNECTION_STRING);
+  }
+
+  @Test
+  public void testFileWithCRLineTerminators() throws IOException {
+    Writer writer = Files.newBufferedWriter(file.toPath(), UTF_8, StandardOpenOption.APPEND);
+    writer.write("\r");
+    writer.close();
+
+    String connectionString = "${file:" + file.getAbsolutePath() + "}";
+    String value = stringSubstitutor.replace(connectionString);
+    assertThat(value).isEqualTo(CONNECTION_STRING);
+  }
+
+  @Test
+  public void testFileWithLFLineTerminators() throws IOException {
+    Writer writer = Files.newBufferedWriter(file.toPath(), UTF_8, StandardOpenOption.APPEND);
+    writer.write("\n");
+    writer.close();
+
+    String connectionString = "${file:" + file.getAbsolutePath() + "}";
     String value = stringSubstitutor.replace(connectionString);
     assertThat(value).isEqualTo(CONNECTION_STRING);
   }


### PR DESCRIPTION
Fix #3628. The original approach does not ignore newline or carriage return.

As I mentioned in the issue, I created the following files and reproduced them in the tests:

* <details>
    <summary>(Success) No line terminator</summary>

    ```
    progxaker@pc-name# cat -A applicationinsights-connection-string_no-eol.txt 
    InstrumentationKey=<ikey>;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/progxaker@pc-name#
    ```

    </details>

* <details>
    <summary>(Failed) CRLF line terminator (Windows)</summary>

    ```
    progxaker@pc-name# cat -A applicationinsights-connection-string_windows.txt 
    InstrumentationKey=<ikey>;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/^M$
    progxaker@pc-name#
    ```

    </details>

* <details>
    <summary>(Failed) CR line terminator (Mac OS)</summary>

    ```
    progxaker@pc-name# cat -A applicationinsights-connection-string_cr-eol.txt 
    InstrumentationKey=<ikey>;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/^Mprogxaker@pc-name#
    ```

    </details>

* <details>
    <summary>(Failed) LF line terminator (Linux)</summary>

    ```
    progxaker@pc-name# cat -A applicationinsights-connection-string.txt 
    InstrumentationKey=<ikey>;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com$
    progxaker@pc-name#
    ```

    </details>

**Decisions**
* At first I wanted to replace line terminators with "", but I decided to use the `trim()` function.
* I prefer to add line terminators to the test file so we don't have to check if the file exists or rewrite it:
    ```java
    Writer writer = Files.newBufferedWriter(file.toPath(), UTF_8);
    writer.write(CONNECTION_STRING+"\r\n");
    writer.close();
    ```
    but if you don't want to add the `StandardOpenOption` class import, I can rewrite that block.
* I'm not quite sure if I should use absolute path or relative path, but I added the tests to the end, thinking the tests would run in order.
* I prefer to create three tests instead of one with a loop.

**Tests**

* If we run tests without the fix, we get the following results:
<details>
<summary>Failed test results</summary>

```
# ./gradlew test                                                                                    
                                                
> Task :agent:agent-tooling:compileTestJava                                                                                  
Note: Some input files use or override a deprecated API.                                          
Note: Recompile with -Xlint:deprecation for details.                                                       
Note: Some input files use unchecked or unsafe operations.                                                                        
Note: Recompile with -Xlint:unchecked for details.                                                                                                                                                
                                                                                                                                                                                                  
> Task :agent:agent-tooling:test                                                                                                                                                                  

FileStringLookupTest > testFileWithCRLineTerminators() FAILED
    org.opentest4j.AssertionFailedError:                                                          
    expected: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake-ingestion-endpoint.example.com/"
     but was: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake-ingestion-endpoint.example.com/
"
        at java.base@17.0.10/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base@17.0.10/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base@17.0.10/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base@17.0.10/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at app//com.microsoft.applicationinsights.agent.internal.configuration.FileStringLookupTest.testFileWithCRLineTerminators(FileStringLookupTest.java:150)

FileStringLookupTest > testFileWithLFLineTerminators() FAILED
    org.opentest4j.AssertionFailedError: 
    expected: 
      "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake-ingestion-endpoint.example.com/"
     but was: 
      "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake-ingestion-endpoint.example.com/
      "
        at java.base@17.0.10/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base@17.0.10/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base@17.0.10/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base@17.0.10/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at app//com.microsoft.applicationinsights.agent.internal.configuration.FileStringLookupTest.testFileWithLFLineTerminators(FileStringLookupTest.java:139)

FileStringLookupTest > testFileWithCRLFLineTerminators() FAILED
    org.opentest4j.AssertionFailedError: 
    expected: 
      "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake-ingestion-endpoint.example.com/"
     but was: 
      "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://fake-ingestion-endpoint.example.com/
      "
        at java.base@17.0.10/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base@17.0.10/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base@17.0.10/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base@17.0.10/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at app//com.microsoft.applicationinsights.agent.internal.configuration.FileStringLookupTest.testFileWithCRLFLineTerminators(FileStringLookupTest.java:128)

...

258 tests completed, 3 failed, 10 skipped
```

</details>

* If we run with the tests with the fix, the build will succeed.

---

The PR is open as a draft, as I'd like to get your opinion on it and make changes if necessary.
(I'm just not a developer, so I might be missing something).

- [x] Design discussion issue #3628 
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
