### PR TITLE
Exclude Zipkin exporter from the agent

### DIFF
--- a/agent/agent/build.gradle.kts
+++ b/agent/agent/build.gradle.kts
@@ -110,6 +110,7 @@ tasks {
     exclude("inst/META-INF/services/io.opentelemetry.javaagent.slf4j.spi.SLF4JServiceProvider")
 
     exclude("inst/io/prometheus/**")
+    exclude("inst/zipkin/**")
 
     dependsOn(isolateJavaagentLibs)
     from(isolateJavaagentLibs.get().outputs)


### PR DESCRIPTION
We don't use it, and so it's an unnecessary source of reports from security scanners (e.g. since it vendors in gson).