### PR TITLE
Fix CVE-2024-35255

### DIFF
--- a/agent/agent-tooling/build.gradle.kts
+++ b/agent/agent-tooling/build.gradle.kts
@@ -87,11 +87,6 @@ dependencies {
   testCompileOnly("com.google.code.findbugs:jsr305")
 }
 
-configurations.all {
-  // temporarily overriding version until next azure-bom release in order to address CVE
-  resolutionStrategy.force("com.azure:azure-identity:1.13.0")
-}
-
 configurations {
   "implementation" {
     exclude(group = "net.bytebuddy", module = "byte-buddy") // we use byte-buddy-dep

--- a/agent/agent/build.gradle.kts
+++ b/agent/agent/build.gradle.kts
@@ -226,7 +226,5 @@ configurations {
     // excluding unused dependencies for size (~1.8mb)
     exclude("com.fasterxml.jackson.dataformat", "jackson-dataformat-xml")
     exclude("com.fasterxml.woodstox", "woodstox-core")
-    // temporarily overriding version until next azure-bom release in order to address CVE
-    resolutionStrategy.force("com.azure:azure-identity:1.13.0")
   }
 }

--- a/licenses/more-licenses.md
+++ b/licenses/more-licenses.md
@@ -1,7 +1,7 @@
 
 # agent
 ## Dependency License Report
-_2024-07-08 03:55:59 UTC_
+_2024-07-09 11:07:48 PDT_
 ## Apache License, Version 2.0
 
 **1** **Group:** `com.fasterxml.jackson.core` **Name:** `jackson-annotations` **Version:** `2.17.2` 


### PR DESCRIPTION
Fix #3755

new OWASP run https://github.com/microsoft/ApplicationInsights-Java/actions/runs/9862118673

We have the latest azure-identity, but we also have an earlier version because of this hack using `resolveStrategy`. We didn't clean up after a newer version became available.