### PR TITLE
Preserve Azure SDK tracing in OpenTelemetry 2.30 update

### DIFF
--- a/agent/agent/build.gradle.kts
+++ b/agent/agent/build.gradle.kts
@@ -28,6 +28,13 @@ val upstreamAgent: Configuration by configurations.creating {
   isCanBeResolved = true
   isCanBeConsumed = false
 }
+// OpenTelemetry 2.30 makes its Azure Core 1.36/1.53 modules require the application's
+// OpenTelemetry context classes. Keep the last modules that also support Azure applications
+// without a direct OpenTelemetry API dependency.
+val upstreamAzureAgent: Configuration by configurations.creating {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+}
 
 val otelInstrumentationVersion: String by project
 val otelInstrumentationAlphaVersion: String by project
@@ -46,6 +53,9 @@ dependencies {
   javaagentLibs(project(":agent:agent-tooling"))
 
   upstreamAgent("io.opentelemetry.javaagent:opentelemetry-javaagent:$otelInstrumentationVersion")
+  upstreamAzureAgent("io.opentelemetry.javaagent:opentelemetry-javaagent") {
+    version { strictly("2.28.1") }
+  }
 
   licenseReportDependencies(project(":agent:agent-tooling"))
 }
@@ -118,6 +128,8 @@ tasks {
 
     exclude("inst/io/prometheus/**")
     exclude("inst/zipkin/**")
+    exclude("inst/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/**")
+    exclude("inst/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/**")
 
     dependsOn(isolateJavaagentLibs)
     from(isolateJavaagentLibs.get().outputs)
@@ -145,6 +157,10 @@ tasks {
     dependsOn(shadowJarWithDuplicates)
 
     from(zipTree(shadowJarWithDuplicates.get().archiveFile))
+    from(zipTree(upstreamAzureAgent.singleFile)) {
+      include("inst/io/opentelemetry/javaagent/instrumentation/azurecore/v1_36/**")
+      include("inst/io/opentelemetry/javaagent/instrumentation/azurecore/v1_53/**")
+    }
 
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 


### PR DESCRIPTION
Fixes the Azure SDK smoke-test regressions in #4821 without rolling back the OpenTelemetry SDK or the rest of the 2.30 instrumentation update.

OpenTelemetry Java instrumentation 2.30 added an Azure Core bridge whose muzzle references require `io.opentelemetry.context.Context` and `Scope` in the application classloader. The Azure SDK smoke app intentionally has no direct OpenTelemetry API dependency, so the agent rejects the entire Azure Core instrumentation module as mismatched and the expected `hello` dependency telemetry disappears.

This keeps the upgraded 2.30 agent and replaces only its Azure Core 1.36 and 1.53 instrumentation slices with their 2.28.1 versions, which support Azure applications without an explicit OpenTelemetry API dependency. The dependency is strict so the 2.30 BOM cannot silently realign the compatibility artifact. This is scoped to the two modules changed by the upstream Azure context bridge ([open-telemetry/opentelemetry-java-instrumentation#18886](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18886)).

Verification:

- On the exact #4821 head (`1871dc7ebbe15dca7c42e587870b8b0153cb7e7e`), `AzureSdkTest$Tomcat8Java8Test` times out because the `hello` dependency is absent; the same test passes with this commit.
- The complete affected Azure matrix passes: all eight `AzureSdkTest` container/JVM variants plus `AzureSdkControllerSpansEnabledTest` (9/9).
- The custom `methods`, `azure-functions`, and `applicationinsights-web-2.3` instrumentation test suites pass against the retained 2.30 agent.
- `./gradlew assemble spotlessCheck` passes (995 tasks).
- `./gradlew test -x :agent:agent-tooling:test` passes. The full test command reaches 313 agent-tooling tests with only the pre-existing macOS-only `SystemInformationTest.testOs` assertion failing; the same focused test fails on a clean checkout of the exact #4821 head.
- `./gradlew resolveAndLockAll --write-locks` and `./gradlew generateLicenseReport --no-build-cache` pass and produce no dependency-lock or license-content diff.
- The packaged Azure 1.53 module matches the 2.28.1 artifact hash, and the 2.30-only context helper is absent from the replaced slices.
