### PR TITLE
Suppress false positive OWASP dependency-check findings on azure artifacts

### DIFF
--- a/buildscripts/dependency-check-suppressions.xml
+++ b/buildscripts/dependency-check-suppressions.xml
@@ -31,12 +31,15 @@
     <cve>CVE-2024-35255</cve>
   </suppress>
   <suppress>
-    <notes>
+    <notes><![CDATA[
       CVE-2026-33117 affects azure-security-keyvault-keys (fixed in 4.10.6), which we do not depend on.
       NVD maps it to the generic cpe:2.3:a:microsoft:azure_sdk_for_java "up to (excluding) 4.10.6",
       so it matches every com.azure artifact whose own (unrelated) version is below 4.10.6,
       e.g. azure-core 1.58.1, azure-core-http-netty 1.16.5, azure-identity 1.18.3, azure-json 1.5.1.
-    </notes>
+      Those version lines will never reach 4.10.6, so upgrading cannot clear this finding.
+      If azure-security-keyvault-keys is ever added as a dependency, revisit this suppression.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.azure/(?!azure-security-keyvault-keys@).*$</packageUrl>
     <cve>CVE-2026-33117</cve>
   </suppress>
   <suppress>

--- a/buildscripts/dependency-check-suppressions.xml
+++ b/buildscripts/dependency-check-suppressions.xml
@@ -32,6 +32,26 @@
   </suppress>
   <suppress>
     <notes>
+      CVE-2026-33117 affects azure-security-keyvault-keys (fixed in 4.10.6), which we do not depend on.
+      NVD maps it to the generic cpe:2.3:a:microsoft:azure_sdk_for_java "up to (excluding) 4.10.6",
+      so it matches every com.azure artifact whose own (unrelated) version is below 4.10.6,
+      e.g. azure-core 1.58.1, azure-core-http-netty 1.16.5, azure-identity 1.18.3, azure-json 1.5.1.
+    </notes>
+    <cve>CVE-2026-33117</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+      azure-monitor-opentelemetry-autoconfigure is an Azure Java library, but dependency-check infers
+      cpe:2.3:a:opentelemetry:opentelemetry from its name. That CPE then matches OpenTelemetry
+      Go / .NET / C++ CVEs whose fixed versions happen to be higher than this artifact's version,
+      e.g. CVE-2026-39882 and CVE-2026-41178 (Go), CVE-2026-40894 and CVE-2026-41078 (.NET),
+      CVE-2026-44967 (C++). None of them apply to Java.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.azure/azure-monitor-opentelemetry-autoconfigure@.*$</packageUrl>
+    <cpe>cpe:2.3:a:opentelemetry:opentelemetry</cpe>
+  </suppress>
+  <suppress>
+    <notes>
       CVE-2023-35116 is not a valid CVE, see comment from library maintainer
       https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596308216
     </notes>


### PR DESCRIPTION
Suppressing the false positives that update issue #4729 every day.

## Problem

The [OWASP dependency check (daily)](.github/workflows/owasp-dependency-check-daily.yml) workflow has been failing:

> Dependency-Analyze Failure:
> One or more dependencies were identified with vulnerabilities that have a CVSS score greater than '0.0': CVE-2026-44967, CVE-2026-33117, CVE-2026-39882, CVE-2026-40894, CVE-2026-41078, CVE-2026-41178

All 6 are CPE mismatches. None affect any code shipped by the agent.

## Analysis

### CVE-2026-33117 — flagged on `azure-core`, `azure-core-http-netty`, `azure-identity`, `azure-json`

The actual vulnerability is in `azure-security-keyvault-keys` < 4.10.6 (incorrect authentication tag comparison in the local cryptographic verification path). That artifact is not a dependency of this project — confirmed absent from all `gradle.lockfile` files.

NVD assigned the CVE the generic CPE `cpe:2.3:a:microsoft:azure_sdk_for_java:*` with range *up to (excluding) 4.10.6*, so it matches every `com.azure` artifact whose own unrelated version number is below 4.10.6.

### CVE-2026-39882 / 40894 / 41078 / 41178 / 44967 — flagged on `azure-monitor-opentelemetry-autoconfigure` 1.5.0

These are OpenTelemetry issues in three other languages, none with a Java component:

| CVE | Language | Fixed in |
|---|---|---|
| CVE-2026-41078 | .NET (`OpenTelemetry.Exporter.Jaeger`) | won't fix, deprecated 2023 |
| CVE-2026-40894 | .NET (`OpenTelemetry.Api`, `.Extensions.Propagators`) | 1.15.3 |
| CVE-2026-44967 | C++ | 1.27.0 |
| CVE-2026-41178 | Go | 1.42.0 |
| CVE-2026-39882 | Go | 1.43.0 |

dependency-check infers `cpe:2.3:a:opentelemetry:opentelemetry` from the artifact name, and 1.5.0 sorts below all of the fixed versions above.

## Fix

Two entries added to [buildscripts/dependency-check-suppressions.xml](buildscripts/dependency-check-suppressions.xml).

Note that **neither finding can be cleared by upgrading**. The `azure-core` / `azure-json` / `azure-identity` / `azure-core-http-netty` version lines will never reach 4.10.6, and bumping `azure-monitor-opentelemetry-autoconfigure` past 1.6.0 would clear only 1 of its 5 findings. Suppression is the only available remedy.

- The CVE-2026-33117 suppression is scoped to `com.azure` purls **excluding** `azure-security-keyvault-keys`, so it cannot mask the genuine vulnerability if that dependency is ever introduced.
- The `azure-monitor-opentelemetry-autoconfigure` suppression targets the mis-inferred **CPE** rather than the individual CVE IDs. This is deliberate: it also prevents future OpenTelemetry Go/.NET/C++ CVEs from re-breaking the build on this artifact, while genuine CVEs filed against the Azure Java library — which match via its Maven purl — continue to be reported.

## Testing

Suppression file validated as well-formed; the negative-lookahead pattern verified to match `pkg:maven/com.azure/azure-core@1.58.1` and not match `pkg:maven/com.azure/azure-security-keyvault-keys@4.10.5`. End-to-end verification requires re-running the daily workflow via `workflow_dispatch` (needs the `NVD_API_KEY` secret).

## Out of scope

The build also logs that the Sonatype OSS Index analyzer is now disabled due to missing credentials — it now requires an authentication token. That did not cause this failure, but it does mean a data source is silently unused.