### PR TITLE
Only run CodeQL on pushes to main

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '**'
+      - main
 
 jobs:
   # ===== Java Analysis Job =====


### PR DESCRIPTION
This looks like a recent change in #4198 that was probably done in order to be able to test CodeQL in other branches, but has side effect of opening CodeQL issues when those other branches fail (#4315).