### PR TITLE
Fix CodeQL failures due to recent org-level permission changes

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Now needs explicit declared permissions.

Confirmed this PR fixed the issue: https://github.com/microsoft/ApplicationInsights-Java/actions/runs/11767099299