### PR TITLE
Don't validate the JSON connection string if APPLICATIONINSIGHT__CONNECTION_STRING

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/ConfigurationBuilder.java
@@ -743,7 +743,8 @@ public class ConfigurationBuilder {
     String replacedConnectionString = stringSubstitutor.replace(config.connectionString);
     if (replacedConnectionString != null
         && !replacedConnectionString.startsWith("InstrumentationKey=")
-        && config.connectionString.equals(replacedConnectionString)) {
+        && config.connectionString.equals(replacedConnectionString)
+        && System.getenv(APPLICATIONINSIGHTS_CONNECTION_STRING_ENV) == null) {
       throw new FriendlyException(
           "Your connection string seems to have a wrong format: \""
               + config.connectionString


### PR DESCRIPTION
Because the connection string from the APPLICATIONINSIGHT__CONNECTION_STRING environment variable takes precedence over the connection string coming from the JSON file.

Fix #3707


