### PR TITLE
Fix log sampling overrides by running preview processors before filtering

### DIFF
--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureMonitorLogFilteringProcessor.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/AzureMonitorLogFilteringProcessor.java
@@ -5,8 +5,13 @@ package com.microsoft.applicationinsights.agent.internal.init;
 
 import com.azure.monitor.opentelemetry.autoconfigure.implementation.AiSemanticAttributes;
 import com.microsoft.applicationinsights.agent.internal.configuration.Configuration;
+import com.microsoft.applicationinsights.agent.internal.configuration.Configuration.ProcessorConfig;
+import com.microsoft.applicationinsights.agent.internal.configuration.Configuration.ProcessorType;
 import com.microsoft.applicationinsights.agent.internal.sampling.AiFixedPercentageSampler;
 import com.microsoft.applicationinsights.agent.internal.sampling.SamplingOverrides;
+import com.microsoft.applicationinsights.agent.internal.processors.AgentProcessor;
+import com.microsoft.applicationinsights.agent.internal.processors.AttributeProcessor;
+import com.microsoft.applicationinsights.agent.internal.processors.LogProcessor;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Context;
@@ -14,10 +19,13 @@ import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import io.opentelemetry.semconv.ExceptionAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class AzureMonitorLogFilteringProcessor implements LogRecordProcessor {
@@ -25,6 +33,8 @@ public class AzureMonitorLogFilteringProcessor implements LogRecordProcessor {
   private final SamplingOverrides logSamplingOverrides;
   private final SamplingOverrides exceptionSamplingOverrides;
   private final LogRecordProcessor batchLogRecordProcessor;
+  private final List<ProcessorApplier> previewProcessorAppliers;
+  private final boolean hasPreviewProcessors;
 
   private volatile int severityThreshold;
 
@@ -32,13 +42,15 @@ public class AzureMonitorLogFilteringProcessor implements LogRecordProcessor {
       List<Configuration.SamplingOverride> logSamplingOverrides,
       List<Configuration.SamplingOverride> exceptionSamplingOverrides,
       LogRecordProcessor batchLogRecordProcessor,
-      int severityThreshold) {
+      int severityThreshold,
+      List<ProcessorConfig> processorConfigs) {
 
     this.severityThreshold = severityThreshold;
     this.logSamplingOverrides = new SamplingOverrides(logSamplingOverrides);
     this.exceptionSamplingOverrides = new SamplingOverrides(exceptionSamplingOverrides);
     this.batchLogRecordProcessor = batchLogRecordProcessor;
-    this.severityThreshold = severityThreshold;
+    this.previewProcessorAppliers = buildProcessorAppliers(processorConfigs);
+    this.hasPreviewProcessors = !previewProcessorAppliers.isEmpty();
   }
 
   public void setSeverityThreshold(int severityThreshold) {
@@ -54,6 +66,9 @@ public class AzureMonitorLogFilteringProcessor implements LogRecordProcessor {
       return;
     }
 
+    LogRecordData processedLogRecord =
+        hasPreviewProcessors ? applyPreviewProcessors(logRecord) : logRecord.toLogRecordData();
+
     Double parentSpanSampleRate = null;
     Span currentSpan = Span.fromContext(context);
     if (currentSpan instanceof ReadableSpan) {
@@ -64,14 +79,17 @@ public class AzureMonitorLogFilteringProcessor implements LogRecordProcessor {
     // deal with sampling synchronously so that we only call setAttributeExceptionLogged()
     // when we know we are emitting the exception (span sampling happens synchronously as well)
 
-    String stack = logRecord.getAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE);
+    String stack =
+        processedLogRecord
+            .getAttributes()
+            .get(ExceptionAttributes.EXCEPTION_STACKTRACE);
 
     SamplingOverrides samplingOverrides =
         stack != null ? exceptionSamplingOverrides : logSamplingOverrides;
 
     SpanContext spanContext = logRecord.getSpanContext();
 
-    AiFixedPercentageSampler sampler = samplingOverrides.getOverride(logRecord.getAttributes());
+    AiFixedPercentageSampler sampler = samplingOverrides.getOverride(processedLogRecord.getAttributes());
 
     boolean hasSamplingOverride = sampler != null;
 
@@ -98,7 +116,7 @@ public class AzureMonitorLogFilteringProcessor implements LogRecordProcessor {
       logRecord.setAttribute(AiSemanticAttributes.SAMPLE_RATE, sampleRate);
     }
 
-    setAttributeExceptionLogged(LocalRootSpan.fromContext(context), logRecord);
+    setAttributeExceptionLogged(LocalRootSpan.fromContext(context), stack);
 
     batchLogRecordProcessor.onEmit(context, logRecord);
   }
@@ -118,10 +136,94 @@ public class AzureMonitorLogFilteringProcessor implements LogRecordProcessor {
     batchLogRecordProcessor.close();
   }
 
-  private static void setAttributeExceptionLogged(Span span, ReadWriteLogRecord logRecord) {
-    String stacktrace = logRecord.getAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE);
+  private LogRecordData applyPreviewProcessors(ReadWriteLogRecord logRecord) {
+    LogRecordData processed = logRecord.toLogRecordData();
+    for (ProcessorApplier processorApplier : previewProcessorAppliers) {
+      processed = processorApplier.apply(processed);
+    }
+    return processed;
+  }
+
+  private static List<ProcessorApplier> buildProcessorAppliers(
+      List<ProcessorConfig> processorConfigs) {
+    if (processorConfigs.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<ProcessorApplier> appliers = new ArrayList<>(processorConfigs.size());
+    for (ProcessorConfig processorConfig : processorConfigs) {
+      appliers.add(ProcessorApplier.fromConfig(processorConfig));
+    }
+    return Collections.unmodifiableList(appliers);
+  }
+
+  private static void setAttributeExceptionLogged(Span span, String stacktrace) {
     if (stacktrace != null) {
       span.setAttribute(AiSemanticAttributes.LOGGED_EXCEPTION, stacktrace);
+    }
+  }
+
+  private interface ProcessorApplier {
+    LogRecordData apply(LogRecordData logRecordData);
+
+    static ProcessorApplier fromConfig(ProcessorConfig config) {
+      config.validate();
+      if (config.type == ProcessorType.ATTRIBUTE) {
+        AttributeProcessor attributeProcessor = AttributeProcessor.create(config, true);
+        return new AttributeProcessorApplier(attributeProcessor);
+      }
+      if (config.type == ProcessorType.LOG) {
+        LogProcessor logProcessor = LogProcessor.create(config);
+        return new LogBodyProcessorApplier(logProcessor);
+      }
+      throw new IllegalStateException("Unsupported processor type: " + config.type);
+    }
+  }
+
+  private static final class AttributeProcessorApplier implements ProcessorApplier {
+    private final AttributeProcessor attributeProcessor;
+
+    private AttributeProcessorApplier(AttributeProcessor attributeProcessor) {
+      this.attributeProcessor = attributeProcessor;
+    }
+
+    @Override
+    public LogRecordData apply(LogRecordData logRecordData) {
+      AgentProcessor.IncludeExclude include = attributeProcessor.getInclude();
+      if (include != null
+          && !include.isMatch(logRecordData.getAttributes(), logRecordData.getBody().asString())) {
+        return logRecordData;
+      }
+      AgentProcessor.IncludeExclude exclude = attributeProcessor.getExclude();
+      if (exclude != null
+          && exclude.isMatch(logRecordData.getAttributes(), logRecordData.getBody().asString())) {
+        return logRecordData;
+      }
+      return attributeProcessor.processActions(logRecordData);
+    }
+  }
+
+  private static final class LogBodyProcessorApplier implements ProcessorApplier {
+    private final LogProcessor logProcessor;
+
+    private LogBodyProcessorApplier(LogProcessor logProcessor) {
+      this.logProcessor = logProcessor;
+    }
+
+    @Override
+    public LogRecordData apply(LogRecordData logRecordData) {
+      AgentProcessor.IncludeExclude include = logProcessor.getInclude();
+      if (include != null
+          && !include.isMatch(logRecordData.getAttributes(), logRecordData.getBody().asString())) {
+        return logRecordData;
+      }
+      AgentProcessor.IncludeExclude exclude = logProcessor.getExclude();
+      if (exclude != null
+          && exclude.isMatch(logRecordData.getAttributes(), logRecordData.getBody().asString())) {
+        return logRecordData;
+      }
+
+      LogRecordData updatedLog = logProcessor.processFromAttributes(logRecordData);
+      return logProcessor.processToAttributes(updatedLog);
     }
   }
 }

--- a/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/SecondEntryPoint.java
+++ b/agent/agent-tooling/src/main/java/com/microsoft/applicationinsights/agent/internal/init/SecondEntryPoint.java
@@ -345,7 +345,8 @@ public class SecondEntryPoint
         logSamplingOverrides,
         exceptionSamplingOverrides,
         logRecordProcessor,
-        configuration.instrumentation.logging.getSeverityThreshold());
+        configuration.instrumentation.logging.getSeverityThreshold(),
+        getLogProcessorConfigs(configuration));
   }
 
   private static SpanExporter buildTraceExporter(

--- a/smoke-tests/apps/TelemetryProcessors/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestController.java
+++ b/smoke-tests/apps/TelemetryProcessors/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestController.java
@@ -46,6 +46,12 @@ public class TestController {
     return "delete existing log attribute";
   }
 
+  @GetMapping("/log-filtered-by-attribute")
+  public String logFilteredByAttribute() {
+    logger.info("Noisy log that should not be sent to AppInsights");
+    return "log filtered by attribute";
+  }
+
   @GetMapping("/test-non-string-strict-span-attributes")
   public String testNonStringStrictSpanAttributes() {
     Span.current()

--- a/smoke-tests/apps/TelemetryProcessors/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TelemetryProcessorLogFilterSamplingOverridesTest.java
+++ b/smoke-tests/apps/TelemetryProcessors/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/TelemetryProcessorLogFilterSamplingOverridesTest.java
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.applicationinsights.smoketest;
+
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_11;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_11_OPENJ9;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_17;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_17_OPENJ9;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_21;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_21_OPENJ9;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_25;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_25_OPENJ9;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_8;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.TOMCAT_8_JAVA_8_OPENJ9;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.WILDFLY_13_JAVA_8;
+import static com.microsoft.applicationinsights.smoketest.EnvironmentValue.WILDFLY_13_JAVA_8_OPENJ9;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@UseAgent("applicationinsights-log-filtered-by-attribute.json")
+abstract class TelemetryProcessorLogFilterSamplingOverridesTest {
+
+  @RegisterExtension static final SmokeTestExtension testing = SmokeTestExtension.create();
+
+  @Test
+  @TargetUri("/log-filtered-by-attribute")
+  void logFilteredBySamplingOverrides() throws Exception {
+    Telemetry telemetry = testing.getTelemetry(0);
+    assertThat(telemetry.rd.getName())
+        .isEqualTo("GET /TelemetryProcessors/log-filtered-by-attribute");
+
+    assertThat(testing.mockedIngestion.getCountForType("MessageData")).isZero();
+  }
+
+  @Environment(TOMCAT_8_JAVA_8)
+  static class Tomcat8Java8Test extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_8_OPENJ9)
+  static class Tomcat8Java8OpenJ9Test
+      extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_11)
+  static class Tomcat8Java11Test extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_11_OPENJ9)
+  static class Tomcat8Java11OpenJ9Test
+      extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_17)
+  static class Tomcat8Java17Test extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_17_OPENJ9)
+  static class Tomcat8Java17OpenJ9Test
+      extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_21)
+  static class Tomcat8Java21Test extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_21_OPENJ9)
+  static class Tomcat8Java21OpenJ9Test
+      extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_25)
+  static class Tomcat8Java25Test extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(TOMCAT_8_JAVA_25_OPENJ9)
+  static class Tomcat8Java25OpenJ9Test
+      extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(WILDFLY_13_JAVA_8)
+  static class Wildfly13Java8Test extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+
+  @Environment(WILDFLY_13_JAVA_8_OPENJ9)
+  static class Wildfly13Java8OpenJ9Test
+      extends TelemetryProcessorLogFilterSamplingOverridesTest {}
+}

