### PR TITLE
Gradle 9 prereq: remove smoke test dependencies on Spring Boot launcher

### DIFF
--- a/smoke-tests/apps/AzureFunctions/build.gradle.kts
+++ b/smoke-tests/apps/AzureFunctions/build.gradle.kts
@@ -3,5 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation("org.springframework.boot:spring-boot-starter-web:2.5.12")
+  implementation("org.springframework:spring-webmvc:5.3.39")
+  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.98")
+  compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 }

--- a/smoke-tests/apps/AzureFunctions/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
+++ b/smoke-tests/apps/AzureFunctions/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
@@ -6,17 +6,24 @@ package com.microsoft.applicationinsights.smoketestapp;
 import com.microsoft.azure.functions.worker.handler.FunctionEnvironmentReloadRequestHandler;
 import java.lang.reflect.Field;
 import java.util.Map;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-@SpringBootApplication
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = "com.microsoft.applicationinsights.smoketestapp")
 public class SpringBootApp {
 
   private static final String FAKE_BREEZE_INGESTION_ENDPOINT =
       "http://host.testcontainers.internal:6060/";
 
   public static void main(String[] args) throws Exception {
-
+    // Set up Azure Functions environment
     setEnv("AzureWebJobsStorage", "dummy");
     setEnv(
         "APPLICATIONINSIGHTS_CONNECTION_STRING",
@@ -27,7 +34,23 @@ public class SpringBootApp {
 
     new FunctionEnvironmentReloadRequestHandler().execute();
 
-    SpringApplication.run(SpringBootApp.class, args);
+    // Start embedded Tomcat with Spring MVC
+    Tomcat tomcat = new Tomcat();
+    tomcat.setPort(8080);
+    tomcat.getConnector();
+    Context context = tomcat.addContext("", System.getProperty("java.io.tmpdir"));
+
+    AnnotationConfigWebApplicationContext appContext = new AnnotationConfigWebApplicationContext();
+    appContext.setServletContext(context.getServletContext());
+    appContext.register(SpringBootApp.class);
+    appContext.refresh();
+
+    DispatcherServlet dispatcher = new DispatcherServlet(appContext);
+    Tomcat.addServlet(context, "dispatcher", dispatcher).setLoadOnStartup(1);
+    context.addServletMappingDecoded("/*", "dispatcher");
+
+    tomcat.start();
+    tomcat.getServer().await();
   }
 
   public static void setEnv(String name, String value) throws Exception {

--- a/smoke-tests/apps/JettyNativeHandler/build.gradle.kts
+++ b/smoke-tests/apps/JettyNativeHandler/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-  implementation("org.springframework.boot:spring-boot-starter:2.5.12")
-
   // jetty 10 is compiled against Java 11
   implementation("org.eclipse.jetty:jetty-server:9.4.49.v20220914")
 }

--- a/smoke-tests/apps/JettyNativeHandler/src/main/java/com/microsoft/applicationinsights/smoketestapp/JettyNativeHandlerApp.java
+++ b/smoke-tests/apps/JettyNativeHandler/src/main/java/com/microsoft/applicationinsights/smoketestapp/JettyNativeHandlerApp.java
@@ -9,9 +9,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
 public class JettyNativeHandlerApp {
 
   public static void main(String[] args) throws Exception {

--- a/smoke-tests/apps/RuntimeAttach/build.gradle.kts
+++ b/smoke-tests/apps/RuntimeAttach/build.gradle.kts
@@ -5,5 +5,7 @@ plugins {
 dependencies {
   implementation(project(":agent:runtime-attach"))
 
-  implementation("org.springframework.boot:spring-boot-starter-web:2.2.0.RELEASE")
+  implementation("org.springframework:spring-webmvc:5.3.39")
+  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.98")
+  compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 }

--- a/smoke-tests/apps/RuntimeAttach/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
+++ b/smoke-tests/apps/RuntimeAttach/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
@@ -4,21 +4,39 @@
 package com.microsoft.applicationinsights.smoketestapp;
 
 import com.microsoft.applicationinsights.attach.ApplicationInsights;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-@SpringBootApplication
-public class SpringBootApp extends SpringBootServletInitializer {
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = "com.microsoft.applicationinsights.smoketestapp")
+public class SpringBootApp {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
+    // Attach Application Insights agent at runtime
     ApplicationInsights.attach();
-    SpringApplication.run(SpringBootApp.class, args);
-  }
 
-  @Override
-  protected SpringApplicationBuilder configure(SpringApplicationBuilder applicationBuilder) {
-    return applicationBuilder.sources(SpringBootApp.class);
+    // Start embedded Tomcat with Spring MVC
+    Tomcat tomcat = new Tomcat();
+    tomcat.setPort(8080);
+    tomcat.getConnector();
+    Context context = tomcat.addContext("", System.getProperty("java.io.tmpdir"));
+
+    AnnotationConfigWebApplicationContext appContext = new AnnotationConfigWebApplicationContext();
+    appContext.setServletContext(context.getServletContext());
+    appContext.register(SpringBootApp.class);
+    appContext.refresh();
+
+    DispatcherServlet dispatcher = new DispatcherServlet(appContext);
+    Tomcat.addServlet(context, "dispatcher", dispatcher).setLoadOnStartup(1);
+    context.addServletMappingDecoded("/*", "dispatcher");
+
+    tomcat.start();
+    tomcat.getServer().await();
   }
 }

--- a/smoke-tests/apps/RuntimeAttachWithDelayedConnectionString/build.gradle.kts
+++ b/smoke-tests/apps/RuntimeAttachWithDelayedConnectionString/build.gradle.kts
@@ -6,5 +6,7 @@ dependencies {
   implementation(project(":agent:runtime-attach"))
   implementation(project(":classic-sdk:core"))
 
-  implementation("org.springframework.boot:spring-boot-starter-web:2.2.0.RELEASE")
+  implementation("org.springframework:spring-webmvc:5.3.39")
+  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.98")
+  compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 }

--- a/smoke-tests/apps/RuntimeAttachWithDelayedConnectionString/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
+++ b/smoke-tests/apps/RuntimeAttachWithDelayedConnectionString/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
@@ -5,28 +5,47 @@ package com.microsoft.applicationinsights.smoketestapp;
 
 import com.microsoft.applicationinsights.attach.ApplicationInsights;
 import com.microsoft.applicationinsights.connectionstring.ConnectionString;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-@SpringBootApplication
-public class SpringBootApp extends SpringBootServletInitializer {
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = "com.microsoft.applicationinsights.smoketestapp")
+public class SpringBootApp {
 
   private static final String FAKE_INGESTION_ENDPOINT = "http://host.testcontainers.internal:6060/";
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
+    // Attach Application Insights agent at runtime
     ApplicationInsights.attach();
+    // Configure connection string after attach
     ConnectionString.configure(
         "InstrumentationKey=00000000-0000-0000-0000-0FEEDDADBEEF;IngestionEndpoint="
             + FAKE_INGESTION_ENDPOINT
             + ";LiveEndpoint="
             + FAKE_INGESTION_ENDPOINT);
-    SpringApplication.run(SpringBootApp.class, args);
-  }
 
-  @Override
-  protected SpringApplicationBuilder configure(SpringApplicationBuilder applicationBuilder) {
-    return applicationBuilder.sources(SpringBootApp.class);
+    // Start embedded Tomcat with Spring MVC
+    Tomcat tomcat = new Tomcat();
+    tomcat.setPort(8080);
+    tomcat.getConnector();
+    Context context = tomcat.addContext("", System.getProperty("java.io.tmpdir"));
+
+    AnnotationConfigWebApplicationContext appContext = new AnnotationConfigWebApplicationContext();
+    appContext.setServletContext(context.getServletContext());
+    appContext.register(SpringBootApp.class);
+    appContext.refresh();
+
+    DispatcherServlet dispatcher = new DispatcherServlet(appContext);
+    Tomcat.addServlet(context, "dispatcher", dispatcher).setLoadOnStartup(1);
+    context.addServletMappingDecoded("/*", "dispatcher");
+
+    tomcat.start();
+    tomcat.getServer().await();
   }
 }

--- a/smoke-tests/apps/SystemExit/build.gradle.kts
+++ b/smoke-tests/apps/SystemExit/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
 }
 
 dependencies {
-  implementation("org.springframework.boot:spring-boot-starter-web:2.5.12")
+  implementation("org.springframework:spring-webmvc:5.3.39")
+  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.98")
+  compileOnly("javax.servlet:javax.servlet-api:4.0.1")
+
   implementation("io.opentelemetry:opentelemetry-api:1.12.0")
+
+  implementation("org.slf4j:slf4j-api:1.7.36")
+  implementation("ch.qos.logback:logback-classic:1.2.12")
 }

--- a/smoke-tests/apps/SystemExit/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
+++ b/smoke-tests/apps/SystemExit/src/main/java/com/microsoft/applicationinsights/smoketestapp/SpringBootApp.java
@@ -3,14 +3,36 @@
 
 package com.microsoft.applicationinsights.smoketestapp;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-@SpringBootApplication
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = "com.microsoft.applicationinsights.smoketestapp")
 public class SpringBootApp {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
+    // Start embedded Tomcat with Spring MVC
+    Tomcat tomcat = new Tomcat();
+    tomcat.setPort(8080);
+    tomcat.getConnector();
+    Context context = tomcat.addContext("", System.getProperty("java.io.tmpdir"));
 
-    SpringApplication.run(SpringBootApp.class, args);
+    AnnotationConfigWebApplicationContext appContext = new AnnotationConfigWebApplicationContext();
+    appContext.setServletContext(context.getServletContext());
+    appContext.register(SpringBootApp.class);
+    appContext.refresh();
+
+    DispatcherServlet dispatcher = new DispatcherServlet(appContext);
+    Tomcat.addServlet(context, "dispatcher", dispatcher).setLoadOnStartup(1);
+    context.addServletMappingDecoded("/*", "dispatcher");
+
+    tomcat.start();
+    tomcat.getServer().await();
   }
 }

--- a/smoke-tests/apps/gRPC/build.gradle.kts
+++ b/smoke-tests/apps/gRPC/build.gradle.kts
@@ -28,7 +28,9 @@ protobuf {
 }
 
 dependencies {
-  implementation("org.springframework.boot:spring-boot-starter-web:2.5.12")
+  implementation("org.springframework:spring-webmvc:5.3.39")
+  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.98")
+  compileOnly("javax.servlet:javax.servlet-api:4.0.1")
 
   implementation("io.grpc:grpc-core:$grpcVersion")
   implementation("io.grpc:grpc-netty:$grpcVersion")


### PR DESCRIPTION
Keeping dependencies on Spring, only removing dependencies on Spring Boot launcher.

Reason: upgrading to Gradle 9.3.1 forces an upgrade of Spring Boot Gradle plugin from 2.5.12 to 3.4.2 (Spring Boot 2.7.x uses deprecated Gradle APIs removed in Gradle 9). Spring Boot 3.x compiles its `bootJar` launcher classes for Java 17+, making it impossible to run these JARs on Java 8 (which we want to continue testing against).
