### PR TITLE
Fix OWASP check

### DIFF
--- a/.github/workflows/owasp-dependency-check-daily.yml
+++ b/.github/workflows/owasp-dependency-check-daily.yml
@@ -20,6 +20,8 @@ jobs:
           java-version: 17
 
       - uses: gradle/gradle-build-action@v3
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         with:
           arguments: ":agent:agent:dependencyCheckAnalyze"
 


### PR DESCRIPTION
This should fix the OWASP sporadic failures:

> An NVD API Key was not provided - it is highly recommended to use an NVD API key as the update can take a VERY long time without an API Key