### PR TITLE
Fix issue notification workflow permissions

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -32,6 +32,8 @@ jobs:
         uses: github/codeql-action/analyze@v3
 
   scheduled-job-notification:
+    permissions:
+      issues: write
     needs:
       - analyze
     if: always()

--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -30,7 +30,8 @@ jobs:
           path: agent/agent/build/reports
 
   scheduled-job-notification:
-    permissions: write-all
+    permissions:
+      issues: write
     needs:
       - analyze
     if: always()

--- a/.github/workflows/reusable-scheduled-job-notification.yml
+++ b/.github/workflows/reusable-scheduled-job-notification.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   notify-if-needed:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This workflow is failing due to recent org-level permission changes, now needs explicit declared permissions.

Confirmed this fixes the issue:
* https://github.com/microsoft/ApplicationInsights-Java/actions/runs/11767285777
* https://github.com/microsoft/ApplicationInsights-Java/issues/3953