### PR TITLE
Fix pull-request-helper

### DIFF
--- a/.github/workflows/pull-request-helper.yml
+++ b/.github/workflows/pull-request-helper.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - 'dependabot/**/*'
 
+permissions:
+  contents: write
+
 jobs:
   pull-request-helper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The git push step of pull-request-helper starts to fail after #4553.
Examples: #4557, #4561.