### PR TITLE
Improve Dependabot grouping for OpenTelemetry version variables

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,15 +46,19 @@ updates:
       opentelemetry:
         patterns:
           - "otelSdkVersion"
+          - "otelSdkAlphaVersion"
           - "otelInstrumentationVersion"
           - "otelInstrumentationAlphaVersion"
           - "otelContribVersion"
+          - "otelContribAlphaVersion"
           - "io.opentelemetry:opentelemetry-bom"
           - "io.opentelemetry:opentelemetry-bom-alpha"
           - "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom"
           - "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha"
           - "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator"
           - "io.opentelemetry.instrumentation:gradle-plugins"
+          - "io.opentelemetry.contrib:opentelemetry-jfr-connection"
+          - "io.opentelemetry.contrib:opentelemetry-runtime-attach-core"
 
       opentelemetry-semconv:
         patterns:

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -8,9 +8,11 @@ val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
 val otelSdkVersion = "1.61.0"
+val otelSdkAlphaVersion = "1.61.0-alpha"
 val otelInstrumentationAlphaVersion = "2.27.0-alpha"
 val otelInstrumentationVersion = "2.27.0"
 val otelContribVersion = "1.56.0"
+val otelContribAlphaVersion = "1.56.0-alpha"
 
 rootProject.extra["otelInstrumentationVersion"] = otelInstrumentationVersion
 rootProject.extra["otelInstrumentationAlphaVersion"] = otelInstrumentationAlphaVersion
@@ -18,7 +20,7 @@ rootProject.extra["otelInstrumentationAlphaVersion"] = otelInstrumentationAlphaV
 val DEPENDENCY_BOMS = listOf(
   "com.fasterxml.jackson:jackson-bom:2.21.2",
   "io.opentelemetry:opentelemetry-bom:${otelSdkVersion}",
-  "io.opentelemetry:opentelemetry-bom-alpha:${otelSdkVersion}-alpha",
+  "io.opentelemetry:opentelemetry-bom-alpha:${otelSdkAlphaVersion}",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:${otelInstrumentationVersion}",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationAlphaVersion}",
   "com.azure:azure-sdk-bom:1.3.6",
@@ -67,8 +69,8 @@ val DEPENDENCIES = listOf(
   "com.azure:azure-core-test:1.26.2", // this is not included in azure-sdk-bom
   "org.assertj:assertj-core:3.27.7",
   "org.awaitility:awaitility:4.3.0",
-  "io.opentelemetry.contrib:opentelemetry-jfr-connection:${otelContribVersion}-alpha",
-  "io.opentelemetry.contrib:opentelemetry-runtime-attach-core:${otelContribVersion}-alpha",
+  "io.opentelemetry.contrib:opentelemetry-jfr-connection:${otelContribAlphaVersion}",
+  "io.opentelemetry.contrib:opentelemetry-runtime-attach-core:${otelContribAlphaVersion}",
   "com.google.code.findbugs:jsr305:3.0.2",
   "com.github.spotbugs:spotbugs-annotations:4.9.8"
 )


### PR DESCRIPTION
## Why

After #4721, Dependabot didn't group all OpenTelemetry packages in the same PR.

Issue 1: Changes in #4724 should be grouped into #4719 as part of the opentelemetry group.
Issue 2: `otelInstrumentationAlphaVersion` is detected by Dependabot to create PRs like #4719. But `otelSdkVersion` and `otelContribVersion` are not detected. The difference seems to be there is Kotlin string interpolation.

## What Changed
- Introduce explicit alpha-version variables for OTel SDK and contrib versions instead of using `${...}-alpha` interpolation in dependency declarations
- Update OTel BOM and contrib dependency entries to use the new explicit alpha vars
- Expand Dependabot `opentelemetry` group patterns to include the new alpha vars and concrete contrib artifacts

This makes OTel dependency versioning clearer for humans and easier for Dependabot to detect and group consistently.