### PR TITLE
Avoid gh pr checkout in pull request helper workflow

### DIFF
--- a/.github/workflows/pull-request-helper.yml
+++ b/.github/workflows/pull-request-helper.yml
@@ -15,13 +15,8 @@ jobs:
           # this is the personal access token used for "git push" below
           # which is needed in order to trigger workflows
           token: ${{ secrets.PR_HELPER_GITHUB_TOKEN }}
-
-      - name: Check out PR branch
-        env:
-          NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr checkout $NUMBER
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6


### PR DESCRIPTION
Avoid gh pr checkout in Dependabot helper workflow by checking out PR branch directly

This will be done in multiple steps:
1. [This PR] Merge a small workflow PR to main that checks out the Dependabot PR branch directly instead of running gh pr checkout.
2. Rerun or refresh the affected Dependabot PRs (#4702) so their pull_request_target jobs use the updated workflow from main.
3. In a follow-up cleanup PR, normalize Gradle wrapper .bat line endings so Windows checkouts and GitHub Actions agree.
4. After both changes land, future Dependabot wrapper PRs should avoid the intermittent checkout conflict on gradlew.bat files.

## Issue
Today there has been two PRs stuck on the "Pull request helper" step due to failure: #4687, #4702:

```
Run gh pr checkout $NUMBER
From https://github.com/microsoft/ApplicationInsights-Java
 * [new branch]          dependabot/gradle/otelInstrumentationAlphaVersion-2.27.0-alpha -> origin/dependabot/gradle/otelInstrumentationAlphaVersion-2.27.0-alpha
error: Your local changes to the following files would be overwritten by checkout:
	gradlew.bat
	perf-tests/gradlew.bat
Please commit your changes or stash them before you switch branches.
Aborting
failed to run git: exit status 1
Error: Process completed with exit code 1.

```