### PR TITLE
Fix Release Tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           else
             opt_prerelease="--prerelease"
           fi
-          gh release create --target main \
+          gh release create --target HEAD \
                             --title "Application Insights Java $VERSION$opt_ga" \
                             --notes-file /tmp/release-notes.txt \
                             $opt_prerelease \


### PR DESCRIPTION
Fix #4500.

Enable creating a release based on a previous commit. The release pipeline needs to be initiated from a previous commit.