### PR TITLE
Revise Dependabot grouping rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,11 @@ updates:
           - "otelInstrumentationVersion"
           - "otelInstrumentationAlphaVersion"
           - "otelContribVersion"
+          - "io.opentelemetry:opentelemetry-bom"
+          - "io.opentelemetry:opentelemetry-bom-alpha"
           - "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom"
+          - "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha"
+          - "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator"
           - "io.opentelemetry.instrumentation:gradle-plugins"
 
       opentelemetry-semconv:


### PR DESCRIPTION
After the last Dependabot grouping rule PR #4713 was merged, newly created PRs #4715 and #4719 are not grouped in the same PR.

This PR is trying to fix that.