### PR TITLE
Revert pull-request-helper change

### DIFF
--- a/.github/workflows/pull-request-helper.yml
+++ b/.github/workflows/pull-request-helper.yml
@@ -1,14 +1,24 @@
 name: Pull request helper
 on:
-  push:
-    branches:
-      - 'dependabot/**/*'
+  pull_request_target:
 
 jobs:
   pull-request-helper:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # this is the personal access token used for "git push" below
+          # which is needed in order to trigger workflows
+          token: ${{ secrets.PR_HELPER_GITHUB_TOKEN }}
+
+      - name: Check out PR branch
+        env:
+          NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr checkout $NUMBER
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -19,6 +29,16 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      # - name: Spotless
+      #   env:
+      #     NUMBER: ${{ github.event.issue.number }}
+      #   run: |
+      #     ./gradlew spotlessApply
+      #     if git diff --quiet; then
+      #       exit 0 # success
+      #     fi
+      #     git commit -a -m "./gradlew spotlessApply"
 
       - name: Update license report
         env:
@@ -47,4 +67,7 @@ jobs:
           git commit -m "./gradlew resolveAndLockAll --write-locks"
 
       - name: Push
-        run: git push
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git push


### PR DESCRIPTION
Revert #4553.

Sometimes, the PR checks in the repo are not running. The only job is the "required-status-check" job stuck at "Expected — Waiting for status to be reported". Example: #4564, #4557, #4561.

This only happens when the command `@dependabot recreate` caused `github-actions` bot to modify the code with `./gradlew resolveAndLockAll --write-locks` command. If the `github-actions` bot wasn't triggered, the PR checks workflow would trigger properly. Example: #4565.
 
I can unblock it for a given PR, but it needs MANUALLY closing and reopening the PR every single time according to this StackOverflow https://stackoverflow.com/questions/52200096/github-pull-request-waiting-for-status-to-be-reported
