### PR TITLE
Nicer smoke test assertions

### DIFF
--- a/smoke-tests/apps/AutoPerfCounters/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/AutoPerfCountersTest.java
+++ b/smoke-tests/apps/AutoPerfCounters/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/AutoPerfCountersTest.java
@@ -15,15 +15,7 @@ import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCA
 import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_8_OPENJ9;
 import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.WILDFLY_13_JAVA_8;
 import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.WILDFLY_13_JAVA_8_OPENJ9;
-import static org.assertj.core.api.Assertions.assertThat;
 
-import com.microsoft.applicationinsights.smoketest.schemav2.DataPoint;
-import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
-import com.microsoft.applicationinsights.smoketest.schemav2.MetricData;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -34,105 +26,31 @@ abstract class AutoPerfCountersTest {
 
   @Test
   @TargetUri(value = "index.jsp")
-  void testPerformanceCounterData() throws Exception {
-    System.out.println("Waiting for performance data...");
-    long start = System.currentTimeMillis();
+  void testPerformanceCounterData() {
 
-    int timeout = 10;
+    testing.waitAndAssertMetric("\\Memory\\Available Bytes", MetricAssert::hasValueGreaterThanZero);
 
-    Envelope availableMem =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("\\Memory\\Available Bytes"), timeout, TimeUnit.SECONDS);
-    Envelope totalCpu =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("\\Processor(_Total)\\% Processor Time"),
-            timeout,
-            TimeUnit.SECONDS);
+    testing.waitAndAssertMetric(
+        "\\Processor(_Total)\\% Processor Time", MetricAssert::hasValueGreaterThanZero);
 
-    Envelope processIo =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("\\Process(??APP_WIN32_PROC??)\\IO Data Bytes/sec"),
-            timeout,
-            TimeUnit.SECONDS);
-    Envelope processMemUsed =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("\\Process(??APP_WIN32_PROC??)\\Private Bytes"),
-            timeout,
-            TimeUnit.SECONDS);
-    Envelope processCpu =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("\\Process(??APP_WIN32_PROC??)\\% Processor Time"),
-            timeout,
-            TimeUnit.SECONDS);
-    Envelope processCpuNormalized =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("\\Process(??APP_WIN32_PROC??)\\% Processor Time Normalized"),
-            timeout,
-            TimeUnit.SECONDS);
-    System.out.println("PerformanceCounterData are good: " + (System.currentTimeMillis() - start));
+    testing.waitAndAssertMetric("\\Process(??APP_WIN32_PROC??)\\IO Data Bytes/sec", metric -> {});
 
-    MetricData metricMem = SmokeTestExtension.getBaseData(availableMem);
-    assertPerfMetric(metricMem);
-    assertThat(metricMem.getMetrics().get(0).getName()).isEqualTo("\\Memory\\Available Bytes");
+    testing.waitAndAssertMetric(
+        "\\Process(??APP_WIN32_PROC??)\\Private Bytes", MetricAssert::hasValueGreaterThanZero);
 
-    MetricData pdCpu = SmokeTestExtension.getBaseData(totalCpu);
-    assertPerfMetric(pdCpu);
-    assertThat(pdCpu.getMetrics().get(0).getName())
-        .isEqualTo("\\Processor(_Total)\\% Processor Time");
+    testing.waitAndAssertMetric(
+        "\\Process(??APP_WIN32_PROC??)\\% Processor Time", MetricAssert::hasValueGreaterThanZero);
 
-    assertPerfMetric(SmokeTestExtension.getBaseData(processIo));
-    assertPerfMetric(SmokeTestExtension.getBaseData(processMemUsed));
-    assertPerfMetric(SmokeTestExtension.getBaseData(processCpu));
-    assertPerfMetric(SmokeTestExtension.getBaseData(processCpuNormalized));
+    testing.waitAndAssertMetric(
+        "\\Process(??APP_WIN32_PROC??)\\% Processor Time Normalized",
+        MetricAssert::hasValueGreaterThanZero);
 
-    start = System.currentTimeMillis();
-    System.out.println("Waiting for metric data...");
-    Envelope deadlocks =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("Suspected Deadlocked Threads"), timeout, TimeUnit.SECONDS);
-    Envelope heapUsed =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("Heap Memory Used (MB)"), timeout, TimeUnit.SECONDS);
-    Envelope gcTotalCount =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("GC Total Count"), timeout, TimeUnit.SECONDS);
-    Envelope gcTotalTime =
-        testing.mockedIngestion.waitForItem(
-            getPerfMetricPredicate("GC Total Time"), timeout, TimeUnit.SECONDS);
-    System.out.println("MetricData are good: " + (System.currentTimeMillis() - start));
+    testing.waitAndAssertMetric("Suspected Deadlocked Threads", metric -> metric.hasValue(0));
 
