### PR TITLE
Disable publication of gradle modeule metadata for runtime-attach

### DIFF
--- a/agent/runtime-attach/build.gradle.kts
+++ b/agent/runtime-attach/build.gradle.kts
@@ -24,4 +24,9 @@ tasks {
       attributes("Automatic-Module-Name" to "com.microsoft.applicationinsights.attach")
     }
   }
+
+  // disabling the publication of Gradle Module Metadata
+  withType<GenerateModuleMetadata>().configureEach {
+    enabled = false
+  }
 }


### PR DESCRIPTION
Fix #3822