### PR TITLE
Fix OWASP CPE suppression matching

### DIFF
--- a/buildscripts/dependency-check-suppressions.xml
+++ b/buildscripts/dependency-check-suppressions.xml
@@ -45,13 +45,16 @@
   <suppress>
     <notes><![CDATA[
       azure-monitor-opentelemetry-autoconfigure is an Azure Java library, but dependency-check infers
-      cpe:2.3:a:opentelemetry:opentelemetry from its name. That CPE then matches OpenTelemetry
+      cpe:2.3:a:opentelemetry:opentelemetry from its name. The report displays CPE 2.3, but
+      suppression matching converts detected CPEs to CPE 2.2, so this rule uses the CPE 2.2 form.
+      The trailing colon enforces a whole product-name boundary and does not match
+      opentelemetry_collector. That CPE then matches OpenTelemetry
       Go / .NET / C++ CVEs whose fixed versions happen to be higher than this artifact's version,
       e.g. CVE-2026-39882 and CVE-2026-41178 (Go), CVE-2026-40894 and CVE-2026-41078 (.NET),
       CVE-2026-44967 (C++). None of them apply to Java.
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure-monitor-opentelemetry-autoconfigure@.*$</packageUrl>
-    <cpe>cpe:2.3:a:opentelemetry:opentelemetry</cpe>
+    <cpe>cpe:/a:opentelemetry:opentelemetry:</cpe>
   </suppress>
   <suppress>
     <notes>


### PR DESCRIPTION
The daily OWASP dependency check workflow fails due to this false positive: https://github.com/microsoft/ApplicationInsights-Java/issues/4729#issuecomment-5350310484

## Summary
- Use the CPE 2.2 URI that Dependency-Check 13.0.0 compares against when suppressing false positives for `azure-monitor-opentelemetry-autoconfigure`.
- Document the CPE 2.3 report versus CPE 2.2 matching behavior and retain the trailing product boundary so `opentelemetry_collector` is excluded.

## Validation
- Parsed `buildscripts/dependency-check-suppressions.xml` and asserted the scoped suppression uses `cpe:/a:opentelemetry:opentelemetry:`.
- `./gradlew :agent:agent:dependencyCheckAnalyze --rerun-tasks --no-build-cache` is blocked because the configured NVD API key is empty (`Invalid API Key, length of 0 too short to provided a masked partial key`).