### PR TITLE
Smoke test for custom events with OTel API

### DIFF
--- a/smoke-tests/apps/LiveMetrics/build.gradle.kts
+++ b/smoke-tests/apps/LiveMetrics/build.gradle.kts
@@ -7,5 +7,5 @@ dependencies {
   implementation("log4j:log4j:1.2.17")
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.22.1")
   implementation("com.azure:azure-json:1.0.0")
-  implementation("com.azure:azure-monitor-opentelemetry-autoconfigure:1.0.0-beta.1")
+  implementation("com.azure:azure-monitor-opentelemetry-autoconfigure:1.1.0")
 }

--- a/smoke-tests/apps/OpenTelemetryApiLogBridge/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestController.java
+++ b/smoke-tests/apps/OpenTelemetryApiLogBridge/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestController.java
@@ -50,5 +50,4 @@ public class TestController {
         .emit();
     return "OK!";
   }
-
 }

--- a/smoke-tests/apps/OpenTelemetryApiLogBridge/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestController.java
+++ b/smoke-tests/apps/OpenTelemetryApiLogBridge/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestController.java
@@ -4,6 +4,7 @@
 package com.microsoft.applicationinsights.smoketestapp;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.semconv.ExceptionAttributes;
 import java.io.PrintWriter;
@@ -37,4 +38,17 @@ public class TestController {
         .emit();
     return "OK!";
   }
+
+  @GetMapping("/test-custom-event")
+  public String testCustomEvent() {
+    GlobalOpenTelemetry.get()
+        .getLogsBridge()
+        .get("my logger")
+        .logRecordBuilder()
+        .setAttribute(AttributeKey.stringKey("microsoft.custom_event.name"), "my_custom_event")
+        .setSeverity(Severity.INFO)
+        .emit();
+    return "OK!";
+  }
+
 }

--- a/smoke-tests/apps/OpenTelemetryApiLogBridge/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiLogBridgeTest.java
+++ b/smoke-tests/apps/OpenTelemetryApiLogBridge/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OpenTelemetryApiLogBridgeTest.java
@@ -69,8 +69,7 @@ abstract class OpenTelemetryApiLogBridgeTest {
 
     RequestData rd = (RequestData) ((Data<?>) rdEnvelope.getData()).getBaseData();
     assertThat(rd.getUrl())
-        .matches(
-            "http://localhost:[0-9]+/OpenTelemetryApiLogBridge/test-custom-event");
+        .matches("http://localhost:[0-9]+/OpenTelemetryApiLogBridge/test-custom-event");
     assertThat(rd.getResponseCode()).isEqualTo("200");
     assertThat(rd.getSuccess()).isTrue();
     assertThat(rd.getSource()).isNull();
@@ -88,8 +87,6 @@ abstract class OpenTelemetryApiLogBridgeTest {
     EventData ed = (EventData) ((Data<?>) edList.get(0).getData()).getBaseData();
     assertThat(ed.getName()).isEqualTo("my_custom_event");
   }
-
-
 
   @Environment(TOMCAT_8_JAVA_8)
   static class Tomcat8Java8Test extends OpenTelemetryApiLogBridgeTest {}


### PR DESCRIPTION
This PR adds a smoke test to confirm that custom events emitted via the OTel API are received by the java agent and sent to breeze.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated
