### PR TITLE
Revert "Fix Release Tag (#4517)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           else
             opt_prerelease="--prerelease"
           fi
-          gh release create --target HEAD \
+          gh release create --target main \
                             --title "Application Insights Java $VERSION$opt_ga" \
                             --notes-file /tmp/release-notes.txt \
                             $opt_prerelease \


### PR DESCRIPTION
Revert #4517. It didn't work. The command requires a commit or branch.

Using `HEAD` would [fail](https://github.com/microsoft/ApplicationInsights-Java/actions/runs/21368474846/job/61506496526) with error message:

> HTTP 422: Validation Failed (https://api.github.com/repos/microsoft/ApplicationInsights-Java/releases)
> Release.target_commitish is invalid
