### PR TITLE
Fix missing artifact warning

### DIFF
--- a/agent/instrumentation/applicationinsights-web-2.3/build.gradle.kts
+++ b/agent/instrumentation/applicationinsights-web-2.3/build.gradle.kts
@@ -17,7 +17,7 @@ val otelVersion: String by project
 dependencies {
   compileOnly("com.microsoft.azure:applicationinsights-web:2.3.0")
 
-  testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:$otelVersion")
+  testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:$otelInstrumentationAlphaVersion")
 
   testImplementation("com.microsoft.azure:applicationinsights-web:2.3.0")
   testImplementation("javax.servlet:javax.servlet-api:3.0.1")


### PR DESCRIPTION
I think this warning that mentions `repo.maven.apache.org` may be what's triggering (one of) the current S360 violations:

> Task :agent:instrumentation:applicationinsights-web-2.3:compileTestJava FROM-CACHE
Resource missing. [HTTP GET: https://repo.maven.apache.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-annotations/1.42.1/opentelemetry-instrumentation-annotations-1.42.1.pom]

