### PR TITLE
Fix auto-updating of runtime-attach dependency

### DIFF
--- a/agent/runtime-attach/build.gradle.kts
+++ b/agent/runtime-attach/build.gradle.kts
@@ -10,7 +10,7 @@ val otelVersion: String by project
 val agent: Configuration by configurations.creating
 
 dependencies {
-  implementation("io.opentelemetry.contrib:opentelemetry-runtime-attach-core:$otelContribAlphaVersion")
+  implementation("io.opentelemetry.contrib:opentelemetry-runtime-attach-core:1.35.0-alpha")
   agent(project(":agent:agent", configuration = "shadow"))
 }
 

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -14,13 +14,11 @@ rootProject.extra["versions"] = dependencyVersions
 val otelVersion = "1.40.0"
 val otelInstrumentationAlphaVersion = "2.6.0-alpha"
 val otelInstrumentationVersion = "2.6.0"
-val otelContribAlphaVersion = "1.35.0-alpha"
 val byteBuddyVersion = "1.14.11"
 
 rootProject.extra["otelVersion"] = otelVersion
 rootProject.extra["otelInstrumentationVersion"] = otelInstrumentationVersion
 rootProject.extra["otelInstrumentationAlphaVersion"] = otelInstrumentationAlphaVersion
-rootProject.extra["otelContribAlphaVersion"] = otelContribAlphaVersion
 
 val DEPENDENCY_BOMS = listOf(
   "com.fasterxml.jackson:jackson-bom:2.17.2",


### PR DESCRIPTION
Once this is merged, hopefully dependabot will auto-update runtime-attach to 1.37.0-alpha