### PR TITLE
Fix flakiness of live metrics test

### DIFF
--- a/smoke-tests/apps/LiveMetrics/src/main/java/com/microsoft/applicationinsights/smoketestapp/HealthCheckServlet.java
+++ b/smoke-tests/apps/LiveMetrics/src/main/java/com/microsoft/applicationinsights/smoketestapp/HealthCheckServlet.java
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.applicationinsights.smoketestapp;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+// this is used by the test infra in order to know when it's ok to start running the tests
+@WebServlet("")
+public class HealthCheckServlet extends HttpServlet {
+
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) {}
+}

--- a/smoke-tests/apps/LiveMetrics/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestServlet.java
+++ b/smoke-tests/apps/LiveMetrics/src/main/java/com/microsoft/applicationinsights/smoketestapp/TestServlet.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
-@WebServlet("/*")
+@WebServlet("/test")
 public class TestServlet extends HttpServlet {
 
   private static final Logger logger = LogManager.getLogger("smoketestapp-livemetrics");


### PR DESCRIPTION
Fix #4362 .

QuickPulse has its own internal buffer. If the first "Fake Exception" (from the health check) was buffered but not yet sent when `mockedIngestion.resetData()` was called, it will be delivered to the new `LiveMetricsVerifier` along with the
second exception.

The PR adds a specific servlet for the health check to avoid the race condition