-    MetricData mdDeadlocks = SmokeTestExtension.getBaseData(deadlocks);
-    assertPerfMetric(mdDeadlocks);
-    assertThat(mdDeadlocks.getMetrics().get(0).getValue()).isEqualTo(0);
+    testing.waitAndAssertMetric("Heap Memory Used (MB)", MetricAssert::hasValueGreaterThanZero);
 
-    MetricData mdHeapUsed = SmokeTestExtension.getBaseData(heapUsed);
-    assertPerfMetric(mdHeapUsed);
-    assertThat(mdHeapUsed.getMetrics().get(0).getValue()).isGreaterThan(0);
-
-    MetricData mdGcTotalCount = SmokeTestExtension.getBaseData(gcTotalCount);
-    assertPerfMetric(mdGcTotalCount);
-
-    MetricData mdGcTotalTime = SmokeTestExtension.getBaseData(gcTotalTime);
-    assertPerfMetric(mdGcTotalTime);
-  }
-
-  private void assertPerfMetric(MetricData perfMetric) {
-    List<DataPoint> metrics = perfMetric.getMetrics();
-    assertThat(metrics).hasSize(1);
-  }
-
-  private static Predicate<Envelope> getPerfMetricPredicate(String name) {
-    Objects.requireNonNull(name, "name");
-    return new Predicate<Envelope>() {
-      @Override
-      public boolean test(Envelope input) {
-        if (!input.getData().getBaseType().equals("MetricData")) {
-          return false;
-        }
-        MetricData md = SmokeTestExtension.getBaseData(input);
-        return name.equals(md.getMetrics().get(0).getName());
-      }
-    };
+    testing.waitAndAssertMetric("GC Total Count", metric -> {});
+    testing.waitAndAssertMetric("GC Total Time", metric -> {});
   }
 
   @Environment(TOMCAT_8_JAVA_8)

--- a/smoke-tests/apps/gRPC/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/GrpcTest.java
+++ b/smoke-tests/apps/gRPC/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/GrpcTest.java
@@ -11,17 +11,8 @@ import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.JAVA_
 import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.JAVA_21_OPENJ9;
 import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.JAVA_8;
 import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.JAVA_8_OPENJ9;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 
