### PR TITLE
Fix misleading connection string message

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -743,7 +743,7 @@ public class ConfigurationBuilder {
         && !replacedConnectionString.startsWith("InstrumentationKey=")
         && config.connectionString.equals(replacedConnectionString)) {
       throw new FriendlyException(
-          "You connection string seems to have a wrong format: \""
+          "Your connection string seems to have a wrong format: \""
               + config.connectionString
               + "\").\n"
               + "If you want to load the connection string from a file, please use this format:"

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -743,7 +743,7 @@ public class ConfigurationBuilder {
         && !replacedConnectionString.startsWith("InstrumentationKey=")
         && config.connectionString.equals(replacedConnectionString)) {
       throw new FriendlyException(
-          "You connection seems to have a wrong format: \""
+          "You connection string seems to have a wrong format: \""
               + config.connectionString
               + "\").\n"
               + "If you want to load the connection string from a file, please use this format:"

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -743,10 +743,10 @@ public class ConfigurationBuilder {
         && !replacedConnectionString.startsWith("InstrumentationKey=")
         && config.connectionString.equals(replacedConnectionString)) {
       throw new FriendlyException(
-          "Error loading connection string from a file (\""
+          "You connection seems to have a wrong format: \""
               + config.connectionString
               + "\").\n"
-              + "Please use this format instead:"
+              + "If you want to read the connection string from a file, please use this format:"
               + "\n{ \"connectionString\": \"${file:connection-string-file.txt}\" }\n",
           "Learn more about configuration options here: " + CONFIGURATION_OPTIONS_LINK);
     }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -746,7 +746,7 @@ public class ConfigurationBuilder {
           "You connection seems to have a wrong format: \""
               + config.connectionString
               + "\").\n"
-              + "If you want to read the connection string from a file, please use this format:"
+              + "If you want to load the connection string from a file, please use this format:"
               + "\n{ \"connectionString\": \"${file:connection-string-file.txt}\" }\n",
           "Learn more about configuration options here: " + CONFIGURATION_OPTIONS_LINK);
     }


### PR DESCRIPTION
The following error messages were displayed for cases not related to a misconfiguration of a connection string from a file:

`Error loading connection string from a file`

```
Please use this format instead:
{ "connectionString": "${file:connection-string-file.txt}" }
```

For example `totoInstrumentationKey` for a connection string creates these error messages.

It can be misleading for the users.

Related to #3707



