### PR TITLE
Add timeout on profiler settings pull

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/configuration/Configuration.java
@@ -1530,6 +1530,7 @@ public class Configuration {
     public boolean enableDiagnostics = false;
     public boolean enableRequestTriggering = false;
     public List<RequestTrigger> requestTriggerEndpoints = new ArrayList<>();
+    public int serviceProfilerHttpTimeoutSeconds = 30;
   }
 
   public static class GcEventConfiguration {

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/ProfilingInitializer.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/profiler/ProfilingInitializer.java
@@ -7,6 +7,7 @@ import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.policy.DefaultRedirectStrategy;
 import com.azure.core.http.policy.RedirectPolicy;
+import com.azure.core.http.policy.TimeoutPolicy;
 import com.azure.monitor.opentelemetry.autoconfigure.implementation.utils.SystemInformation;
 import com.azure.monitor.opentelemetry.autoconfigure.implementation.utils.ThreadPoolUtils;
 import com.microsoft.applicationinsights.agent.internal.common.FriendlyException;
@@ -23,6 +24,7 @@ import com.microsoft.applicationinsights.alerting.config.AlertingConfiguration;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.Executors;
@@ -127,7 +129,8 @@ public class ProfilingInitializer {
                     3,
                     "Location",
                     new HashSet<>(
-                        Arrays.asList(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST)))));
+                        Arrays.asList(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST)))),
+            new TimeoutPolicy(Duration.ofSeconds(configuration.serviceProfilerHttpTimeoutSeconds)));
 
     serviceProfilerExecutorService =
         Executors.newScheduledThreadPool(
@@ -140,7 +143,8 @@ public class ProfilingInitializer {
             getServiceProfilerFrontEndPoint(configuration),
             telemetryClient.getInstrumentationKey(),
             httpPipeline,
-            userAgent);
+            userAgent,
+            configuration.serviceProfilerHttpTimeoutSeconds);
 
     // Monitor service remains alive permanently due to scheduling an periodic config pull
     startPollingForConfigUpdates();

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/config/ConfigServiceTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/config/ConfigServiceTest.java
@@ -27,7 +27,8 @@ class ConfigServiceTest extends TestBase {
         new ServiceProfilerClient(
             new URL("https://agent.azureserviceprofiler.net/"),
             "00000000-0000-0000-0000-000000000000",
-            getHttpPipeline());
+            getHttpPipeline(),
+            30);
 
     ConfigService configService = new ConfigService(serviceProfilerClient);
 
@@ -56,7 +57,8 @@ class ConfigServiceTest extends TestBase {
         new ServiceProfilerClient(
             new URL("https://agent.azureserviceprofiler.net/"),
             "00000000-0000-0000-0000-000000000000",
-            getHttpPipeline());
+            getHttpPipeline(),
+            30);
 
     ConfigService configService = new ConfigService(serviceProfilerClient);
     Mono<ProfilerConfiguration> result = configService.pullSettings();

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/upload/UploadServiceSimpleTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/upload/UploadServiceSimpleTest.java
@@ -32,7 +32,8 @@ class UploadServiceSimpleTest {
         new ServiceProfilerClient(
             new URL("https://agent.azureserviceprofiler.net/"),
             "00000000-0000-0000-0000-000000000000",
-            httpPipeline);
+            httpPipeline,
+            30);
 
     File tmpFile = createFakeJfrFile();
     UUID appId = UUID.randomUUID();
@@ -93,7 +94,8 @@ class UploadServiceSimpleTest {
         new ServiceProfilerClient(
             new URL("https://agent.azureserviceprofiler.net/"),
             "00000000-0000-0000-0000-000000000000",
-            httpPipeline);
+            httpPipeline,
+            30);
 
     UUID appId = UUID.randomUUID();
     UUID profileId = UUID.randomUUID();

--- a/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/upload/UploadServiceTest.java
+++ b/agent/agent-tooling/src/test/java/com/microsoft/applicationinsights/agent/internal/profiler/upload/UploadServiceTest.java
@@ -30,7 +30,8 @@ class UploadServiceTest extends TestBase {
         new ServiceProfilerClient(
             new URL("https://agent.azureserviceprofiler.net/"),
             "00000000-0000-0000-0000-000000000000",
-            httpPipeline);
+            httpPipeline,
+            30);
 
     File tmpFile = createFakeJfrFile();
     UUID appId = UUID.randomUUID();


### PR DESCRIPTION
Add a time out on HTTP pull of the profiler settings. Defaulting to 30 seconds