### PR TITLE
Change enforcedPlatform to platform

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -84,7 +84,9 @@ javaPlatform {
 
 dependencies {
   for (bom in DEPENDENCY_BOMS) {
-    api(enforcedPlatform(bom))
+    // using enforcedPlatform prevents us from using a newer version
+    // of azure-monitor-opentelemetry-autoconfigure than is present in the azure SDK BOM
+    api(platform(bom))
     val split = bom.split(':')
     dependencyVersions[split[0]] = split[2]
   }


### PR DESCRIPTION
This was making it silently ignore a newer version of azure-monitor-opentelemetry-autoconfigure when we specify one.

Luckily not an active issue since the latest bom has the latest autoconfigure, but could cause issues in the future.

(and does cause issues today when trying to test with 1.3.0-beta.1 snapshots)