--- a/smoke-tests/apps/TelemetryProcessors/src/smokeTest/resources/applicationinsights-log-filtered-by-attribute.json
+++ b/smoke-tests/apps/TelemetryProcessors/src/smokeTest/resources/applicationinsights-log-filtered-by-attribute.json
@@ -1,0 +1,37 @@
+{
+  "role": {
+    "name": "testrolename",
+    "instance": "testroleinstance"
+  },
+  "sampling": {
+    "percentage": 100,
+    "overrides": [
+      {
+        "telemetryType": "trace",
+        "attributes": [
+          {
+            "key": "TODELETE",
+            "value": ".*",
+            "matchType": "regexp"
+          }
+        ],
+        "percentage": 0
+      }
+    ]
+  },
+  "preview": {
+    "processors": [
+      {
+        "type": "log",
+        "body": {
+          "toAttributes": {
+            "rules": [
+              "^Noisy log (?<TODELETE>.*)"
+            ]
+          }
+        },
+        "id": "/log/extractToDelete"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Summary**
- Add a smoke test (`TelemetryProcessorLogFilterSamplingOverridesTest`) that reproduces issue #4526 by exercising sampling overrides based on attributes derived by preview processors.
- Adjust the log filtering pipeline so `AzureMonitorLogFilteringProcessor` applies preview attribute/log processors before executing severity filtering and sampling overrides, ensuring those overrides see the processed attributes.

**Root Cause**
- [PR #4130](https://github.com/microsoft/ApplicationInsights-Java/pull/4130) introduced `AzureMonitorLogFilteringProcessor`, moving severity filtering and sampling overrides from `AgentLogExporter` to a processor that now runs ahead of preview attribute and log processors.
- Because these preview processors still wrap only the exporter, overrides that relied on attributes they extract (e.g., regex-based fields) were evaluated against unprocessed log records, causing the regression described in issue #4526.

**Fix Details**
- Apply preview attribute and log processors inside `AzureMonitorLogFilteringProcessor` before sampling decisions so overrides can match on transformed attributes.
- Thread the processor configs from `SecondEntryPoint` into the filtering processor to maintain the prior processing order.
