### PR TITLE
Group related Gradle Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,12 +45,18 @@ updates:
 
       opentelemetry:
         patterns:
-          - "io.opentelemetry*:*"
           - "otelSdkVersion"
           - "otelInstrumentationVersion"
           - "otelInstrumentationAlphaVersion"
           - "otelContribVersion"
-      
+          - "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom"
+          - "io.opentelemetry.instrumentation:gradle-plugins"
+
+      opentelemetry-semconv:
+        patterns:
+          - "io.opentelemetry.semconv:opentelemetry-semconv"
+          - "io.opentelemetry.semconv:opentelemetry-semconv-incubating"
+
       # Spotless repeatedly appears as two separate dependency names for the same version bump
       spotless:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,20 @@ updates:
         patterns:
           - "org.testcontainers:*"
 
+      opentelemetry:
+        patterns:
+          - "io.opentelemetry*:*"
+          - "otelSdkVersion"
+          - "otelInstrumentationVersion"
+          - "otelInstrumentationAlphaVersion"
+          - "otelContribVersion"
+      
+      # Spotless repeatedly appears as two separate dependency names for the same version bump
+      spotless:
+        patterns:
+          - "com.diffplug.spotless"
+          - "com.diffplug.spotless:*"
+
   - package-ecosystem: "gradle"
     directory: "/perf-tests"
     registries:


### PR DESCRIPTION
Add Dependabot groups for OpenTelemetry and Spotless dependencies so related version bumps are opened together instead of as separate PRs.

This reduces repeated Dependabot PR churn for dependencies that often move as a release family, while keeping riskier unrelated updates isolated for easier review and troubleshooting.

Examples: #4687 and #4688.