### PR TITLE
Align Gradle with upstream: Adopt test suites for smoke tests

### DIFF
--- a/smoke-tests/apps/OtlpMetrics/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OtlpLogAnalyticsOnAksTest.java
+++ b/smoke-tests/apps/OtlpMetrics/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OtlpLogAnalyticsOnAksTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockserver.model.HttpRequest.request;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import com.microsoft.applicationinsights.smoketest.schemav2.Data;
 import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
@@ -28,11 +27,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockserver.model.HttpRequest;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(
-    classes = {OtlpApplication.class},
-    webEnvironment = RANDOM_PORT)
 @UseAgent
 abstract class OtlpLogAnalyticsOnAksTest {
 

--- a/smoke-tests/apps/OtlpMetrics/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OtlpTest.java
+++ b/smoke-tests/apps/OtlpMetrics/src/smokeTest/java/com/microsoft/applicationinsights/smoketest/OtlpTest.java
@@ -8,7 +8,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockserver.model.HttpRequest.request;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 import com.microsoft.applicationinsights.smoketest.schemav2.Data;
 import com.microsoft.applicationinsights.smoketest.schemav2.Envelope;
@@ -19,11 +18,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockserver.model.HttpRequest;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(
-    classes = {OtlpApplication.class},
-    webEnvironment = RANDOM_PORT)
 @UseAgent
 abstract class OtlpTest {
 


### PR DESCRIPTION
Replace manual source set and configuration setup with native Gradle JvmTestSuite. This aligns with upstream OpenTelemetry Java instrumentation patterns (adopted in v1.24.0) and provides better IDE integration.
