### PR TITLE
Simplify running against azure-monitor-opentelemetry-autoconfigure snapshots

### DIFF
--- a/.github/scripts/build-azure-monitor-dependency.sh
+++ b/.github/scripts/build-azure-monitor-dependency.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Script to build and install azure-monitor-opentelemetry-autoconfigure dependency
+# from a specified GitHub repository and branch
+
+set -e
+
+echo "Building azure-monitor-opentelemetry-autoconfigure from $AZURE_MONITOR_OPENTELEMETRY_AUTOCONFIGURE"
+
+# Parse repo and branch from format "owner/repo:branch"
+REPO_BRANCH="$AZURE_MONITOR_OPENTELEMETRY_AUTOCONFIGURE"
+REPO=$(echo "$REPO_BRANCH" | cut -d':' -f1)
+BRANCH=$(echo "$REPO_BRANCH" | cut -d':' -f2)
+
+echo "Repository: $REPO"
+echo "Branch: $BRANCH"
+
+# Clone the repository
+echo "Cloning repository..."
+git clone https://github.com/$REPO.git azure-sdk-temp
+cd azure-sdk-temp
+git checkout $BRANCH
+
+# Build and install the azure-monitor-opentelemetry-autoconfigure module
+echo "Building and installing azure-monitor-opentelemetry-autoconfigure..."
+mvn clean install -DskipTests -pl sdk/monitor/azure-monitor-opentelemetry-autoconfigure -am
+
+# Get the version that was just built and installed
+echo "Determining installed version..."
+INSTALLED_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -pl sdk/monitor/azure-monitor-opentelemetry-autoconfigure)
+echo "Installed version: $INSTALLED_VERSION"
+
+# Clean up
+echo "Cleaning up..."
+cd ..
+rm -rf azure-sdk-temp
+
+# Update dependency versions in the current project
+echo "Updating dependency versions in project files..."
+
+# Update agent-tooling build.gradle.kts
+if [ -f "agent/agent-tooling/build.gradle.kts" ]; then
+    sed -i "s/com\.azure:azure-monitor-opentelemetry-autoconfigure:[^\"]\+/com.azure:azure-monitor-opentelemetry-autoconfigure:$INSTALLED_VERSION/g" agent/agent-tooling/build.gradle.kts
+    echo "Updated agent/agent-tooling/build.gradle.kts"
+fi
+
+# Update smoke-tests framework build.gradle.kts
+if [ -f "smoke-tests/framework/build.gradle.kts" ]; then
+    sed -i "s/com\.azure:azure-monitor-opentelemetry-autoconfigure:[^\"]\+/com.azure:azure-monitor-opentelemetry-autoconfigure:$INSTALLED_VERSION/g" smoke-tests/framework/build.gradle.kts
+    echo "Updated smoke-tests/framework/build.gradle.kts"
+fi
+
+./gradlew resolveAndLockAll --write-locks
+./gradlew generateLicenseReport --no-build-cache
+
+ # this is needed to make license report pass
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git commit -a -m "update azure-monitor-opentelemetry-autoconfigure dependency to $INSTALLED_VERSION"
+
+echo "azure-monitor-opentelemetry-autoconfigure dependency build completed successfully"
+echo "All project files updated to use version: $INSTALLED_VERSION"

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -8,7 +8,9 @@ on:
         required: false
 
 env:
-  EXPORTER_VERSION: 1.1.0 # to be updated with the latest version
+  # set this to <repo>:<branch/sha> to build and test with an unreleased
+  # version of the azure-monitor-opentelemetry-autoconfigure dependency
+  AZURE_MONITOR_OPENTELEMETRY_AUTOCONFIGURE:
 
 jobs:
   spotless:
@@ -46,12 +48,9 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Using a local standalone exporter dependency?
-        if: ${{ hashFiles('azure-monitor-opentelemetry-autoconfigure-1.0.0-beta.*.jar') != '' }}
-        run: |
-          echo "exporter_version: ${{ env.EXPORTER_VERSION }}"
-          mvn -version
-          mvn install:install-file -Dfile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.jar" -DpomFile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.pom" -DgroupId="com.azure" -DartifactId="azure-monitor-opentelemetry-autoconfigure" -Dversion="${{ env.EXPORTER_VERSION }}"
+      - name: Build and install local azure-monitor-opentelemetry-autoconfigure dependency
+        if: env.AZURE_MONITOR_OPENTELEMETRY_AUTOCONFIGURE != ''
+        run: ./.github/scripts/build-azure-monitor-dependency.sh
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -93,12 +92,10 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Using a local standalone exporter dependency?
-        if: ${{ hashFiles('azure-monitor-opentelemetry-autoconfigure-1.0.0-beta.*.jar') != '' }}
-        run: |
-          echo "exporter_version: ${{ env.EXPORTER_VERSION }}"
-          mvn -version
-          mvn install:install-file -Dfile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.jar" -DpomFile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.pom" -DgroupId="com.azure" -DartifactId="azure-monitor-opentelemetry-autoconfigure" -Dversion="${{ env.EXPORTER_VERSION }}"
+      - name: Build and install local azure-monitor-opentelemetry-autoconfigure dependency
+        if: env.AZURE_MONITOR_OPENTELEMETRY_AUTOCONFIGURE != ''
+        shell: bash
+        run: ./.github/scripts/build-azure-monitor-dependency.sh
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -165,12 +162,10 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Using a local standalone exporter dependency?
-        if: ${{ hashFiles('azure-monitor-opentelemetry-autoconfigure-1.0.0-beta.*.jar') != '' }}
-        run: |
-          echo "exporter_version: ${{ env.EXPORTER_VERSION }}"
-          mvn -version
-          mvn install:install-file -Dfile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.jar" -DpomFile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.pom" -DgroupId="com.azure" -DartifactId="azure-monitor-opentelemetry-autoconfigure" -Dversion="${{ env.EXPORTER_VERSION }}"
+      - name: Build and install local azure-monitor-opentelemetry-autoconfigure dependency
+        if: env.AZURE_MONITOR_OPENTELEMETRY_AUTOCONFIGURE != ''
+        shell: bash
+        run: ./.github/scripts/build-azure-monitor-dependency.sh
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -239,12 +234,9 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Using a local standalone exporter dependency?
-        if: ${{ hashFiles('azure-monitor-opentelemetry-autoconfigure-1.0.0-beta.*.jar') != '' }}
-        run: |
-          echo "exporter_version: ${{ env.EXPORTER_VERSION }}"
-          mvn -version
-          mvn install:install-file -Dfile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.jar" -DpomFile="azure-monitor-opentelemetry-autoconfigure-${{ env.EXPORTER_VERSION }}.pom" -DgroupId="com.azure" -DartifactId="azure-monitor-opentelemetry-autoconfigure" -Dversion="${{ env.EXPORTER_VERSION }}"
+      - name: Build and install local azure-monitor-opentelemetry-autoconfigure dependency
+        if: env.AZURE_MONITOR_OPENTELEMETRY_AUTOCONFIGURE != ''
+        run: ./.github/scripts/build-azure-monitor-dependency.sh
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
This makes it easier to work across the two repos (which is still painful).

Tested in #4314