-import com.microsoft.applicationinsights.smoketest.schemav2.Data;
-import com.microsoft.applicationinsights.smoketest.schemav2.DataPoint;
-import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
-import com.microsoft.applicationinsights.smoketest.schemav2.MetricData;
-import com.microsoft.applicationinsights.smoketest.schemav2.RemoteDependencyData;
-import com.microsoft.applicationinsights.smoketest.schemav2.RequestData;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -32,174 +23,156 @@ abstract class GrpcTest {
 
   @Test
   @TargetUri("/simple")
-  void doSimpleTest() throws Exception {
-    List<Envelope> rdList = testing.mockedIngestion.waitForItems("RequestData", 2);
-    List<Envelope> rpcClientDurationMetrics =
-        testing.mockedIngestion.waitForMetricItems("rpc.client.duration", 1);
-    List<Envelope> rpcServerMetrics =
-        testing.mockedIngestion.waitForMetricItems("rpc.server.duration", 1);
+  void doSimpleTest() {
+    testing.waitAndAssertTrace(
+        trace ->
+            trace
+                .hasRequestSatisying(
+                    request ->
+                        request
+                            .hasName("GET /simple")
+                            .hasSuccess(true)
+                            .hasProperty("_MS.ProcessedByMetricExtractors", "True")
+                            .hasTag("ai.operation.name", "GET /simple")
+                            .hasNoParent())
+                .hasDependencySatisying(
+                    dependency ->
+                        dependency
+                            .hasName("example.Greeter/SayHello")
+                            .hasTarget("localhost:10203")
+                            .hasSuccess(true)
+                            .hasProperty("_MS.ProcessedByMetricExtractors", "True")
+                            .hasTag("ai.operation.name", "GET /simple")
+                            .hasParent(trace.getRequestId(0)))
+                .hasRequestSatisying(
+                    request ->
+                        request
+                            .hasName("example.Greeter/SayHello")
+                            .hasSuccess(true)
+                            .hasProperty("_MS.ProcessedByMetricExtractors", "True")
+                            .hasTag("ai.operation.name", "example.Greeter/SayHello")
+                            .hasParent(trace.getDependencyId(0)))
+                // auto-collected grpc events are suppressed by exporter because they are noisy
+                .hasMessageCount(0));
 
-    Envelope rdEnvelope1 = getRequestEnvelope(rdList, "GET /simple");
-    Envelope rdEnvelope2 = getRequestEnvelope(rdList, "example.Greeter/SayHello");
-    String operationId = rdEnvelope1.getTags().get("ai.operation.id");
+    testing.waitAndAssertMetric(
+        "rpc.client.duration",
+        metric ->
+            metric
+                .hasValueGreaterThanZero()
+                .hasCount(1)
+                .hasMinGreaterThanZero()
+                .hasMaxGreaterThanZero()
+                .containsTagKey("ai.internal.sdkVersion")
+                .containsTags(
+                    entry("ai.cloud.roleInstance", "testroleinstance"),
+                    entry("ai.cloud.role", "testrolename"))
+                .containsPropertiesExactly(
+                    entry("_MS.MetricId", "dependencies/duration"),
+                    entry("dependency/target", "localhost:10203"),
+                    entry("Dependency.Success", "True"),
+                    entry("Dependency.Type", "grpc"),
+                    entry("operation/synthetic", "False"),
+                    entry("cloud/roleInstance", "testroleinstance"),
+                    entry("cloud/roleName", "testrolename"),
+                    entry("_MS.IsAutocollected", "True")));
 
-    List<Envelope> rddList =
-        testing.mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
-    // auto-collected grpc events are suppressed by exporter because they are noisy
-    assertThat(testing.mockedIngestion.getCountForType("MessageData", operationId)).isZero();
-
-    Envelope rddEnvelope = getDependencyEnvelope(rddList, "example.Greeter/SayHello");
-
-    assertThat(rdEnvelope1.getSampleRate()).isNull();
-    assertThat(rdEnvelope2.getSampleRate()).isNull();
-    assertThat(rddEnvelope.getSampleRate()).isNull();
-
-    RequestData rd1 = (RequestData) ((Data<?>) rdEnvelope1.getData()).getBaseData();
-    RemoteDependencyData rdd =
-        (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
-
-    assertThat(rdd.getTarget()).isEqualTo("localhost:10203");
-
-    assertThat(rd1.getProperties())
-        .containsExactly(entry("_MS.ProcessedByMetricExtractors", "True"));
-    assertThat(rd1.getSuccess()).isTrue();
-
-    assertThat(rdd.getProperties())
-        .containsExactly(entry("_MS.ProcessedByMetricExtractors", "True"));
-    assertThat(rdd.getSuccess()).isTrue();
-
-    // TODO (trask): verify rd2
-
-    SmokeTestExtension.assertParentChild(rd1, rdEnvelope1, rddEnvelope, "GET /simple");
-    SmokeTestExtension.assertParentChild(
-        rdd.getId(), rddEnvelope, rdEnvelope2, "GET /simple", "example.Greeter/SayHello", false);
-
-    verifyRpcClientDurationPreAggregatedMetrics(rpcClientDurationMetrics);
-    verifyRpcServerDurationPreAggregatedMetrics(rpcServerMetrics);
+    testing.waitAndAssertMetric(
+        "rpc.server.duration",
+        metric ->
+            metric
+                .hasValueGreaterThanZero()
+                .hasCount(1)
+                .hasMinGreaterThanZero()
+                .hasMaxGreaterThanZero()
+                .containsTagKey("ai.internal.sdkVersion")
+                .containsTags(
+                    entry("ai.cloud.roleInstance", "testroleinstance"),
+                    entry("ai.cloud.role", "testrolename"))
+                .containsPropertiesExactly(
+                    entry("_MS.MetricId", "requests/duration"),
+                    entry("Request.Success", "True"),
+                    entry("operation/synthetic", "False"),
+                    entry("cloud/roleInstance", "testroleinstance"),
+                    entry("cloud/roleName", "testrolename"),
+                    entry("_MS.IsAutocollected", "True")));
   }
 
   @Test
   @TargetUri("/conversation")
-  void doConversationTest() throws Exception {
-    List<Envelope> rdList = testing.mockedIngestion.waitForItems("RequestData", 2);
-    List<Envelope> rpcClientDurationMetrics =
-        testing.mockedIngestion.waitForMetricItems("rpc.client.duration", 1);
-    List<Envelope> rpcServerMetrics =
-        testing.mockedIngestion.waitForMetricItems("rpc.server.duration", 1);
+  void doConversationTest() {
+    testing.waitAndAssertTrace(
+        trace ->
+            trace
+                .hasRequestSatisying(
+                    request ->
+                        request
+                            .hasName("GET /conversation")
+                            .hasSuccess(true)
+                            .hasProperty("_MS.ProcessedByMetricExtractors", "True")
+                            .hasTag("ai.operation.name", "GET /conversation")
+                            .hasNoParent())
+                .hasDependencySatisying(
+                    dependency ->
+                        dependency
+                            .hasName("example.Greeter/Conversation")
+                            .hasTarget("localhost:10203")
+                            .hasSuccess(true)
+                            .hasProperty("_MS.ProcessedByMetricExtractors", "True")
+                            .hasTag("ai.operation.name", "GET /conversation")
+                            .hasParent(trace.getRequestId(0)))
+                .hasRequestSatisying(
+                    request ->
+                        request
+                            .hasName("example.Greeter/Conversation")
+                            .hasSuccess(true)
+                            .hasProperty("_MS.ProcessedByMetricExtractors", "True")
+                            .hasTag("ai.operation.name", "example.Greeter/Conversation")
+                            .hasParent(trace.getDependencyId(0)))
+                // auto-collected grpc events are suppressed by exporter because they are noisy
+                .hasMessageCount(0));
 
-    Envelope rdEnvelope1 = getRequestEnvelope(rdList, "GET /conversation");
-    Envelope rdEnvelope2 = getRequestEnvelope(rdList, "example.Greeter/Conversation");
-    String operationId = rdEnvelope1.getTags().get("ai.operation.id");
+    testing.waitAndAssertMetric(
+        "rpc.client.duration",
+        metric ->
+            metric
+                .hasValueGreaterThanZero()
+                .hasCount(1)
+                .hasMinGreaterThanZero()
+                .hasMaxGreaterThanZero()
+                .containsTagKey("ai.internal.sdkVersion")
+                .containsTags(
+                    entry("ai.cloud.roleInstance", "testroleinstance"),
+                    entry("ai.cloud.role", "testrolename"))
+                .containsPropertiesExactly(
+                    entry("_MS.MetricId", "dependencies/duration"),
+                    entry("dependency/target", "localhost:10203"),
+                    entry("Dependency.Success", "True"),
+                    entry("Dependency.Type", "grpc"),
+                    entry("operation/synthetic", "False"),
+                    entry("cloud/roleInstance", "testroleinstance"),
+                    entry("cloud/roleName", "testrolename"),
+                    entry("_MS.IsAutocollected", "True")));
 
-    List<Envelope> rddList =
-        testing.mockedIngestion.waitForItemsInOperation("RemoteDependencyData", 1, operationId);
-    // auto-collected grpc events are suppressed by exporter because they are noisy
-    assertThat(testing.mockedIngestion.getCountForType("MessageData", operationId)).isZero();
-
-    Envelope rddEnvelope = getDependencyEnvelope(rddList, "example.Greeter/Conversation");
-
-    assertThat(rdEnvelope1.getSampleRate()).isNull();
-    assertThat(rdEnvelope2.getSampleRate()).isNull();
-    assertThat(rddEnvelope.getSampleRate()).isNull();
-
-    RequestData rd1 = (RequestData) ((Data<?>) rdEnvelope1.getData()).getBaseData();
-    RemoteDependencyData rdd =
-        (RemoteDependencyData) ((Data<?>) rddEnvelope.getData()).getBaseData();
-
-    assertThat(rdd.getTarget()).isEqualTo("localhost:10203");
-
-    assertThat(rd1.getProperties())
-        .containsExactly(entry("_MS.ProcessedByMetricExtractors", "True"));
-    assertThat(rd1.getSuccess()).isTrue();
-
-    assertThat(rdd.getProperties())
-        .containsExactly(entry("_MS.ProcessedByMetricExtractors", "True"));
-    assertThat(rdd.getSuccess()).isTrue();
-
-    // TODO (trask): verify rd2
-
-    SmokeTestExtension.assertParentChild(rd1, rdEnvelope1, rddEnvelope, "GET /conversation");
-    SmokeTestExtension.assertParentChild(
-        rdd.getId(),
-        rddEnvelope,
-        rdEnvelope2,
-        "GET /conversation",
-        "example.Greeter/Conversation",
-        false);
-
-    verifyRpcClientDurationPreAggregatedMetrics(rpcClientDurationMetrics);
-    verifyRpcServerDurationPreAggregatedMetrics(rpcServerMetrics);
-  }
-
-  private static Envelope getRequestEnvelope(List<Envelope> envelopes, String name) {
-    for (Envelope envelope : envelopes) {
-      RequestData rd = (RequestData) ((Data<?>) envelope.getData()).getBaseData();
-      if (rd.getName().equals(name)) {
-        return envelope;
-      }
-    }
-    throw new IllegalStateException("Could not find request with name: " + name);
-  }
-
-  private static Envelope getDependencyEnvelope(List<Envelope> envelopes, String name) {
-    for (Envelope envelope : envelopes) {
-      RemoteDependencyData rdd =
-          (RemoteDependencyData) ((Data<?>) envelope.getData()).getBaseData();
-      if (rdd.getName().equals(name)) {
-        return envelope;
-      }
-    }
-    throw new IllegalStateException("Could not find dependency with name: " + name);
-  }
-
-  private static void verifyRpcClientDurationPreAggregatedMetrics(List<Envelope> metrics) {
-    assertThat(metrics.size()).isEqualTo(1);
-
-    Envelope envelope1 = metrics.get(0);
-    validateTags(envelope1);
-    MetricData md1 = (MetricData) ((Data<?>) envelope1.getData()).getBaseData();
-    validateMetricData("client", md1);
-  }
-
-  private static void verifyRpcServerDurationPreAggregatedMetrics(List<Envelope> metrics) {
-    assertThat(metrics.size()).isEqualTo(1);
-
-    Envelope envelope1 = metrics.get(0);
-    validateTags(envelope1);
-    MetricData md1 = (MetricData) ((Data<?>) envelope1.getData()).getBaseData();
-    validateMetricData("server", md1);
-  }
-
-  private static void validateTags(Envelope envelope) {
-    Map<String, String> tags = envelope.getTags();
-    assertThat(tags.get("ai.internal.sdkVersion")).isNotNull();
-    assertThat(tags).containsEntry("ai.cloud.roleInstance", "testroleinstance");
-    assertThat(tags).containsEntry("ai.cloud.role", "testrolename");
-  }
-
-  private static void validateMetricData(String type, MetricData metricData) {
-    List<DataPoint> dataPoints = metricData.getMetrics();
-    assertThat(dataPoints).hasSize(1);
-    DataPoint dataPoint = dataPoints.get(0);
-    assertThat(dataPoint.getCount()).isEqualTo(1);
-    assertThat(dataPoint.getValue()).isGreaterThan(0d).isLessThan(60 * 1000.0);
-    assertThat(dataPoint.getMin()).isGreaterThan(0d).isLessThan(60 * 1000.0);
-    assertThat(dataPoint.getMin()).isGreaterThan(0d).isLessThan(60 * 1000.0);
-    Map<String, String> properties = metricData.getProperties();
-    if ("client".equals(type)) {
-      assertThat(properties).hasSize(8);
-      assertThat(properties.get("_MS.MetricId")).isEqualTo("dependencies/duration");
-      assertThat(properties.get("dependency/target")).isEqualTo("localhost:10203");
-      assertThat(properties.get("Dependency.Type")).isEqualTo("grpc");
-    } else {
-      assertThat(properties).hasSize(6);
-      assertThat(properties.get("_MS.MetricId")).isEqualTo("requests/duration");
-      assertThat(properties.get("Request.Success")).isEqualTo("True");
-    }
-    assertThat(properties.get("operation/synthetic")).isEqualTo("False");
-    assertThat(properties.get("cloud/roleInstance")).isEqualTo("testroleinstance");
-    assertThat(properties.get("cloud/roleName")).isEqualTo("testrolename");
-    assertThat(properties.get("_MS.IsAutocollected")).isEqualTo("True");
+    testing.waitAndAssertMetric(
+        "rpc.server.duration",
+        metric ->
+            metric
+                .hasValueGreaterThanZero()
+                .hasCount(1)
+                .hasMinGreaterThanZero()
+                .hasMaxGreaterThanZero()
+                .containsTagKey("ai.internal.sdkVersion")
+                .containsTags(
+                    entry("ai.cloud.roleInstance", "testroleinstance"),
+                    entry("ai.cloud.role", "testrolename"))
+                .containsPropertiesExactly(
+                    entry("_MS.MetricId", "requests/duration"),
+                    entry("Request.Success", "True"),
+                    entry("operation/synthetic", "False"),
+                    entry("cloud/roleInstance", "testroleinstance"),
+                    entry("cloud/roleName", "testrolename"),
+                    entry("_MS.IsAutocollected", "True")));
   }
 
   @Environment(JAVA_8)

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/DependencyAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/DependencyAssert.java
@@ -1,0 +1,70 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.microsoft.applicationinsights.smoketest.schemav2.Data;
+import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
+import com.microsoft.applicationinsights.smoketest.schemav2.RemoteDependencyData;
+import org.assertj.core.api.AbstractAssert;
+
+public class DependencyAssert extends AbstractAssert<DependencyAssert, Envelope> {
+
+  public DependencyAssert(Envelope envelope) {
+    super(envelope, DependencyAssert.class);
+  }
+
+  @CanIgnoreReturnValue
+  public DependencyAssert hasName(String name) {
+    isNotNull();
+    assertThat(getDependencyData().getName()).isEqualTo(name);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public DependencyAssert hasTarget(String target) {
+    isNotNull();
+    assertThat(getDependencyData().getTarget()).isEqualTo(target);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public DependencyAssert hasSuccess(boolean success) {
+    isNotNull();
+    assertThat(getDependencyData().getSuccess()).isEqualTo(success);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public DependencyAssert hasProperty(String key, String value) {
+    isNotNull();
+    assertThat(getDependencyData().getProperties()).containsEntry(key, value);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public DependencyAssert hasTag(String key, String value) {
+    isNotNull();
+    assertThat(actual.getTags()).containsEntry(key, value);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public DependencyAssert hasNoParent() {
+    isNotNull();
+    assertThat(getDependencyData().getProperties().get("ai.operation.parentId")).isNull();
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public DependencyAssert hasParent(String parentId) {
+    isNotNull();
+    assertThat(getDependencyData().getProperties().get("ai.operation.parentId")).isNull();
+    return this;
+  }
+
+  private RemoteDependencyData getDependencyData() {
+    Data<?> data = (Data<?>) actual.getData();
+    return (RemoteDependencyData) data.getBaseData();
+  }
+}

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/DependencyAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/DependencyAssert.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.microsoft.applicationinsights.smoketest;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/MetricAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/MetricAssert.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.microsoft.applicationinsights.smoketest;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/MetricAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/MetricAssert.java
@@ -1,0 +1,92 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.microsoft.applicationinsights.smoketest.schemav2.Data;
+import com.microsoft.applicationinsights.smoketest.schemav2.DataPoint;
+import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
+import com.microsoft.applicationinsights.smoketest.schemav2.MetricData;
+import java.util.HashMap;
+import java.util.Map;
+import org.assertj.core.api.AbstractAssert;
+
+public class MetricAssert extends AbstractAssert<MetricAssert, Envelope> {
+
+  public MetricAssert(Envelope envelope) {
+    super(envelope, MetricAssert.class);
+  }
+
+  @CanIgnoreReturnValue
+  public MetricAssert hasValue(double value) {
+    isNotNull();
+    assertThat(getDataPoint().getValue()).isEqualTo(value);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MetricAssert hasValueGreaterThanZero() {
+    isNotNull();
+    assertThat(getDataPoint().getValue()).isGreaterThan(0);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MetricAssert hasCount(int count) {
+    isNotNull();
+    assertThat(getDataPoint().getCount()).isEqualTo(count);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MetricAssert hasMinGreaterThanZero() {
+    isNotNull();
+    assertThat(getDataPoint().getMin()).isGreaterThan(0);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public MetricAssert hasMaxGreaterThanZero() {
+    isNotNull();
+    assertThat(getDataPoint().getMax()).isGreaterThan(0);
+    return this;
+  }
+
+  @SafeVarargs
+  @CanIgnoreReturnValue
+  public final MetricAssert containsPropertiesExactly(Map.Entry<String, String>... entries) {
+    Map<String, String> map = new HashMap<>();
+    for (Map.Entry<String, String> entry : entries) {
+      map.put(entry.getKey(), entry.getValue());
+    }
+
+    isNotNull();
+    MetricData baseData = getMetricData();
+    assertThat(baseData.getProperties()).containsExactlyInAnyOrderEntriesOf(map);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public final MetricAssert containsTagKey(String key) {
+    isNotNull();
+    assertThat(actual.getTags()).containsKey(key);
+    return this;
+  }
+
+  @SafeVarargs
+  @CanIgnoreReturnValue
+  public final MetricAssert containsTags(Map.Entry<String, String>... tags) {
+    isNotNull();
+    assertThat(actual.getTags()).contains(tags);
+    return this;
+  }
+
+  private DataPoint getDataPoint() {
+    return getMetricData().getMetrics().get(0);
+  }
+
+  private MetricData getMetricData() {
+    Data<?> data = (Data<?>) actual.getData();
+    return (MetricData) data.getBaseData();
+  }
+}

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/RequestAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/RequestAssert.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.microsoft.applicationinsights.smoketest;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/RequestAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/RequestAssert.java
@@ -1,0 +1,62 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.microsoft.applicationinsights.smoketest.schemav2.Data;
+import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
+import com.microsoft.applicationinsights.smoketest.schemav2.RequestData;
+import org.assertj.core.api.AbstractAssert;
+
+public class RequestAssert extends AbstractAssert<RequestAssert, Envelope> {
+
+  public RequestAssert(Envelope envelope) {
+    super(envelope, RequestAssert.class);
+  }
+
+  public RequestAssert hasName(String name) {
+    isNotNull();
+    assertThat(getRequestData().getName()).isEqualTo(name);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public RequestAssert hasSuccess(boolean success) {
+    isNotNull();
+    assertThat(getRequestData().getSuccess()).isEqualTo(success);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public RequestAssert hasProperty(String key, String value) {
+    isNotNull();
+    assertThat(getRequestData().getProperties()).containsEntry(key, value);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public RequestAssert hasTag(String key, String value) {
+    isNotNull();
+    assertThat(actual.getTags()).containsEntry(key, value);
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public RequestAssert hasNoParent() {
+    isNotNull();
+    assertThat(getRequestData().getProperties().get("ai.operation.parentId")).isNull();
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public RequestAssert hasParent(String parentId) {
+    isNotNull();
+    assertThat(getRequestData().getProperties().get("ai.operation.parentId")).isNull();
+    return this;
+  }
+
+  private RequestData getRequestData() {
+    Data<?> data = (Data<?>) actual.getData();
+    return (RequestData) data.getBaseData();
+  }
+}

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/TraceAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/TraceAssert.java
@@ -1,0 +1,72 @@
+package com.microsoft.applicationinsights.smoketest;
+
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.microsoft.applicationinsights.smoketest.schemav2.Data;
+import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
+import com.microsoft.applicationinsights.smoketest.schemav2.RemoteDependencyData;
+import com.microsoft.applicationinsights.smoketest.schemav2.RequestData;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class TraceAssert {
+
+  private final List<Envelope> requests;
+  private final List<Envelope> dependencies;
+  private final List<Envelope> messages;
+
+  public TraceAssert(List<Envelope> trace) {
+
+    // TODO sort by parent/child if same timestamp?
+    List<Envelope> sorted =
+        trace.stream()
+            .sorted(comparing(envelope -> Instant.parse(envelope.getTime())))
+            .collect(toList());
+
+    requests =
+        sorted.stream()
+            .filter(envelope -> envelope.getData().getBaseType().equals("RequestData"))
+            .collect(toList());
+    dependencies =
+        sorted.stream()
+            .filter(envelope -> envelope.getData().getBaseType().equals("RemoteDependencyData"))
+            .collect(toList());
+    messages =
+        sorted.stream()
+            .filter(envelope -> envelope.getData().getBaseType().equals("MessageData"))
+            .collect(toList());
+  }
+
+  @CanIgnoreReturnValue
+  public TraceAssert hasRequestSatisying(Consumer<RequestAssert> assertion) {
+    assertThat(requests).anySatisfy(envelope -> assertion.accept(new RequestAssert(envelope)));
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public TraceAssert hasDependencySatisying(Consumer<DependencyAssert> assertion) {
+    assertThat(dependencies)
+        .anySatisfy(envelope -> assertion.accept(new DependencyAssert(envelope)));
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public TraceAssert hasMessageCount(int count) {
+    assertThat(messages).hasSize(count);
+    return this;
+  }
+
+  public String getRequestId(int index) {
+    Data<?> data = (Data<?>) requests.get(index).getData();
+    return ((RequestData) data.getBaseData()).getId();
+  }
+
+  public String getDependencyId(int index) {
+    Data<?> data = (Data<?>) dependencies.get(index).getData();
+    return ((RemoteDependencyData) data.getBaseData()).getId();
+  }
+}

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/TraceAssert.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/TraceAssert.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.microsoft.applicationinsights.smoketest;
 
 import static java.util.Comparator.comparing;

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/fakeingestion/MockedAppInsightsIngestionServer.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/fakeingestion/MockedAppInsightsIngestionServer.java
@@ -83,6 +83,10 @@ public class MockedAppInsightsIngestionServer {
     return this.servlet.getItemsByType(type);
   }
 
+  public List<Envelope> getAllItems() {
+    return this.servlet.getAllItems();
+  }
+
   public <T extends Domain> List<T> getTelemetryDataByType(String type) {
     return getTelemetryDataByType(type, false);
   }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/fakeingestion/MockedAppInsightsIngestionServlet.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/fakeingestion/MockedAppInsightsIngestionServlet.java
@@ -68,6 +68,14 @@ class MockedAppInsightsIngestionServlet extends HttpServlet {
     }
   }
 
+  List<Envelope> getAllItems() {
+    synchronized (multimapLock) {
+      // need to make a copy to avoid ConcurrentModificationException
+      // if the caller iterates over it at the same time as another telemetry item arrives
+      return new ArrayList<>(type2envelope.values());
+    }
+  }
+
   void awaitAnyItems(long timeout, TimeUnit timeUnit)
       throws InterruptedException, ExecutionException, TimeoutException {
     waitForItems(x -> true, 1, timeout, timeUnit);

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/AvailabilityData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/AvailabilityData.java
@@ -83,4 +83,30 @@ public class AvailabilityData extends Domain {
     }
     return this.measurements;
   }
+
+  @Override
+  public String toString() {
+    return "AvailabilityData{"
+        + "id='"
+        + id
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", duration="
+        + duration
+        + ", success="
+        + success
+        + ", runLocation='"
+        + runLocation
+        + '\''
+        + ", message='"
+        + message
+        + '\''
+        + ", properties="
+        + properties
+        + ", measurements="
+        + measurements
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Base.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Base.java
@@ -4,7 +4,7 @@
 package com.microsoft.applicationinsights.smoketest.schemav2;
 
 /** Data contract class Base. */
-public class Base {
+public abstract class Base {
   /** Backing field for property BaseType. */
   private String baseType;
 

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Data.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Data.java
@@ -20,4 +20,9 @@ public class Data<T extends Domain> extends Base {
   public void setBaseData(T value) {
     this.baseData = value;
   }
+
+  @Override
+  public String toString() {
+    return "Data{" + "baseData=" + baseData + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/DataPoint.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/DataPoint.java
@@ -98,4 +98,26 @@ public class DataPoint {
   public void setStdDev(Double value) {
     this.stdDev = value;
   }
+
+  @Override
+  public String toString() {
+    return "DataPoint{"
+        + "name='"
+        + name
+        + '\''
+        + ", ns='"
+        + ns
+        + '\''
+        + ", value="
+        + value
+        + ", count="
+        + count
+        + ", min="
+        + min
+        + ", max="
+        + max
+        + ", stdDev="
+        + stdDev
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Domain.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Domain.java
@@ -4,7 +4,7 @@
 package com.microsoft.applicationinsights.smoketest.schemav2;
 
 /** Data contract class Domain. */
-public class Domain {
+public abstract class Domain {
   /** Initializes a new instance of the Domain class. */
   public Domain() {}
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Envelope.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/Envelope.java
@@ -89,4 +89,25 @@ public class Envelope {
   public void setData(Base value) {
     this.data = value;
   }
+
+  @Override
+  public String toString() {
+    return "Envelope{"
+        + "name='"
+        + name
+        + '\''
+        + ", time='"
+        + time
+        + '\''
+        + ", sampleRate="
+        + sampleRate
+        + ", iKey='"
+        + iKey
+        + '\''
+        + ", tags="
+        + tags
+        + ", data="
+        + data
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/EventData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/EventData.java
@@ -45,4 +45,17 @@ public class EventData extends Domain {
     }
     return this.measurements;
   }
+
+  @Override
+  public String toString() {
+    return "EventData{"
+        + "name='"
+        + name
+        + '\''
+        + ", properties="
+        + properties
+        + ", measurements="
+        + measurements
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/ExceptionData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/ExceptionData.java
@@ -63,4 +63,18 @@ public class ExceptionData extends Domain {
     }
     return this.measurements;
   }
+
+  @Override
+  public String toString() {
+    return "ExceptionData{"
+        + "exceptions="
+        + exceptions
+        + ", severityLevel="
+        + severityLevel
+        + ", properties="
+        + properties
+        + ", measurements="
+        + measurements
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/ExceptionDetails.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/ExceptionDetails.java
@@ -94,4 +94,27 @@ public class ExceptionDetails {
   public String getStack() {
     return stack;
   }
+
+  @Override
+  public String toString() {
+    return "ExceptionDetails{"
+        + "id="
+        + id
+        + ", outerId="
+        + outerId
+        + ", typeName='"
+        + typeName
+        + '\''
+        + ", message='"
+        + message
+        + '\''
+        + ", hasFullStack="
+        + hasFullStack
+        + ", stack='"
+        + stack
+        + '\''
+        + ", parsedStack="
+        + parsedStack
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/MessageData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/MessageData.java
@@ -47,4 +47,17 @@ public class MessageData extends Domain {
     }
     return this.properties;
   }
+
+  @Override
+  public String toString() {
+    return "MessageData{"
+        + "message='"
+        + message
+        + '\''
+        + ", severityLevel="
+        + severityLevel
+        + ", properties="
+        + properties
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/MetricData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/MetricData.java
@@ -34,4 +34,9 @@ public class MetricData extends Domain {
     }
     return this.properties;
   }
+
+  @Override
+  public String toString() {
+    return "MetricData{" + "metrics=" + metrics + ", properties=" + properties + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/PageViewData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/PageViewData.java
@@ -33,4 +33,9 @@ public class PageViewData extends EventData {
   public void setDuration(Duration value) {
     this.duration = value;
   }
+
+  @Override
+  public String toString() {
+    return "PageViewData{" + "url='" + url + '\'' + ", duration=" + duration + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/RemoteDependencyData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/RemoteDependencyData.java
@@ -136,4 +136,36 @@ public class RemoteDependencyData extends Domain {
     }
     return this.measurements;
   }
+
+  @Override
+  public String toString() {
+    return "RemoteDependencyData{"
+        + "name='"
+        + name
+        + '\''
+        + ", id='"
+        + id
+        + '\''
+        + ", resultCode='"
+        + resultCode
+        + '\''
+        + ", duration="
+        + duration
+        + ", success="
+        + success
+        + ", data='"
+        + data
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", target='"
+        + target
+        + '\''
+        + ", properties="
+        + properties
+        + ", measurements="
+        + measurements
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/RequestData.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/RequestData.java
@@ -123,4 +123,33 @@ public class RequestData extends Domain {
     }
     return this.measurements;
   }
+
+  @Override
+  public String toString() {
+    return "RequestData{"
+        + "id='"
+        + id
+        + '\''
+        + ", duration="
+        + duration
+        + ", responseCode='"
+        + responseCode
+        + '\''
+        + ", success="
+        + success
+        + ", source='"
+        + source
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", url='"
+        + url
+        + '\''
+        + ", properties="
+        + properties
+        + ", measurements="
+        + measurements
+        + '}';
+  }
 }

--- a/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/StackFrame.java
+++ b/smoke-tests/framework/src/main/java/com/microsoft/applicationinsights/smoketest/schemav2/StackFrame.java
@@ -48,4 +48,23 @@ public class StackFrame {
   public void setLine(int value) {
     this.line = value;
   }
+
+  @Override
+  public String toString() {
+    return "StackFrame{"
+        + "level="
+        + level
+        + ", method='"
+        + method
+        + '\''
+        + ", assembly='"
+        + assembly
+        + '\''
+        + ", fileName='"
+        + fileName
+        + '\''
+        + ", line="
+        + line
+        + '}';
+  }
 }


### PR DESCRIPTION
Easier to read, also more aligned with upstream OpenTelemetry which uses similar assertj wrappers